### PR TITLE
Mise à jours des aides - Décembre 2024

### DIFF
--- a/.changeset/blue-onions-brush.md
+++ b/.changeset/blue-onions-brush.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Update - Département Hérault - Précision sur la construction du plan Hérault Vélo 2025-2030

--- a/.changeset/curly-dots-buy.md
+++ b/.changeset/curly-dots-buy.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Update - Ville d'Amboise - Mise à jour du lien

--- a/.changeset/eight-melons-attend.md
+++ b/.changeset/eight-melons-attend.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Remove - Ville de Bidart - Budget 2024 épuisé

--- a/.changeset/empty-dodos-pull.md
+++ b/.changeset/empty-dodos-pull.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes de Cattenom et Environs

--- a/.changeset/fast-papayas-mate.md
+++ b/.changeset/fast-papayas-mate.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Commune de villiers-en-Bière

--- a/.changeset/fluffy-laws-attack.md
+++ b/.changeset/fluffy-laws-attack.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Le Syndicat mixte des Transports du Bassin de Briey

--- a/.changeset/gorgeous-gifts-remain.md
+++ b/.changeset/gorgeous-gifts-remain.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes des 7 Vallées

--- a/.changeset/happy-nails-cross.md
+++ b/.changeset/happy-nails-cross.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté urbaine d'Arras

--- a/.changeset/light-cats-sniff.md
+++ b/.changeset/light-cats-sniff.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Lorient Agglomération

--- a/.changeset/lucky-jars-remain.md
+++ b/.changeset/lucky-jars-remain.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Val Parisis Agglo

--- a/.changeset/many-ligers-shave.md
+++ b/.changeset/many-ligers-shave.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression du Bonus vélo et de la Prime à la conversion (cf. décret n°2024-1084 du 29 novembre 2024)

--- a/.changeset/new-lemons-whisper.md
+++ b/.changeset/new-lemons-whisper.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes du Pays Haut Val d'Alzette

--- a/.changeset/ninety-boxes-complain.md
+++ b/.changeset/ninety-boxes-complain.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Territoire de l'Ouest (TCO)

--- a/.changeset/olive-avocados-glow.md
+++ b/.changeset/olive-avocados-glow.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes Les Portes Briardes Entre Villes et Forêts

--- a/.changeset/olive-owls-push.md
+++ b/.changeset/olive-owls-push.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Ville de Charenton-le-Pont

--- a/.changeset/perfect-snails-jog.md
+++ b/.changeset/perfect-snails-jog.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Remove - Communauté de communes du Pays de Mormal - Les documents pour demander l'aide ne sont plus accessibles

--- a/.changeset/proud-waves-occur.md
+++ b/.changeset/proud-waves-occur.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Add - le statut 'reconversion' dans 'demandeur . statut'

--- a/.changeset/purple-zoos-sin.md
+++ b/.changeset/purple-zoos-sin.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes Pévèle Carembault

--- a/.changeset/real-mails-study.md
+++ b/.changeset/real-mails-study.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Question 'demandeur . bénéficiaire de l'AAH'

--- a/.changeset/rich-clocks-thank.md
+++ b/.changeset/rich-clocks-thank.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes de l'Ouest Vosgien

--- a/.changeset/seven-tomatoes-greet.md
+++ b/.changeset/seven-tomatoes-greet.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Ville de Vaucresson

--- a/.changeset/short-owls-film.md
+++ b/.changeset/short-owls-film.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Durance-Lubéron-Verdon Agglomération

--- a/.changeset/silver-dots-dress.md
+++ b/.changeset/silver-dots-dress.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Remove - Ville de Trébeurden - Plus d'information sur le site de la ville

--- a/.changeset/stale-jokes-double.md
+++ b/.changeset/stale-jokes-double.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté Urbaine Creusot-Montceau

--- a/.changeset/strong-sloths-fold.md
+++ b/.changeset/strong-sloths-fold.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Commune de Binic-Etables sur Mer

--- a/.changeset/tender-windows-admire.md
+++ b/.changeset/tender-windows-admire.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Update - Vile de Boé - Mise à jour du lien

--- a/.changeset/tough-houses-study.md
+++ b/.changeset/tough-houses-study.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Update - Mont de Marsan Agglo - Mise à jour du lien

--- a/.changeset/two-students-drive.md
+++ b/.changeset/two-students-drive.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Arc Sud Bretagne

--- a/.changeset/unlucky-bees-yawn.md
+++ b/.changeset/unlucky-bees-yawn.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Communauté de communes du Pays des Sorgues et des Monts de Vaucluse

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "compile:rules": "publicodes compile src/rules",
     "generate": "yarn run compile:rules && bun scripts/generate.js",
     "pretest": "yarn run generate",
-    "test": "vitest run --globals",
+    "test": "vitest run",
     "precompile": "yarn run generate",
     "compile": "tsup",
     "release": "yarn compile && changeset publish"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "generate": "yarn run compile:rules && bun scripts/generate.js",
     "pretest": "yarn run generate",
     "test": "vitest run",
+    "test:links": "bun scripts/check-links-validity.js",
     "precompile": "yarn run generate",
     "compile": "tsup",
     "release": "yarn compile && changeset publish"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.9",
     "@etalab/decoupage-administratif": "^4.0.0",
-    "@publicodes/tools": "^1.3.0-1",
+    "@publicodes/tools": "^1.3.0-2",
     "@types/jest": "^29.5.13",
     "bun": "^1.1.32",
     "terser": "^5.36.0",

--- a/scripts/generate-aides-collectivities.js
+++ b/scripts/generate-aides-collectivities.js
@@ -53,44 +53,51 @@ function extractCollectivityFromAST(rule) {
     "code insee",
   ];
 
