### PR TITLE
feat(rules)!: reintroduce 'aides . bonus vélo' and 'aides . prime à la conversion'

### DIFF
--- a/.changeset/angry-avocados-wink.md
+++ b/.changeset/angry-avocados-wink.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Add - Réintroduction du bonus écologique et de la prime à la conversion jusqu'au 14 février 2025

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -47,107 +47,119 @@ plafond état:
     bénéficier du Bonus vélo.
   valeur: 15400 €/an  
 
-# NOTE: fin du bonus vélo à partir du 2 décembre 2024 : https://www.economie.gouv.fr/cedef/bonus-ecologique-velo-electrique
-# aides . bonus vélo:
-#   remplace: état
-#   titre: Bonus vélo
-#   description: Nouveau bonus $vélo applicable à partir du 14 février 2024.
-#   applicable si:
-#     toutes ces conditions:
-#       - localisation . pays = 'France'
-#       - demandeur . âge . majeur
-#       - une de ces conditions:
-#           - vélo . électrique ou mécanique
-#           - vélo . adapté
-#       - une de ces conditions:
-#           - revenu fiscal de référence par part <= plafond état
-#           - demandeur . en situation de handicap
-#   valeur: 40% * vélo . prix
-#   plafond:
-#     variations:
-#       - si:
-#           une de ces conditions:
-#             - vélo . cargo
-#             - vélo . pliant
-#             - vélo . adapté
-#         alors: 
-#           variations:
-#             - si: 
-#                 une de ces conditions:
-#                   - revenu fiscal de référence par part <= 7100 €/an
-#                   - demandeur . en situation de handicap
-#               alors: 2000€
-#             - sinon: 1000€
-#       - si: vélo . électrique
-#         alors: 
-#           variations:
-#             - si: 
-#                 une de ces conditions:
-#                   - revenu fiscal de référence par part <= 7100 €/an
-#                   - demandeur . en situation de handicap
-#               alors: 400€
-#             - sinon: 300€
-#       - sinon:
-#           variations:
-#             - si: 
-#                 une de ces conditions:
-#                   - revenu fiscal de référence par part <= 7100 €/an
-#                   - demandeur . en situation de handicap
-#               alors: 150€
-#             - sinon: 0€
-#   lien: https://www.economie.gouv.fr/particuliers/prime-velo-electrique# 
+aides . bonus vélo:
+  remplace: état
+  titre: Bonus vélo
+  description: >
+    Le bonus vélo a été supprimé le 2 décembre 2024 !
 
