### PR TITLE
Améliore le test des descriptions

### DIFF
--- a/.changeset/lazy-peaches-sing.md
+++ b/.changeset/lazy-peaches-sing.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Improve description test

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -9064,6 +9064,8 @@ aides . montmorillon:
 aides . monaco:
   remplace: commune
   titre: Monaco
+  description: >
+    Monaco subventionne l'achat d'un vélo électrique neuf.
   applicable si:
     toutes ces conditions:
       - vélo . électrique

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -1,4 +1,5 @@
 import { Aide, AideRuleNames, AidesVeloEngine } from "../src";
+import { Localisation } from "../src/data";
 import { describe, expect, it } from "vitest";
 
 describe("AidesVeloEngine", () => {
@@ -93,19 +94,24 @@ describe("AidesVeloEngine", () => {
     });
 
     it("should have a description", function () {
-      const engine = globalTestEngine.shallowCopy();
-      const allAides = engine.getAllAidesIn();
-      allAides.forEach((aide) => {
-        expect(typeof aide.description, 'Error description empty ' + aide.title).toBe("string")
+    const engine = globalTestEngine.shallowCopy();
+    const countries: Array<Localisation["country"]> = ["france", "monaco", "luxembourg"];
+    
+    countries.forEach(country => {
+        const allAides = engine.getAllAidesIn(country);
+        allAides.forEach((aide) => {
+        expect(typeof aide.description, `Description should be a string for benefit: ${aide.title} (${country})`).toBe("string");
+        expect(aide.description.length, `Description cannot be empty for benefit: ${aide.title} (${country})`).toBeGreaterThan(0);
         const innerText = aide.description
             .replace(/<\/?[^>]+>/gi, "")
             .replace(/\s\s+/g, " ")
-            .trim()
-        expect(innerText.length).toBeGreaterThanOrEqual(10)
+            .trim();
+        expect(innerText.length, `Description must be at least 10 characters for benefit: ${aide.title} (${country})`).toBeGreaterThanOrEqual(10);
         if (innerText.length > 420) {
-          console.warn(`Text length (${innerText.length}) exceeds maximum allowed length of 420 characters`);
+            console.warn(`Description text length (${innerText.length}) exceeds maximum allowed length of 420 characters for benefit: ${aide.title} (${country})`);
         }
-      });
+        });
+    });
     })
 
     it("should return all aids in Luxembourg if specified", () => {


### PR DESCRIPTION
Les aides dans les autres pays que la france (valeur par défaut dans la méthode `getAllAidesIn`) n'étaient pas traités dans le test de description. Je pense que c'est mieux de tout passer à la moulinette pour avoir des données uniformes.

J'ai ajouté une description pour l'aide de Monaco, mais le lien semble mort et je ne trouve pas d'info sur leur site. On la désactive ?