-  const localisation = reduceAST(
+  const localisations = reduceAST(
     (acc, node) => {
-      if (acc) {
-        return acc;
-      }
       if (node.nodeKind === "operation" && node.operationKind === "=") {
         for (let kind of collectityKinds) {
           if (node.explanation[0]?.dottedName === `localisation . ${kind}`) {
-            return {
+            const loc = {
               kind,
               value: node.explanation[1]?.nodeValue,
             };
+            if (!acc.find((l) => l.kind === loc.kind && l.value == loc.value)) {
+              acc.push(loc);
+            }
+            return acc;
           }
         }
       }
     },
-    null,
+    [],
     rule
   );
 
-  if (!localisation) {
+  if (localisations.length === 0) {
     console.warn(`No localisation found for ${rule.dottedName}`);
     return;
   }
 
-  // In our rule basis we reference EPCI by their name but for iteroperability
-  // with third-party systems it is more robust to expose their SIREN code.
-  if (localisation.kind === "epci") {
-    const code = epci.find(({ nom }) => nom === localisation.value)?.code;
+  const normalizedLocalisations = localisations.map((loc) => {
+    // In our rule basis we reference EPCI by their name but for iteroperability
+    // with third-party systems it is more robust to expose their SIREN code.
+    if (loc.kind === "epci") {
+      const code = epci.find(({ nom }) => nom === loc.value)?.code;
 
-    if (!code) {
-      console.error(`Bad EPCI code: ${localisation.value}`);
-      exit(1);
+      if (!code) {
+        console.error(`Bad EPCI code: ${loc.value}`);
+        exit(1);
+      }
+
+      return { ...loc, code };
     }
 
-    return { ...localisation, code };
-  }
-  return localisation;
+    return loc;
+  });
+
+  // FIXME: should handle multiple localisations
+  return normalizedLocalisations[0];
 }
 
 // TODO: a bit fragile, we should sync this logic with

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2051,8 +2051,8 @@ aides . ronchin:
   remplace: commune
   titre: Ville de Ronchin
   description: >
-    Prime réservée aux habitants de la commune couvre 25% du prix d’achat
-    d’un vélo adulte neuf ou d’occasion vendu par un professionnel, avec éclairage
+    Prime réservée aux habitants de la commune couvre 25% du prix d'achat
+    d'un vélo adulte neuf ou d'occasion vendu par un professionnel, avec éclairage
     homologué et éventuellement un antivol.
 
 
@@ -2908,7 +2908,7 @@ aides . pays de l'ozon:
   remplace: intercommunalité
   titre: Pays de l'Ozon
   description: >
-    Subvention de 200€ par famille pour l’achat d’un vélo à assistance électrique (VAE), 
+    Subvention de 200€ par famille pour l'achat d'un vélo à assistance électrique (VAE), 
     vélo cargo, VAE pliant, vélo électrifié chez un professionnel ou adapté aux 
     personnes porteuses de handicaps.
     
@@ -4217,9 +4217,9 @@ aides . la madeleine:
   remplace: commune
   titre: Ville de La Madeleine
   description: >
-    Subvention pour l’achat de moyens de transport doux (vélos, trottinettes, gyroroues,
-    skateboards) et d’accessoires : antivols en U, dispositifs de marquage, systèmes 
-    d’alarme et puces GPS, éclairage, casques, porte-bébés, remorques enfants, vêtements 
+    Subvention pour l'achat de moyens de transport doux (vélos, trottinettes, gyroroues,
+    skateboards) et d'accessoires : antivols en U, dispositifs de marquage, systèmes 
+    d'alarme et puces GPS, éclairage, casques, porte-bébés, remorques enfants, vêtements 
     de pluie, sacoches, paniers, porte-bagages, top cases, chariots, caddies pour vélo.
   applicable si: 
     toutes ces conditions:
@@ -4383,7 +4383,7 @@ aides . les herbiers:
   remplace: intercommunalité
   titre: Communauté de communes du Pays des Herbiers
   description: >
-    Subvention pour l’achat de vélos à assistance électrique.
+    Subvention pour l'achat de vélos à assistance électrique.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Pays des Herbiers'
@@ -4479,8 +4479,8 @@ aides . grand reims:
   remplace: intercommunalité
   titre: Grand Reims Communauté urbaine
   description: >
-    Subvention jusqu’à 500€ pour l’achat d’un vélo à assistance
-    électrique, sous réserve qu’il soit acheté auprès d’un commerçant ou d’une
+    Subvention jusqu'à 500€ pour l'achat d'un vélo à assistance
+    électrique, sous réserve qu'il soit acheté auprès d'un commerçant ou d'une
     association locale. Les achats en ligne sont exclus. 
    
 
@@ -4518,8 +4518,8 @@ aides . reims:
   remplace: commune
   titre: Ville de Reims
   description: >
-    Aide jusqu’à 250€ pour l’achat d’un vélo, sous réserve qu’il soit acquis auprès d’un 
-    commerçant ou d’une association du Grand Reims. Les achats en ligne livrés à  
+    Aide jusqu'à 250€ pour l'achat d'un vélo, sous réserve qu'il soit acquis auprès d'un 
+    commerçant ou d'une association du Grand Reims. Les achats en ligne livrés à  
     domicile ou en magasin sont exclus. 
    
 
@@ -4822,7 +4822,7 @@ aides . évian-les-bains:
   remplace: commune
   titre: Ville d'Évian-les-Bains
   description: >
-    Aide de 20 % du coût d’achat (plafonnée à 400 €) pour un vélo musculaire ou vélo à
+    Aide de 20 % du coût d'achat (plafonnée à 400 €) pour un vélo musculaire ou vélo à
     assistance électrique (VAE) ou 400 € forfaitaires pour transformer un vélo
     en VAE. Réservée aux habitants, selon critères. Un cahier des charges
     précise l'éligibilité matérielle et de provenance.
@@ -6279,7 +6279,7 @@ aides . béthune bruay:
     l'achat d'un vélo).
 
 
-    Subvention de 30 à 500€ en bon d’achat utilisable chez les
+    Subvention de 30 à 500€ en bon d'achat utilisable chez les
     commerces et associations partenaires (validité limitée au 8 décembre
     2024).
   applicable si:  localisation . epci = 'CA de Béthune-Bruay, Artois-Lys Romane'
@@ -6891,8 +6891,8 @@ aides . genneviliers:
   remplace: commune
   titre: Ville de Genneviliers
   description: >
-    Cette aide pour les Gennevillois‧es de 18 ans et plus s’applique aux vélos
-    achetés chez un professionnel, y compris les vélos d’occasion (depuis 2022).
+    Cette aide pour les Gennevillois‧es de 18 ans et plus s'applique aux vélos
+    achetés chez un professionnel, y compris les vélos d'occasion (depuis 2022).
     En 2024, elle couvre les vélos mécaniques, électriques, cargos, pliants ou
     adaptés. Les vélos électriques, cargos, pliants ou adaptés doivent avoir été
     achetés après le 1er septembre 2024 pour être éligibles.
@@ -9152,3 +9152,74 @@ aides . binic etables sur mer:
           - vélo . adapté
   valeur: 80% * vélo . prix
   plafond: 250€
+  lien: https://www.binic-etables-sur-mer.fr/actualites/une-aide-financiere-pour-lachat-dun-velo-ou-broyeur-de-vegetaux-ou-recuperateur-deau-de-pluie
+
+aides . creusot-montceau:
+  remplace: intercommunalité
+  titre: Communauté Urbaine Creusot-Montceau
+  description: >
+    Aide financière à l'acquisition de vélos traditionnels, de vélos à
+    assistance électrique ou de kits d'électrification de vélos.
+
+
+    L'aide est exclusivement réservée aux personnes dont la résidence
+    principale et le lieu de travail ou de scolarisation se situent sur l'une
+    des 34 communes membres de la Communauté Urbaine Creusot-Montceau.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CU Le Creusot Montceau-les-Mines'
+      - revenu fiscal de référence par part <= 2314 €/mois
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . motorisation
+          - vélo . adapté
+  valeur: 50% * vélo . prix
+  plafond:
+    variations:
+      - si: 
+          toutes ces conditions:
+            - demandeur . âge <= 14 an
+            - demandeur . statut . étudiant
+            - vélo . mécanique simple
+        alors: 100€
+      - si: 
+          toutes ces conditions:
+            - demandeur . âge > 14 an
+            - demandeur . statut . étudiant
+        alors:
+          variations:
+            - si: vélo . mécanique simple
+              alors: 150€
+            - si: vélo . électrique simple
+              alors: 300€
+            - si: vélo . motorisation
+              alors: 350€
+            - sinon: 0€
+      - si: 
+          une de ces conditions:
+            - demandeur . statut . salarié
+            - demandeur . statut . retraité
+            - demandeur . statut . reconversion
+        alors:
+          variations:
+            - si:
+                une de ces conditions: 
+                  - vélo . cargo électrique
+                  - vélo . pliant électrique
+                  - vélo . adapté # TODO: faire la distinction entre électrique et mécanique
+              alors: 1500€
+            - si:
+                une de ces conditions: 
+                  - vélo . cargo 
+                  - vélo . pliant
+                  - vélo . adapté
+              alors: 1000€
+            - si: vélo . électrique
+              alors: 300€
+            - si: vélo . mécanique
+              alors: 150€
+            - si: vélo . motorisation
+              alors: 350€
+            - sinon: 0€
+      - sinon: 0€
+  lien: https://www.creusot-montceau.org/actualite/la-communaute-urbaine-vous-aide-financierement-pour-lacquisition-dun-velo

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9559,3 +9559,40 @@ aides . cc pays haut val d'alzette:
   valeur: 15% * vélo . prix
   plafond: 150 €
   lien: https://www.ccphva.com/VAE
+
+aides . cc cattenom et environs:
+  remplace: intercommunalité
+  titre: Communauté de communes de Cattenom et Environs
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique neuf ou d'occasion ansi
+    que de la transformation d'un vélo classique en vélo électrique.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC de Cattenom et Environs'
+      - une de ces conditions:
+          - vélo . électrique simple
+          - vélo . cargo électrique
+          - vélo . motorisation
+  valeur:
+    variations:
+      - si: vélo . cargo électrique
+        alors: 
+          variations:
+            - si: vélo . état . neuf
+              alors: 500€
+            - sinon:
+                valeur: 50% * vélo . prix 
+                plafond: 500€
+      - si: vélo . électrique simple
+        alors: 
+          variations:
+            - si: vélo . état . neuf
+              alors: 300€
+            - sinon:
+                valeur: 50% * vélo . prix 
+                plafond: 300€
+      - si: vélo . motorisation
+        alors: 
+          valeur: 50% * vélo . prix 
+          plafond: 300€
+  lien: https://www.ccce.fr/aide-achat-vae

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9542,3 +9542,20 @@ aides . cc ouest vosgien:
   valeur: 300 €
   plafond: 25% * vélo . prix
   lien: https://ccov.fr/communaute-de-communes/vie-quotidienne/mobilite/subvention-vae
+
+# NOTE: valide jusqu'au 31/12/2026
+aides . cc pays haut val d'alzette:
+  remplace: intercommunalité
+  titre: Communauté de communes du Pays Haut Val d'Alzette
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique neuf ou d'occasion.
+
+    Dispositif valable jusqu'au 31 décembre 2026.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CC du Pays Haut Val d'Alzette"
+      - demandeur . âge . majeur
+      - vélo . électrique
+  valeur: 15% * vélo . prix
+  plafond: 150 €
+  lien: https://www.ccphva.com/VAE

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9525,3 +9525,20 @@ aides . st2b:
   valeur: 30% * vélo . prix
   plafond: 300 €
   lien: https://www.st2b.fr/fileo/prime-a-lacquisition-dun-velo-a-assistance-electrique
+
+aides . cc ouest vosgien:
+  remplace: intercommunalité
+  titre: Communauté de communes de l'Ouest Vosgien
+  description: >
+    Aide pour l'achat d'un VAE neuf chez un·e commerçant·e professionnel·le
+    implanté·e dans l'une des communes de la CCOV.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC de l'Ouest Vosgien'
+      - demandeur . âge . majeur
+      - revenu fiscal de référence par part <= 14089 €/an
+      - vélo . électrique
+      - vélo . état . neuf
+  valeur: 300 €
+  plafond: 25% * vélo . prix
+  lien: https://ccov.fr/communaute-de-communes/vie-quotidienne/mobilite/subvention-vae

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9461,3 +9461,18 @@ aides . dlvagglo:
           - demandeur . statut . autre
   valeur: 200 €
   lien: https://www.espace-citoyens.net/manosque-dlva/espace-citoyens/Demande/NouvelleDemande/ENV/V_ELEC2024
+
+aides . charenton-le-pont:
+  remplace: commune
+  titre: Ville de Charenton-le-Pont
+  description: >
+    Pass'Vélo - Bon d'achat permettant de bénéficier d'une réduction de 50%
+    (plafonnée à 200€) pour l'achat d'un vélo et des accessoires de sécurité
+    dans les structures partenaires.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '94018'
+      - revenu fiscal de référence par part <= 15000 €/an
+  valeur: 50% * vélo . prix
+  plafond: 200€
+  lien: https://www.charenton.fr/velo/velo_pass-velo

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9378,3 +9378,24 @@ aides . cc pévèle carembault:
           valeur: 50% * vélo . prix
           plafond: 200€
   lien: https://www.pevelecarembault.fr/actualites/des-le-4-mars-demandez-votre-prime-velo-electrique
+
+aides . cc les portes briardes:
+  remplace: intercommunalité
+  titre: Communauté de communes Les Portes Briardes Entre Villes et Forêts
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique ou mécanique neuf ou
+    d'occasion.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Les Portes Briardes Entre Villes et Forêts'
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - toutes ces conditions:
+              - vélo . adapté
+              - demandeur . en situation de handicap
+  valeur:
+    variations:
+      - si: vélo . mécanique simple
+        alors: 80€
+      - sinon: 150€
+  lien: https://www.lesportesbriardes.fr/2023/12/28/beneficiez-dune-aide-a-lachat-de-velo

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5970,22 +5970,56 @@ aides . annonay:
 #   plafond: 200€
 #  lien: https://www.bassin-aubenas.fr/actualites/aide-a-lachat-dun-velo-a-assistance-electrique/
 
-# NOTE: nouvelles version fin octobre 2024, à vérifier en 2025
-# aides . lorient:
-#   remplace: intercommunalité
-#   titre: Lorient Agglomération
-#   applicable si: localisation . epci = 'CA Lorient Agglomération'
-#   valeur: 20% * vélo . prix
-#   plafond:
-#     variations:
-#       - si: vélo . cargo
-#         alors: 250€
-#       - si: vélo . électrique
-#         alors: 200€
-#       - si: vélo . pliant
-#         alors: 100€
-#      - sinon: 0€
-#  lien: https://www.lorient-agglo.bzh/services/deplacements/aide-achat-velo/
+# TODO: à vérifier en 2026
+aides . lorient agglo:
+  remplace: intercommunalité
+  titre: Lorient Agglomération
+  description: >
+    Aide à l'achat de vélos à assistance électrique à partir du 16 octobre 2024
+    aux habitants de son territoire ayant souscrit pendant 3 mois minimum au
+    service de location de vélos à assistance électrique développé par la
+    collectivité IziLo Mobilités de Lorient Agglo.
+
+
+    Fin du dispositif le 31 décembre 2025.
+  applicable si: 
+    toutes ces conditions:
+      - localisation . epci = 'CA Lorient Agglomération'
+      - demandeur . âge . majeur
+      - abonnement Izilo Mobilités
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . adapté
+  valeur: 30% * vélo . prix
+  plafond:
+    variations:
+      - si: 
+          une de ces conditions:
+            - vélo . cargo
+            - vélo . adapté
+        alors: 
+          variations:
+            - si: est élligible à la majoration du plafond
+              alors: 900€
+            - sinon: 300€
+      - si: est élligible à la majoration du plafond
+        alors: 420€
+      - sinon: 230€
+  avec:
+    est élligible à la majoration du plafond:
+      valeur:
+        une de ces conditions:
+          - revenu fiscal de référence par part <= 880 €/mois
+          - toutes ces conditions:
+              - revenu fiscal de référence par part <= 1100 €/mois
+              - demandeur . bénéficiaire de l'AAH
+
+    abonnement Izilo Mobilités:
+      type: booléen
+      question: >
+        Avez-vous souscrit pendant 3 mois minimum au service vélo IziLo ?
+      par défaut: oui
+  lien: https://www.lorient-agglo.bzh/services/deplacements/aide-achat-velo
 
 aides . lanester:
   remplace: commune

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9280,3 +9280,37 @@ aides . territoire de l'ouest:
         alors: 500€
       - sinon: 300€
   lien: https://www.tco.re/vae-du-territoire-de-louest
+
+aides . cc sept vallées:
+  remplace: intercommunalité
+  titre: Communauté de communes des 7 Vallées
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique ou mécanique neuf ou
+    d'occasion.
+
+    Concernant les vélos pour les personnes à mobilité réduite tous les vélos
+    susceptibles d'être adaptés au handicap de la personne demandeuse peuvent
+    faire l'objet d'une demande (tricycles, vélos couchés, tandem etc.)
+    exceptés les vélos 2 roues classiques qu'ils soient équipés d'une
+    assistance électrique ou non.
+  applicable si: 
+    toutes ces conditions:
+      - localisation . epci = 'CC des 7 Vallées'
+      - demandeur . âge >= 16 an
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . adapté
+  variations:
+    - si: vélo . adapté
+      alors: 
+        valeur: 40% * vélo . prix
+        plafond: 500€
+    - si: vélo . électrique
+      alors: 
+        valeur: 15% * vélo . prix
+        plafond: 80€
+    - sinon: 
+        valeur: 15% * vélo . prix
+        plafond: 150€
+  lien: https://7vallees.fr/la-communaute-de-communes-des-7-vallees-peut-vous-aider-a-acheter-un-velo
+

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9354,3 +9354,27 @@ aides . cc arc sud bretagne:
         alors: 200€
       - sinon: 100€
   lien: https://www.arc-sud-bretagne.fr/au-quotidien/mobilite
+
+aides . cc pévèle carembault:
+  remplace: intercommunalité
+  titre: Communauté de communes Pévèle Carembault
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique neuf ou de kits
+    d'électrification de vélos.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Pévèle-Carembault'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - toutes ces conditions:
+              - vélo . état . neuf
+              - vélo . électrique
+          - vélo . motorisation
+  valeur:
+    variations:
+      - si: vélo . électrique
+        alors: 200€
+      - sinon:
+          valeur: 50% * vélo . prix
+          plafond: 200€
+  lien: https://www.pevelecarembault.fr/actualites/des-le-4-mars-demandez-votre-prime-velo-electrique

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9482,8 +9482,8 @@ aides . vaucresson:
   titre: Ville de Vaucresson
   description: >
     Subvention de 150€ pour l'électrification d'un vélo classique. Son
-    attribution est conditionnée par le dépôt d’un dossier en mairie et la
-    signature d’une convention.
+    attribution est conditionnée par le dépôt d'un dossier en mairie et la
+    signature d'une convention.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '92076'
@@ -9505,3 +9505,23 @@ aides . cu arras:
   valeur: 30% * vélo . prix
   plafond: 300 €
   lien: https://www.demarches-simplifiees.fr/commencer/cua-aide-velo-elec
+
+aides . st2b:
+  remplace: intercommunalité
+  titre: Le Syndicat mixte des Transports du Bassin de Briey
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique (VAE) neuf et homologué.
+
+
+    Deux demandes maximum par ménage, non renouvelable.
+  applicable si:
+    toutes ces conditions:
+      - une de ces conditions:
+          - localisation . epci = 'CC Orne Lorraine Confluences'
+          - localisation . epci = 'CC Coeur du Pays Haut'
+      - demandeur . âge . majeur
+      - vélo . électrique
+      - vélo . état . neuf
+  valeur: 30% * vélo . prix
+  plafond: 300 €
+  lien: https://www.st2b.fr/fileo/prime-a-lacquisition-dun-velo-a-assistance-electrique

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3887,12 +3887,15 @@ aides . boé:
     de 100 € (cent euros) pour l'achat d'un vélo neuf ou d'occasion acheté dans
     un commerce de l'agglomération d'Agen. Les achats sur internet ne seront
     pas pris en compte.
+
+
+    Limitée aux 20 premières demandes.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '47031'
       - vélo . électrique
   valeur: 100 €
-  lien: https://www.ville-boe.fr/decouvrir-boe/presentation/dernieres-actualites/2101-aide-achat-vae-2024
+  lien: https://www.ville-boe.fr/vivre-boe/solidarite-seniors/aide-vae
 
 # NOTE: information pour 2023, à vérifier en 2025
 aides . sophia antipolis:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9440,3 +9440,24 @@ aides . cc val parisis:
   valeur: 100€
   plafond: 50% * vélo . prix
   lien: https://valparisis.fr/aide-achat-velo
+
+aides . dlvagglo:
+  remplace: intercommunalité
+  titre: Durance-Lubéron-Verdon Agglomération
+  description: >
+    Subvention de 200€ pour l'achat d'un vélo à assistance électrique pour les
+    habitant·es majeur·es en activité professionnelle.
+
+
+    Limitée à 25 demandes unique par an.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CA Durance-Lubéron-Verdon Agglomération'
+      - demandeur . âge . majeur
+      - vélo . électrique
+      - une de ces conditions:
+          - demandeur . statut . salarié
+          - demandeur . statut . reconversion
+          - demandeur . statut . autre
+  valeur: 200 €
+  lien: https://www.espace-citoyens.net/manosque-dlva/espace-citoyens/Demande/NouvelleDemande/ENV/V_ELEC2024

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5765,7 +5765,7 @@ aides . mont de marsan:
             - vélo . prix >= 200€
         alors: 100€
       - sinon: 0€
-  lien: http://www.montdemarsan-agglo.fr/agglo/document?id=4059&id_attribute=48
+  lien: https://www.montdemarsan.fr/actualites/une-nouvelle-aide-a-lachat-dun-velo
 
 # NOTE: valide pour 2024, à vérifier en 2025 
 aides . plaine de l'ain VAE:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9314,3 +9314,24 @@ aides . cc sept vallées:
         plafond: 150€
   lien: https://7vallees.fr/la-communaute-de-communes-des-7-vallees-peut-vous-aider-a-acheter-un-velo
 
+aides . villiers-en-bière:
+  remplace: commune
+  titre: Commune de Villiers-en-Bière
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique ou mécanique neuf. 
+
+    
+    Cette aide est disponible pour tout achat effectué à partir du 18/07/2024
+    sur présentation des justificatifs.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '77518'
+      - demandeur . âge >= 15 an
+      - vélo . électrique ou mécanique
+      - vélo . état . neuf
+  valeur:
+    variations:
+      - si: vélo . électrique
+        alors: 150€
+      - sinon: 100€
+  lien: https://www.mairievilliersenbiere.fr/aide-a-lacquisition-de-velos

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3442,45 +3442,45 @@ aides . lescar:
             alors: 100€
   lien: https://www.lescar.fr/information-transversale/fil-infos/mise-en-place-dune-aide-pour-lacquisition-dun-velo-pour-les-lescariens-1140
 
-# NOTE: valable pour 2024, à vérifier en 2025
-aides . bidart:
-  remplace: commune
-  titre: Ville de Bidart
-  description: >
-    Si vous avez votre résidence principale à Bidart et que vous achetez un
-    vélo classique ou un vélo à assistance électrique, vous pouvez bénéficier
-    d'une aide de la Ville de Bidart.
-
-
-    Cette aide peut être demandée pour tout achat de vélo effectué à compter du
-    1er mars 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '64125'
-      - vélo . électrique ou mécanique
-  valeur: 50% * vélo . prix
-  plafond:
-    variations:
-      - si: vélo . cargo électrique
-        alors:
-          variations:
-            - si: revenu fiscal de référence par part < 28000 €/an
-              alors: 500€
-            - sinon: 400€
-      - si: vélo . électrique
-        alors:
-          variations:
-            - si: revenu fiscal de référence par part < 28000 €/an
-              alors: 400€
-            - sinon: 300€
-      - si: vélo . mécanique
-        alors:
-          variations:
-            - si: revenu fiscal de référence par part < 28000 €/an
-              alors: 200€
-            - sinon: 100€
-      - sinon: 0€
-  lien: https://www.bidart.fr/demande-daide-a-lachat-de-velos
+# NOTE: valable pour 2024, à vérifier en 2025 (aide épuisée pour 2024)
+# aides . bidart:
+#   remplace: commune
+#   titre: Ville de Bidart
+#   description: >
+#     Si vous avez votre résidence principale à Bidart et que vous achetez un
+#     vélo classique ou un vélo à assistance électrique, vous pouvez bénéficier
+#     d'une aide de la Ville de Bidart.
+#
+#
+#     Cette aide peut être demandée pour tout achat de vélo effectué à compter du
+#     1er mars 2024.
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . code insee = '64125'
+#       - vélo . électrique ou mécanique
+#   valeur: 50% * vélo . prix
+#   plafond:
+#     variations:
+#       - si: vélo . cargo électrique
+#         alors:
+#           variations:
+#             - si: revenu fiscal de référence par part < 28000 €/an
+#               alors: 500€
+#             - sinon: 400€
+#       - si: vélo . électrique
+#         alors:
+#           variations:
+#             - si: revenu fiscal de référence par part < 28000 €/an
+#               alors: 400€
+#             - sinon: 300€
+#       - si: vélo . mécanique
+#         alors:
+#           variations:
+#             - si: revenu fiscal de référence par part < 28000 €/an
+#               alors: 200€
+#             - sinon: 100€
+#       - sinon: 0€
+#   lien: https://www.bidart.fr/demande-daide-a-lachat-de-velos
 
 # NOTE: pas d'information sur la durée de validité, à vérifier en 2025
 aides . vallée d'ossau:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7725,7 +7725,7 @@ aides . amboise:
       - valeur: vélo . prix
         plafond: 1200€
   plancher: 200€
-  lien: https://www.ville-amboise.fr/57-1229/fiche/demande-d-aide-a-l-achat-d-un-velohttps://www.valdereuil.fr/services-municipaux/demarches-en-ligne/bonus-tous-a-velo-electrique.htm
+  lien: https://www.ville-amboise.fr/57-1229/fiche/demande-d-aide-a-l-achat-d-un-velo
 
 # NOTE: plus disponible sur le site 
 # aides . vexin normand:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9132,3 +9132,23 @@ aides . crestois et pays de saillans:
   valeur: 25% * vélo . prix
   plafond: 250€
   lien: https://www.cccps.fr/demarches/aide-pour-lelectrification-dun-velo-classique/
+
+# TODO: à mettre à jour en 2026
+aides . binic etables sur mer:
+  remplace: commune
+  titre: Commune de Binic-Étables sur Mer
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique ou mécanique, neuf ou
+    d'occasion. Est également éligible l'achat de remorque pour vélo.
+
+    
+    Durée du dispositif : 1er janvier 2024 au 31 décembre 2026.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '22055'
+      - revenu fiscal de référence par part <= 2314 €/mois
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . adapté
+  valeur: 80% * vélo . prix
+  plafond: 250€

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9399,3 +9399,20 @@ aides . cc les portes briardes:
         alors: 80€
       - sinon: 150€
   lien: https://www.lesportesbriardes.fr/2023/12/28/beneficiez-dune-aide-a-lachat-de-velo
+
+aides . cc pays des sorgues:
+  remplace: intercommunalité
+  titre: Communauté de communes du Pays des Sorgues et des Monts de Vaucluse
+  description: >
+    Aide à l'achat d'un vélo de 200 € pour tout achat chez un commerçant des
+    communes de la communauté de communes.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC du Pays des Sorgues et des Monts de Vaucluse'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . adapté
+  valeur: 200€
+  plafond: vélo . prix
+  lien: https://www.paysdessorgues.fr/aide-velo

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9490,3 +9490,18 @@ aides . vaucresson:
       - vélo . motorisation
   valeur: 150€
   lien: https://www.vaucresson.fr/mon-cadre-de-vie/mobilite/velos-electriques
+
+aides . cu arras:
+  remplace: intercommunalité
+  titre: Communauté urbaine d'Arras
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique chez un·e commerçant·e du
+    territoire communautaire.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CU d'Arras"
+      - demandeur . âge . majeur
+      - vélo . électrique
+  valeur: 30% * vélo . prix
+  plafond: 300 €
+  lien: https://www.demarches-simplifiees.fr/commencer/cua-aide-velo-elec

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2937,15 +2937,19 @@ aides . pays de l'ozon:
 #   plafond: vélo . prix
 #   lien: https://www.loire.fr/jcms/lw_1383840/fr/beneficiez-de-300-euros-pour-l-achat-d-un-velo-a-assistance-electrique-ou-d-un-kit-d-electrification-vae
 
+# NOTE: le plan hérault-vélo 2025-2030 en cours de construction, à vérifier en 2025
 aides . département hérault:
   remplace: département
   titre: Département Hérault
   description: >
-    Chèque Hérault Vélo - Aide à l'achat d'un vélo électrique neuf réalisé
-    auprès d'un professionnel exerçant son activité professionnelle sur le
-    territoire du Département de l'Hérault. Cette aide peut être complétées par
-    un bonus « Hérault Pichòt » de 20€ pour l'achat d'un siège enfant ou de 50€
-    pour une carriole.
+    Chèque Hérault Vélo - En pause en attendant le plan Hérault Vélo 2025-2030. 
+
+
+  # Chèque Hérault Vélo - Aide à l'achat d'un vélo électrique neuf réalisé
+  # auprès d'un professionnel exerçant son activité professionnelle sur le
+  # territoire du Département de l'Hérault. Cette aide peut être complétées par
+  # un bonus « Hérault Pichòt » de 20€ pour l'achat d'un siège enfant ou de 50€
+  # pour une carriole.
   applicable si:
     toutes ces conditions:
       - localisation . département = '34'
@@ -2964,15 +2968,19 @@ aides . département hérault:
     officielle](https://herault.fr/cms_viewFile.php?idtf=9118&path=Reglement-des-cheques-Herault-Velo-et-Herault-Handi-Velo.pdf).
     Nous avons donc décidé de ne pas l'appliquer.
   # plafond: 250€
-  lien: https://herault.fr/aideProjet/3/321-aide-a-l-achat-d-un-velo-electrique-vae.htm
+  lien: https://herault.fr/actualite/127075/2-le-departement-lance-une-enquete-sur-la-construction-du-plan-herault-velo.htm
+  # lien: https://herault.fr/aideProjet/3/321-aide-a-l-achat-d-un-velo-electrique-vae.htm
 
 aides . département hérault vélo adapté:
   remplace: département
   titre: Département Hérault
   description: >
-    Chèque Hérault Handi-Vélo - Aide à l'achat d'un vélo électrique adapté ou
-    de matériel adapté (dispositif de troisième roue, guidons électriques…)
-    neuf et d'occasion. 
+    Chèque Hérault Handi-Vélo - En pause en attendant le plan Hérault Vélo
+    2025-2030. 
+
+# Chèque Hérault Handi-Vélo - Aide à l'achat d'un vélo électrique adapté ou
+# de matériel adapté (dispositif de troisième roue, guidons électriques…)
+# neuf et d'occasion. 
   applicable si:
     toutes ces conditions:
       - localisation . département = '34'
@@ -2981,7 +2989,8 @@ aides . département hérault vélo adapté:
       - vélo . adapté
   valeur: 50% * vélo . prix
   plafond: 1000€
-  lien: https://herault.fr/aideProjet/3/321-aide-a-l-achat-d-un-velo-electrique-vae.htm
+  lien: https://herault.fr/actualite/127075/2-le-departement-lance-une-enquete-sur-la-construction-du-plan-herault-velo.htm
+  # lien: https://herault.fr/aideProjet/3/321-aide-a-l-achat-d-un-velo-electrique-vae.htm
 
 aides . montpellier:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9257,3 +9257,26 @@ aides . creusot-montceau:
             - sinon: 0€
       - sinon: 0€
   lien: https://www.creusot-montceau.org/actualite/la-communaute-urbaine-vous-aide-financierement-pour-lacquisition-dun-velo
+
+aides . territoire de l'ouest:
+  remplace: intercommunalité
+  titre: Territoire de l'Ouest
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique neuf ou d'occasion, acheté
+    chez un professionnel.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CA Territoire de la Côte Ouest (TCO)'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . adapté
+  valeur:
+    variations:
+      - si: 
+          une de ces conditions:
+            - vélo . cargo
+            - vélo . adapté
+        alors: 500€
+      - sinon: 300€
+  lien: https://www.tco.re/vae-du-territoire-de-louest

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9476,3 +9476,17 @@ aides . charenton-le-pont:
   valeur: 50% * vélo . prix
   plafond: 200€
   lien: https://www.charenton.fr/velo/velo_pass-velo
+
+aides . vaucresson:
+  remplace: commune
+  titre: Ville de Vaucresson
+  description: >
+    Subvention de 150€ pour l'électrification d'un vélo classique. Son
+    attribution est conditionnée par le dépôt d’un dossier en mairie et la
+    signature d’une convention.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '92076'
+      - vélo . motorisation
+  valeur: 150€
+  lien: https://www.vaucresson.fr/mon-cadre-de-vie/mobilite/velos-electriques

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -47,106 +47,107 @@ plafond état:
     bénéficier du Bonus vélo.
   valeur: 15400 €/an  
 
-aides . bonus vélo:
-  remplace: état
-  titre: Bonus vélo
-  description: Nouveau bonus $vélo applicable à partir du 14 février 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . pays = 'France'
-      - demandeur . âge . majeur
-      - une de ces conditions:
-          - vélo . électrique ou mécanique
-          - vélo . adapté
-      - une de ces conditions:
-          - revenu fiscal de référence par part <= plafond état
-          - demandeur . en situation de handicap
-  valeur: 40% * vélo . prix
-  plafond:
-    variations:
-      - si:
-          une de ces conditions:
-            - vélo . cargo
-            - vélo . pliant
-            - vélo . adapté
-        alors: 
-          variations:
-            - si: 
-                une de ces conditions:
-                  - revenu fiscal de référence par part <= 7100 €/an
-                  - demandeur . en situation de handicap
-              alors: 2000€
-            - sinon: 1000€
-      - si: vélo . électrique
-        alors: 
-          variations:
-            - si: 
-                une de ces conditions:
-                  - revenu fiscal de référence par part <= 7100 €/an
-                  - demandeur . en situation de handicap
-              alors: 400€
-            - sinon: 300€
-      - sinon:
-          variations:
-            - si: 
-                une de ces conditions:
-                  - revenu fiscal de référence par part <= 7100 €/an
-                  - demandeur . en situation de handicap
-              alors: 150€
-            - sinon: 0€
-  lien: https://www.economie.gouv.fr/particuliers/prime-velo-electrique# 
+# NOTE: fin du bonus vélo à partir du 2 décembre 2024 : https://www.economie.gouv.fr/cedef/bonus-ecologique-velo-electrique
+# aides . bonus vélo:
+#   remplace: état
+#   titre: Bonus vélo
+#   description: Nouveau bonus $vélo applicable à partir du 14 février 2024.
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . pays = 'France'
+#       - demandeur . âge . majeur
+#       - une de ces conditions:
+#           - vélo . électrique ou mécanique
+#           - vélo . adapté
+#       - une de ces conditions:
+#           - revenu fiscal de référence par part <= plafond état
+#           - demandeur . en situation de handicap
+#   valeur: 40% * vélo . prix
+#   plafond:
+#     variations:
+#       - si:
+#           une de ces conditions:
+#             - vélo . cargo
+#             - vélo . pliant
+#             - vélo . adapté
+#         alors: 
+#           variations:
+#             - si: 
+#                 une de ces conditions:
+#                   - revenu fiscal de référence par part <= 7100 €/an
+#                   - demandeur . en situation de handicap
+#               alors: 2000€
+#             - sinon: 1000€
+#       - si: vélo . électrique
+#         alors: 
+#           variations:
+#             - si: 
+#                 une de ces conditions:
+#                   - revenu fiscal de référence par part <= 7100 €/an
+#                   - demandeur . en situation de handicap
+#               alors: 400€
+#             - sinon: 300€
+#       - sinon:
+#           variations:
+#             - si: 
+#                 une de ces conditions:
+#                   - revenu fiscal de référence par part <= 7100 €/an
+#                   - demandeur . en situation de handicap
+#               alors: 150€
+#             - sinon: 0€
+#   lien: https://www.economie.gouv.fr/particuliers/prime-velo-electrique# 
 
-aides . prime à la conversion:
-  type: état
-  applicable si:
-    toutes ces conditions:
-      - localisation . pays = 'France'
-      - demandeur . âge . majeur
-      - une de ces conditions:
-          - revenu fiscal de référence par part <= 24900 €/an
-          - demandeur . en situation de handicap
-      - une de ces conditions:
-          - vélo . électrique
-          - vélo . adapté
-  titre: Prime à la conversion
-  description: >
-    Pour bénéficier de cette « prime à la casse » vous devez détruire un
-    véhicule diesel immatriculé avant janvier 2011 ou bien un véhicule essence
-    immatriculé avant 2006.
-
-
-    La prime est de 40% du prix du vélo dans la limite de 3 000 €. Elle est
-    cumulable avec les aides à l'achat d'un vélo électrique, comme le « bonus
-    écologique ».
-  valeur: 40% * vélo . prix
-  plafond:
-    variations:
-      - si: 
-          une de ces conditions:
-            - revenu fiscal de référence par part <= 7100 €/an
-            - demandeur . en situation de handicap
-        alors: 3000€
-      - sinon: 1500€
-  lien: https://www.service-public.fr/particuliers/actualites/A17058
-
-aides . prime à la conversion . surprime ZFE:
-  applicable si:
-    toutes ces conditions:
-      - localisation . pays = 'France'
-      - localisation . ZFE
-  titre: Surprime Zone à Faibles Émissions (ZFE)
-  description: >
-    Vous pouvez bénéficier d'une surprime car $ville est une zone à faible
-    émission mobilité (ZFE). Cette surprime est conditionnée à l'octroi d'une
-    aide par la collectivité locale et son montant est identique à l'aide versée
-    par la collectivité locale, dans la limite de 1 000 €.
-  somme:
-    - commune
-    - intercommunalité
-    - département
-    - région
-  plafond: 1000€
-  lien: https://www.service-public.fr/particuliers/vosdroits/F36827
+# aides . prime à la conversion:
+#   type: état
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . pays = 'France'
+#       - demandeur . âge . majeur
+#       - une de ces conditions:
+#           - revenu fiscal de référence par part <= 24900 €/an
+#           - demandeur . en situation de handicap
+#       - une de ces conditions:
+#         - vélo . électrique
+#           - vélo . adapté
+#   titre: Prime à la conversion
+#   description: >
+#     Pour bénéficier de cette « prime à la casse » vous devez détruire un
+#     véhicule diesel immatriculé avant janvier 2011 ou bien un véhicule essence
+#     immatriculé avant 2006.
+# 
+# 
+#     La prime est de 40% du prix du vélo dans la limite de 3 000 €. Elle est
+#     cumulable avec les aides à l'achat d'un vélo électrique, comme le « bonus
+#     écologique ».
+#   valeur: 40% * vélo . prix
+#   plafond:
+#     variations:
+#       - si: 
+#           une de ces conditions:
+#             - revenu fiscal de référence par part <= 7100 €/an
+#             - demandeur . en situation de handicap
+#         alors: 3000€
+#       - sinon: 1500€
+#   lien: https://www.service-public.fr/particuliers/actualites/A17058
+# 
+# aides . prime à la conversion . surprime ZFE:
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . pays = 'France'
+#       - localisation . ZFE
+#   titre: Surprime Zone à Faibles Émissions (ZFE)
+#   description: >
+#     Vous pouvez bénéficier d'une surprime car $ville est une zone à faible
+#     émission mobilité (ZFE). Cette surprime est conditionnée à l'octroi d'une
+#     aide par la collectivité locale et son montant est identique à l'aide versée
+#     par la collectivité locale, dans la limite de 1 000 €.
+#   somme:
+#     - commune
+#     - intercommunalité
+#     - département
+#     - région
+#   plafond: 1000€
+#   lien: https://www.service-public.fr/particuliers/vosdroits/F36827
 
 aides . forfait mobilités durables: 500 €/an
 
@@ -8534,13 +8535,21 @@ aides . la côtière à montluel:
 aides . pays orne moselle:
   remplace: intercommunalité
   titre: Pays Orne Moselle
-  description: Aide à l'achat d'un vélo, neuf ou d'occasion.
+  description: >
+    Aide à l'achat d'un vélo, neuf ou d'occasion.
+
+    
+    A noter que l'élligibilité de cette aide est conditionnée par le fait de
+    bénéficier du "Bonus écologique" de l'État pour les vélos à assistance
+    électrique. Or, ce bonus a été supprimé à partir du 2 décembre 2024.
+    Veuillez vous renseigner auprès de la communauté de communes pour plus
+    d'informations avant de réaliser votre achat.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Pays Orne Moselle'
       - revenu fiscal de référence par part <= plafond état
       - demandeur . âge . majeur
-      - aides . bonus vélo > 0€
+      # - aides . bonus vélo > 0€
       - vélo . électrique ou mécanique
   valeur: 20% * vélo . prix
   plafond:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9335,3 +9335,22 @@ aides . villiers-en-bière:
         alors: 150€
       - sinon: 100€
   lien: https://www.mairievilliersenbiere.fr/aide-a-lacquisition-de-velos
+
+aides . cc arc sud bretagne:
+  remplace: intercommunalité
+  titre: Arc Sud Bretagne
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique ou vélo-cargo neuf ou
+    reconditionné.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Arc Sud Bretagne'
+      - demandeur . âge . majeur
+      - revenu fiscal de référence par part <= 15400 €/an
+      - vélo . électrique
+  valeur:
+    variations:
+      - si: vélo . cargo
+        alors: 200€
+      - sinon: 100€
+  lien: https://www.arc-sud-bretagne.fr/au-quotidien/mobilite

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7619,30 +7619,31 @@ aides . sainghin en melantois:
   lien: https://www.sainghin-en-melantois.fr/aide-lachat-dun-velo
 
 # NOTE: fin de validité en 2024, à vérifier en 2025
-aides . pays de mormal:
-  remplace: intercommunalité
-  titre: Communauté de communes du Pays de Mormal
-  description: >
-    Aide pour l'acquisition auprès d'un professionnel d'un seul vélo (cargo ou
-    familial, pliant, urbain…) à assistance électrique, neuf ou d'occasion et à
-    usage personnel.
-
-
-    Date limite de dépôt des dossiers : 1er décembre 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . epci = 'CC du Pays de Mormal'
-      - vélo . électrique
-  valeur:
-    variations:
-      - si: demandeur . bénéficiaire de minima sociaux
-        alors:
-          valeur: 50% * vélo . prix
-          plafond: 600€
-      - sinon:
-          valeur: 30% * vélo . prix
-          plafond: 360€
-  lien: https://www.cc-paysdemormal.fr/environnement-amenagement-html/aide-velo-trottinette-electrique/documents-velo-electrique/
+# NOTE: demande d'aide non accessible sur le site
+# aides . pays de mormal:
+#   remplace: intercommunalité
+#   titre: Communauté de communes du Pays de Mormal
+#   description: >
+#     Aide pour l'acquisition auprès d'un professionnel d'un seul vélo (cargo ou
+#     familial, pliant, urbain…) à assistance électrique, neuf ou d'occasion et à
+#     usage personnel.
+#
+#
+#     Date limite de dépôt des dossiers : 1er décembre 2024.
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . epci = 'CC du Pays de Mormal'
+#       - vélo . électrique
+#   valeur:
+#     variations:
+#       - si: demandeur . bénéficiaire de minima sociaux
+#         alors:
+#           valeur: 50% * vélo . prix
+#           plafond: 600€
+#       - sinon:
+#           valeur: 30% * vélo . prix
+#           plafond: 360€
+#   lien: https://www.cc-paysdemormal.fr/environnement-amenagement-html/aide-velo-trottinette-electrique/documents-velo-electrique/
 
 # NOTE: à vérifier après le 31 mai 2025
 aides . grand calais:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -8706,10 +8706,10 @@ aides . region centre:
           - localisation . epci = "CC Val de l'Indre - Brenne"
           - localisation . epci = "CC du Val de Bouzanne"
           - localisation . epci = "CC de la Marche Berrichonne"