-# aides . prime à la conversion:
-#   type: état
-#   applicable si:
-#     toutes ces conditions:
-#       - localisation . pays = 'France'
-#       - demandeur . âge . majeur
-#       - une de ces conditions:
-#           - revenu fiscal de référence par part <= 24900 €/an
-#           - demandeur . en situation de handicap
-#       - une de ces conditions:
-#         - vélo . électrique
-#           - vélo . adapté
-#   titre: Prime à la conversion
-#   description: >
-#     Pour bénéficier de cette « prime à la casse » vous devez détruire un
-#     véhicule diesel immatriculé avant janvier 2011 ou bien un véhicule essence
-#     immatriculé avant 2006.
-# 
-# 
-#     La prime est de 40% du prix du vélo dans la limite de 3 000 €. Elle est
-#     cumulable avec les aides à l'achat d'un vélo électrique, comme le « bonus
-#     écologique ».
-#   valeur: 40% * vélo . prix
-#   plafond:
-#     variations:
-#       - si: 
-#           une de ces conditions:
-#             - revenu fiscal de référence par part <= 7100 €/an
-#             - demandeur . en situation de handicap
-#         alors: 3000€
-#       - sinon: 1500€
-#   lien: https://www.service-public.fr/particuliers/actualites/A17058
-# 
-# aides . prime à la conversion . surprime ZFE:
-#   applicable si:
-#     toutes ces conditions:
-#       - localisation . pays = 'France'
-#       - localisation . ZFE
-#   titre: Surprime Zone à Faibles Émissions (ZFE)
-#   description: >
-#     Vous pouvez bénéficier d'une surprime car $ville est une zone à faible
-#     émission mobilité (ZFE). Cette surprime est conditionnée à l'octroi d'une
-#     aide par la collectivité locale et son montant est identique à l'aide versée
-#     par la collectivité locale, dans la limite de 1 000 €.
-#   somme:
-#     - commune
-#     - intercommunalité
-#     - département
-#     - région
-#   plafond: 1000€
-#   lien: https://www.service-public.fr/particuliers/vosdroits/F36827
+    Cependant, une période transitoire permet de pouvoir continuer de
+    bénéficier du bonus pour tout à achat effectué avant le 14 février 2025
+    inclus (date de facturation).
+  applicable si:
+    toutes ces conditions:
+      - localisation . pays = 'France'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . adapté
+      - une de ces conditions:
+          - revenu fiscal de référence par part <= plafond état
+          - demandeur . en situation de handicap
+  valeur: 40% * vélo . prix
+  plafond:
+    variations:
+      - si:
+          une de ces conditions:
+            - vélo . cargo
+            - vélo . pliant
+            - vélo . adapté
+        alors: 
+          variations:
+            - si: 
+                une de ces conditions:
+                  - revenu fiscal de référence par part <= 7100 €/an
+                  - demandeur . en situation de handicap
+              alors: 2000€
+            - sinon: 1000€
+      - si: vélo . électrique
+        alors: 
+          variations:
+            - si: 
+                une de ces conditions:
+                  - revenu fiscal de référence par part <= 7100 €/an
+                  - demandeur . en situation de handicap
+              alors: 400€
+            - sinon: 300€
+      - sinon:
+          variations:
+            - si: 
+                une de ces conditions:
+                  - revenu fiscal de référence par part <= 7100 €/an
+                  - demandeur . en situation de handicap
+              alors: 150€
+            - sinon: 0€
+  lien: https://www.economie.gouv.fr/particuliers/prime-velo-electrique# 
+
+aides . prime à la conversion:
+  type: état
+  titre: Prime à la conversion
+  description: >
+    Supprimée le 2 décembre 2024 !
+
+    Cpendant, une période transitoire est appliquée pour les cycles neufs ou
+    d'occasion, dès lors que leur facturation, ou que le versement du premier
+    loyer en cas de location, intervienne au plus tard le 14 février
+    2025 inclus.
+
+
+    Pour bénéficier de cette « prime à la casse » vous devez détruire un
+    véhicule diesel immatriculé avant janvier 2011 ou bien un véhicule essence
+    immatriculé avant 2006.
+
+
+    La prime est de 40% du prix du vélo dans la limite de 3 000 €. Elle est
+    cumulable avec les aides à l'achat d'un vélo électrique, comme le « bonus
+    écologique ».
+  applicable si:
+    toutes ces conditions:
+      - localisation . pays = 'France'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - revenu fiscal de référence par part <= 24900 €/an
+          - demandeur . en situation de handicap
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . adapté
+  valeur: 40% * vélo . prix
+  plafond:
+    variations:
+      - si: 
+          une de ces conditions:
+            - revenu fiscal de référence par part <= 7100 €/an
+            - demandeur . en situation de handicap
+        alors: 3000€
+      - sinon: 1500€
+  lien: https://www.service-public.fr/particuliers/actualites/A17058
+
+aides . prime à la conversion . surprime ZFE:
+  applicable si:
+    toutes ces conditions:
+      - localisation . pays = 'France'
+      - localisation . ZFE
+  titre: Surprime Zone à Faibles Émissions (ZFE)
+  description: >
+    Vous pouvez bénéficier d'une surprime car $ville est une zone à faible
+    émission mobilité (ZFE). Cette surprime est conditionnée à l'octroi d'une
+    aide par la collectivité locale et son montant est identique à l'aide versée
+    par la collectivité locale, dans la limite de 1 000 €.
+  somme:
+    - commune
+    - intercommunalité
+    - département
+    - région
+  plafond: 1000€
+  lien: https://www.service-public.fr/particuliers/vosdroits/F36827
 
 aides . forfait mobilités durables: 500 €/an
 
@@ -8594,7 +8606,7 @@ aides . pays orne moselle:
       - localisation . epci = 'CC du Pays Orne Moselle'
       - revenu fiscal de référence par part <= plafond état
       - demandeur . âge . majeur
-      # - aides . bonus vélo > 0€
+      - aides . bonus vélo > 0€
       - vélo . électrique ou mécanique
   valeur: 20% * vélo . prix
   plafond:

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -9,7 +9,7 @@ describe("AidesVeloEngine", () => {
 
       const parsedRules = engine.getEngine().getParsedRules();
       expect(parsedRules["aides"]).toBeDefined();
-      // expect(parsedRules["aides . bonus vélo"]).toBeDefined();
+      expect(parsedRules["aides . bonus vélo"]).toBeDefined();
       expect(parsedRules["vélo"]).toBeDefined();
     });
   });