-          - localisation . epci = "CC Eguzon - Argenton - Vallée de la Creuse"
+          - localisation . epci = "CC Éguzon - Argenton - Vallée de la Creuse"
           - localisation . epci = "CC de la Châtre et Sainte-Sévère"
           - localisation . epci = "CC du Châtillonnais en Berry"
-          - localisation . epci = "CC Ecueillé-Valençay"
+          - localisation . epci = "CC Écueillé-Valençay"
   valeur: 25% * vélo . prix
   plafond: 
     variations:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7480,20 +7480,21 @@ aides . lannion-trégor:
 #  plafond: 100€
 #  lien: http://ville.-guirec.com/ma-ville/vie-quotidienne/les-transports/en-velo/aide-a-l-acquisition-d-un-velo-a-assistance-electrique.html
 
-aides . trébeurden:
-  remplace: commune
-  titre: Ville de Trébeurden
-  description: >
-    Subvention de 20% du prix d'achat TTC du VAE neuf dans la limite de 200 €.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '22343'
-      - demandeur . âge . majeur
-      - vélo . état . neuf
-      - vélo . électrique
-  valeur: 20% * vélo . prix
-  plafond: 200€
-  lien: https://www.trebeurden.fr/actualite/subvention-pour-lachat-dun-velo-a-assistance-electrique/
+# NOTE: ne semble plus d'actualité, à vérifier en 2025
+# aides . trébeurden:
+#   remplace: commune
+#   titre: Ville de Trébeurden
+#   description: >
+#     Subvention de 20% du prix d'achat TTC du VAE neuf dans la limite de 200 €.
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . code insee = '22343'
+#       - demandeur . âge . majeur
+#       - vélo . état . neuf
+#       - vélo . électrique
+#   valeur: 20% * vélo . prix
+#   plafond: 200€
+#   lien: https://www.trebeurden.fr/actualite/subvention-pour-lachat-dun-velo-a-assistance-electrique/
 
 aides . morlaix:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5312,7 +5312,7 @@ aides . saint-pair-sur-mer:
     un revenu fiscal de référence par part par part inférieur ou égal à 6 358 €).
 
 
-    La prime est élligible pour les Saint Pairais majeur ayant un revenu fiscal
+    La prime est éligible pour les Saint Pairais majeur ayant un revenu fiscal
     de référence par part inférieur ou égal à 14 089 € ou étant en situation de
     handicap.
   applicable si:
@@ -6011,14 +6011,14 @@ aides . lorient agglo:
             - vélo . adapté
         alors: 
           variations:
-            - si: est élligible à la majoration du plafond
+            - si: est éligible à la majoration du plafond
               alors: 900€
             - sinon: 300€
-      - si: est élligible à la majoration du plafond
+      - si: est éligible à la majoration du plafond
         alors: 420€
       - sinon: 230€
   avec:
-    est élligible à la majoration du plafond:
+    est éligible à la majoration du plafond:
       valeur:
         une de ces conditions:
           - revenu fiscal de référence par part <= 880 €/mois
@@ -8587,7 +8587,7 @@ aides . pays orne moselle:
     Aide à l'achat d'un vélo, neuf ou d'occasion.
 
     
-    A noter que l'élligibilité de cette aide est conditionnée par le fait de
+    A noter que l'éligibilité de cette aide est conditionnée par le fait de
     bénéficier du "Bonus écologique" de l'État pour les vélos à assistance
     électrique. Or, ce bonus a été supprimé à partir du 2 décembre 2024.
     Veuillez vous renseigner auprès de la communauté de communes pour plus

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9416,3 +9416,27 @@ aides . cc pays des sorgues:
   valeur: 200€
   plafond: vélo . prix
   lien: https://www.paysdessorgues.fr/aide-velo