@@ -132,7 +132,9 @@ describe("AidesVeloEngine", () => {
       const engine = globalTestEngine.shallowCopy();
       const aides = engine.computeAides();
 
-      expect(aides).toHaveLength(0);
+      expect(aides).toHaveLength(2);
+      expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+      expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
     });
 
     it("should correctly manage multiple localisations", () => {
@@ -145,10 +147,10 @@ describe("AidesVeloEngine", () => {
         })
         .computeAides();
 
-      expect(aides).toHaveLength(1);
-      expect(aides[0].id).toEqual("aides . st2b");
-      expect(aides[0].amount).toEqual(300);
-      expect(aides[0].collectivity).toEqual({
+      expect(aides).toHaveLength(3);
+      expect(aides[2].id).toEqual("aides . st2b");
+      expect(aides[2].amount).toEqual(300);
+      expect(aides[2].collectivity).toEqual({
         kind: "epci",
         value: "CC Orne Lorraine Confluences",
         code: "200070845",
@@ -162,11 +164,11 @@ describe("AidesVeloEngine", () => {
         })
         .computeAides();
 
-      expect(aides).toHaveLength(1);
-      expect(aides[0].id).toEqual("aides . st2b");
-      expect(aides[0].amount).toEqual(300);
+      expect(aides).toHaveLength(3);
+      expect(aides[2].id).toEqual("aides . st2b");
+      expect(aides[2].amount).toEqual(300);
       // FIXME: should manage multiple localisations (see generate-aides-collectivities.ts)
-      // expect(aides[0].collectivity).toEqual({
+      // expect(aides[2].collectivity).toEqual({
       //   kind: "epci",
       //   value: "CC Coeur du Pays Haut",
       //   code: "200070845",
@@ -187,7 +189,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(2);
+        expect(aides).toHaveLength(4);
         expect(contain(aides, "aides . montmorillon")).toBeTruthy();
         expect(contain(aides, "aides . vienne gartempe")).toBeTruthy();
       });
@@ -205,9 +207,9 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(2);
-        // expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(4);
+        expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . pays de la loire")).toBeTruthy();
         expect(contain(aides, "aides . angers")).toBeTruthy();
       });
@@ -227,9 +229,9 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(1);
-        // expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(3);
+        expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . angers")).toBeTruthy();
       });
 
@@ -247,14 +249,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(1);
-        // expect(
-        //   contain(
-        //     aides,
-        //     "aides . bonus vélo",
-        //     ({ description }) => description?.includes("adapté") ?? false
-        //   )
-        // ).toBeTruthy();
+        expect(aides).toHaveLength(3);
         expect(contain(aides, "aides . occitanie vélo adapté")).toBeTruthy();
       });
 
@@ -272,13 +267,8 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(3);
-        // expect(
-        //   contain(aides, "aides . bonus vélo", ({ description }) =>
-        //     description?.includes("adapté")
-        //   )
-        // ).toBeTruthy();
-        // expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+        expect(aides).toHaveLength(5);
+        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
         expect(contain(aides, "aides . occitanie vélo adapté")).toBeTruthy();
         expect(
           contain(
@@ -301,7 +291,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(1);
+        expect(aides).toHaveLength(3);
         expect(contain(aides, "aides . cacl")).toBeTruthy();
       });
     });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -25,8 +25,8 @@ describe("Aides Vélo", () => {
       // NOTE: should be generated at compile time
       const noNeedToAssociatesLoc: RuleName[] = [
         ...rulesToIgnore,
-        // "aides . bonus vélo",
-        // "aides . prime à la conversion",
+        "aides . bonus vélo",
+        "aides . prime à la conversion",
       ];
 
       ruleNames.forEach((key: RuleName) => {
@@ -75,9 +75,7 @@ describe("Aides Vélo", () => {
     });
   });
 
-  // NOTE: bonus vélo has been removed however we might want to re-introduce it
-  // in the future if it's reintroduced..
-  describe.skip("Bonus Vélo", () => {
+  describe("Bonus Vélo", () => {
     const baseSituation = {
       "localisation . code insee": "'75056'",
       "localisation . epci": "'Métropole du Grand Paris'",
@@ -286,9 +284,13 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
 
+      const aideEtat = engine.evaluate("aides . état").nodeValue;
+      expect(aideEtat).toEqual(400);
+
+      const expectedAmount = 0.5 * (1000 - aideEtat);
       expect(
         engine.evaluate("aides . occitanie vélo adapté").nodeValue
-      ).toEqual(500);
+      ).toEqual(expectedAmount);
 
       engine.setSituation({
         "localisation . région": "'76'",


### PR DESCRIPTION
Cette PR réactive le bonus écologique ainsi que la prime à la conversion car [une période transitoire](https://www.service-public.fr/particuliers/vosdroits/F36828) a été mise en place jusqu'au 14 février 2024.