+
+aides . cc val parisis:
+  remplace: intercommunalité
+  titre: Val Parisis Agglo
+  description: >
+    Aide à l'achat d'un vélo à assistance électrique, pliant ou cargo neuf ou
+    reconditionné.
+
+    
+    Le cumul de l'aide de Val Parisis Agglo avec celle de la Région
+    Île-de-France ne peut excéder 50% du prix du vélo.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CA Val Parisis'
+      - une de ces conditions:
+          - est non applicable: aides . ile de france 
+          - aides . ile de france < 50% * vélo . prix
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . pliant
+          - vélo . cargo
+  valeur: 100€
+  plafond: 50% * vélo . prix
+  lien: https://valparisis.fr/aide-achat-velo

--- a/src/rules/demandeur.publicodes
+++ b/src/rules/demandeur.publicodes
@@ -72,7 +72,7 @@ demandeur . statut:
       titre: Apprenti·e
       valeur: statut = 'apprenti'
     demandeur d'emploi:
-      titre: Demandeureuse d'emploi
+      titre: Demandeur·euse d'emploi
       valeur: statut = 'demandeur d'emploi'
     salarié:
       titre: Salarié·e

--- a/src/rules/demandeur.publicodes
+++ b/src/rules/demandeur.publicodes
@@ -55,6 +55,7 @@ demandeur . statut:
     - demandeur d'emploi
     - salarié
     - retraité
+    - reconversion
     - autre
   par défaut: "'autre'"
   avec:
@@ -73,10 +74,12 @@ demandeur . statut:
     retraité:
       titre: Retraité·e
       valeur: statut = 'retraité'
+    reconversion:
+      titre: En reconversion
+      valeur: statut = 'reconversion'
     autre:
       titre: Autre
       valeur: statut = 'autre'
-
 
 demandeur . âge:
   type: nombre

--- a/src/rules/demandeur.publicodes
+++ b/src/rules/demandeur.publicodes
@@ -21,6 +21,11 @@ demandeur . bénéficiaire du RSA:
   question: Percevez-vous le RSA ?
   par défaut: non
 
+demandeur . bénéficiaire de l'AAH:
+  type: booléen
+  question: Percevez-vous l'allocation adulte handicapé (AAH) ?
+  par défaut: non
+
 demandeur . bénéficiaire de minima sociaux:
   type: booléen
   question: Percevez-vous le RSA, l'AAH, l'ASS ou ASPA ?
@@ -32,6 +37,7 @@ demandeur . bénéficiaire de minima sociaux:
   par défaut:
     une de ces conditions:
       - bénéficiaire du RSA
+      - bénéficiaire de l'AAH
 
 demandeur . en situation de handicap:
   type: booléen

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -1,4 +1,5 @@
 import { Aide, AideRuleNames, AidesVeloEngine } from "../src";
+import { describe, expect, it } from "vitest";
 
 describe("AidesVeloEngine", () => {
   describe("new AidesVeloEngine()", () => {
@@ -132,6 +133,44 @@ describe("AidesVeloEngine", () => {
       const aides = engine.computeAides();
 
       expect(aides).toHaveLength(0);
+    });
+
+    it("should correctly manage multiple localisations", () => {
+      const engine = globalTestEngine.shallowCopy();
+      let aides = engine
+        .setInputs({
+          "localisation . epci": "CC Orne Lorraine Confluences",
+          "localisation . pays": "France",
+          "vélo . prix": 1000,
+        })
+        .computeAides();
+
+      expect(aides).toHaveLength(1);
+      expect(aides[0].id).toEqual("aides . st2b");
+      expect(aides[0].amount).toEqual(300);
+      expect(aides[0].collectivity).toEqual({
+        kind: "epci",
+        value: "CC Orne Lorraine Confluences",
+        code: "200070845",
+      });
+
+      aides = engine
+        .setInputs({
+          "localisation . epci": "CC Coeur du Pays Haut",
+          "localisation . pays": "France",
+          "vélo . prix": 1000,
+        })
+        .computeAides();
+
+      expect(aides).toHaveLength(1);
+      expect(aides[0].id).toEqual("aides . st2b");
+      expect(aides[0].amount).toEqual(300);
+      // FIXME: should manage multiple localisations (see generate-aides-collectivities.ts)
+      // expect(aides[0].collectivity).toEqual({
+      //   kind: "epci",
+      //   value: "CC Coeur du Pays Haut",
+      //   code: "200070845",
+      // });
     });
 
     describe("with specific inputs", () => {

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -8,7 +8,7 @@ describe("AidesVeloEngine", () => {
 
       const parsedRules = engine.getEngine().getParsedRules();
       expect(parsedRules["aides"]).toBeDefined();
-      expect(parsedRules["aides . bonus vélo"]).toBeDefined();
+      // expect(parsedRules["aides . bonus vélo"]).toBeDefined();
       expect(parsedRules["vélo"]).toBeDefined();
     });
   });
@@ -130,9 +130,7 @@ describe("AidesVeloEngine", () => {
       const engine = globalTestEngine.shallowCopy();
       const aides = engine.computeAides();
 
-      expect(aides).toHaveLength(2);
-      expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-      expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+      expect(aides).toHaveLength(0);
     });
 
     describe("with specific inputs", () => {
@@ -149,7 +147,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(4);
+        expect(aides).toHaveLength(2);
         expect(contain(aides, "aides . montmorillon")).toBeTruthy();
         expect(contain(aides, "aides . vienne gartempe")).toBeTruthy();
       });
@@ -167,9 +165,9 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(4);
-        expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(2);
+        // expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . pays de la loire")).toBeTruthy();
         expect(contain(aides, "aides . angers")).toBeTruthy();
       });
@@ -189,9 +187,9 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(3);
-        expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(1);
+        // expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . angers")).toBeTruthy();
       });
 
@@ -209,14 +207,14 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(3);
-        expect(
-          contain(
-            aides,
-            "aides . bonus vélo",
-            ({ description }) => description?.includes("adapté") ?? false
-          )
-        ).toBeTruthy();
+        expect(aides).toHaveLength(1);
+        // expect(
+        //   contain(
+        //     aides,
+        //     "aides . bonus vélo",
+        //     ({ description }) => description?.includes("adapté") ?? false
+        //   )
+        // ).toBeTruthy();
         expect(contain(aides, "aides . occitanie vélo adapté")).toBeTruthy();
       });
 
@@ -234,13 +232,13 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(5);
-        expect(
-          contain(aides, "aides . bonus vélo", ({ description }) =>
-            description?.includes("adapté")
-          )
-        ).toBeTruthy();
-        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(3);
+        // expect(
+        //   contain(aides, "aides . bonus vélo", ({ description }) =>
+        //     description?.includes("adapté")
+        //   )
+        // ).toBeTruthy();
+        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . occitanie vélo adapté")).toBeTruthy();
         expect(
           contain(
@@ -263,7 +261,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(3);
+        expect(aides).toHaveLength(1);
         expect(contain(aides, "aides . cacl")).toBeTruthy();
       });
     });

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -67,6 +67,7 @@ describe("AidesVeloEngine", () => {
         "demandeur d'emploi",
         "salarié",
         "retraité",
+        "reconversion",
         "autre",
       ]);
     });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1859,4 +1859,41 @@ describe("Aides Vélo", () => {
       );
     });
   });
+
+  describe("Val Parisis Agglo", () => {
+    const baseSituation = {
+      "localisation . epci": "'CA Val Parisis'",
+      "vélo . prix": 1000,
+    };
+
+    test("par défaut", () => {
+      engine.setSituation(baseSituation);
+      expect(engine.evaluate("aides . cc val parisis").nodeValue).toEqual(100);
+    });
+
+    test("cargo électrique", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'cargo électrique'",
+      });
+      expect(engine.evaluate("aides . cc val parisis").nodeValue).toEqual(100);
+    });
+
+    test("ile de france > 50%", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "localisation . région": "'11'",
+      });
+      expect(engine.evaluate("aides . ile de france").nodeValue).toEqual(400);
+      expect(engine.evaluate("aides . cc val parisis").nodeValue).toEqual(100);
+
+      engine.setSituation({
+        ...baseSituation,
+        "localisation . région": "'11'",
+        "vélo . prix": 150,
+      });
+      expect(engine.evaluate("aides . ile de france").nodeValue).toEqual(75);
+      expect(engine.evaluate("aides . cc val parisis").nodeValue).toBeNull();
+    });
+  });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -24,8 +24,8 @@ describe("Aides Vélo", () => {
       // NOTE: should be generated at compile time
       const noNeedToAssociatesLoc: RuleName[] = [
         ...rulesToIgnore,
-        "aides . bonus vélo",
-        "aides . prime à la conversion",
+        // "aides . bonus vélo",
+        // "aides . prime à la conversion",
       ];
 
       ruleNames.forEach((key: RuleName) => {
@@ -74,7 +74,9 @@ describe("Aides Vélo", () => {
     });
   });
 
-  describe("Bonus Vélo", () => {
+  // NOTE: bonus vélo has been removed however we might want to re-introduce it
+  // in the future if it's reintroduced..
+  describe.skip("Bonus Vélo", () => {
     const baseSituation = {
       "localisation . code insee": "'75056'",
       "localisation . epci": "'Métropole du Grand Paris'",
@@ -283,14 +285,9 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
 
-      const aideEtat = engine.evaluate("aides . état").nodeValue;
-      assert(typeof aideEtat === "number");
-      expect(aideEtat).toEqual(400);
-
-      const expectedAmount = 0.5 * (1000 - aideEtat);
       expect(
         engine.evaluate("aides . occitanie vélo adapté").nodeValue
-      ).toEqual(expectedAmount);
+      ).toEqual(500);
 
       engine.setSituation({
         "localisation . région": "'76'",

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1763,4 +1763,75 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
     });
   });
+
+  describe("Lorient Agglomération", () => {
+    const baseSituation = {
+      "localisation . epci": "'CA Lorient Agglomération'",
+      "vélo . prix": 1000,
+      "revenu fiscal de référence par part": "1000 €/mois",
+    };
+
+    test("par défaut", () => {
+      engine.setSituation(baseSituation);
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(230);
+    });
+
+    test("mécanique", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'mécanique simple'",
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toBeNull();
+    });
+
+    test("électrique simple ou pliant", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(230);
+
+      engine.setSituation({
+        ...baseSituation,
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+        "revenu fiscal de référence par part": "500 €/mois",
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(300);
+
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'pliant électrique'",
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+        "demandeur . bénéficiaire de l'AAH": "oui",
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(300);
+    });
+
+    test("cargo ou adapté", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+        "vélo . type": "'cargo électrique'",
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(300);
+
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'cargo électrique'",
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+        "revenu fiscal de référence par part": "500 €/mois",
+        "vélo . prix": 10000,
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(900);
+
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'adapté'",
+        "aides . lorient agglo . abonnement Izilo Mobilités": "oui",
+        "demandeur . bénéficiaire de l'AAH": "oui",
+        "vélo . prix": 10000,
+      });
+      expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(900);
+    });
+  });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1834,4 +1834,29 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . lorient agglo").nodeValue).toEqual(900);
     });
   });
+
+  describe("Arc Sud Bretagne", () => {
+    const baseSituation = {
+      "localisation . epci": "'CC Arc Sud Bretagne'",
+      "vélo . prix": 1000,
+      "revenu fiscal de référence par part": "10000 €/an",
+    };
+
+    test("par défaut", () => {
+      engine.setSituation(baseSituation);
+      expect(engine.evaluate("aides . cc arc sud bretagne").nodeValue).toEqual(
+        100
+      );
+    });
+
+    test("cargo électrique", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "vélo . type": "'cargo électrique'",
+      });
+      expect(engine.evaluate("aides . cc arc sud bretagne").nodeValue).toEqual(
+        200
+      );
+    });
+  });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,5 +1,6 @@
 import Engine, { Rule } from "publicodes";
-import assert from "assert";
+import { describe, expect, it, test } from "vitest";
+
 import { AideRuleNames, RuleName } from "../src";
 import rules from "../publicodes-build";
 import { aidesAvecLocalisation, miniatures } from "../src/data";

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1633,4 +1633,134 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . val de drôme").nodeValue).toEqual(50);
     });
   });
+
+  describe("Communauté Urbaine Creusot-Montceau", () => {
+    const baseSituation = {
+      "localisation . epci": "'CU Le Creusot Montceau-les-Mines'",
+      "vélo . prix": 400,
+      "revenu fiscal de référence par part": "2000 €/mois",
+    };
+
+    test("élève de moins de 14 ans", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "13 an",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "13 an",
+        "demandeur . statut": "'étudiant'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "13 an",
+        "demandeur . statut": "'étudiant'",
+        "vélo . type": "'mécanique simple'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        100
+      );
+    });
+
+    test("élève de plus de 14 ans ou étudiant:e en étude supérieure", () => {
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "18 an",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "18 an",
+        "demandeur . statut": "'étudiant'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        200
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "18 an",
+        "demandeur . statut": "'étudiant'",
+        "vélo . type": "'mécanique simple'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        150
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . âge": "18 an",
+        "demandeur . statut": "'étudiant'",
+        "vélo . type": "'pliant'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+    });
+
+    test("actif:ve, retraité:e, ou en reconversion professionnelle", () => {
+      engine.setSituation({
+        ...baseSituation,
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'salarié'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        200
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'retraité'",
+        "vélo . type": "'mécanique simple'",
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        150
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'retraité'",
+        "vélo . type": "'cargo'",
+        "vélo . prix": 2500,
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        1000
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'salarié'",
+        "vélo . type": "'cargo électrique'",
+        "vélo . prix": 2500,
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        1250
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'reconversion'",
+        "vélo . type": "'adapté'",
+        "vélo . prix": 2500,
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
+        1250
+      );
+
+      engine.setSituation({
+        ...baseSituation,
+        "demandeur . statut": "'autre'",
+        "vélo . type": "'adapté'",
+        "vélo . prix": 2500,
+      });
+      expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(0);
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,10 +818,10 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@publicodes/tools@^1.3.0-1":
-  version "1.3.0-1"
-  resolved "https://registry.yarnpkg.com/@publicodes/tools/-/tools-1.3.0-1.tgz#a45199af518a2efa53e0ad4b1f66e22ed15c6757"
-  integrity sha512-2OgCtE58uwP5+b8juEP0kKuKR7wgCYv1YWQ8U+/tcqAe9kzkEHJXJIChDn08TzxfveFZsq9f71n277Em6xNaIg==
+"@publicodes/tools@^1.3.0-2":
+  version "1.3.0-2"
+  resolved "https://registry.yarnpkg.com/@publicodes/tools/-/tools-1.3.0-2.tgz#4088c3779603034ca89a3edfcbb8606f2d7e7804"
+  integrity sha512-/kn7+anS3iygHtXywrZdFR2dH4bk1dAOk0tuY8j3LDU5SdrGosHMY/fouAxMp+Da7Xl8p5u6/D7JKR8l3uJ8Bw==
   dependencies:
     "@clack/prompts" "^0.7.0"
     "@oclif/core" "^4.0.23"


### PR DESCRIPTION
### Changelog

- Suppression du bonus vélo ainsi que de la prime à la conversion (cf. #16 et le [décret n°2024-1084 du 29 novembre 2024](https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000050690951))
- Ajout d'une vingtaine de nouvelles aides tirées de #16
- Ajout de la question `demandeur . bénéficiaire de l'AAH`
- Ajout de la possibilité `reconversion` pour la règle `demandeur . statut`
- Suppression des quelques aides plus d'actualité 
- Mise à jour des liens cassés référencés dans #2