### PR TITLE
Correction de l'erreur de typage lié à la description des aides

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,6 @@ jobs:
 
       - name: Test the package
         run: yarn test
+
+      - name: Compile the package
+        run: yarn compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Mise à jour de quelques descriptions et amélioration de leur test. ([#32](https://github.com/betagouv/publicodes-aides-velo/pull/32))
+- Update - Mise à jour de quelques descriptions et amélioration de leur test. ([#32](https://github.com/betagouv/publicodes-aides-velo/pull/32))
 
 ## 0.3.2
 

--- a/src/lib/AidesVeloEngine.ts
+++ b/src/lib/AidesVeloEngine.ts
@@ -20,7 +20,7 @@ export type Aide = {
   /** The title of the aid (as defined in the Publicodes rules). */
   title: string;
   /** The description of the aid (with resolved placeholders). */
-  description: string;
+  description: string | undefined;
   /** The URL of the aid (as defined in the Publicodes rules). */
   url: string;
   /** The collectivity that provides the aid. */
@@ -39,7 +39,7 @@ export type Aide = {
    * probably want to extract the miniature from the URL and format them
    * according to your needs.
    */
-  logo?: string;
+  logo: string | undefined;
 };
 
 const aidesAvecLocalisationEntries = Object.entries(

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -93,26 +93,48 @@ describe("AidesVeloEngine", () => {
       });
     });
 
+    /**
+     * NOTE: for now, we verify that all aids have a description although it is not
+     * required in the {@link Aide} type. This is because we want to force the
+     * user to check if the description is defined before using it allowing us
+     * to remove the constraint in the future if needed without breaking the API.
+     */
     it("should have a description", function () {
-    const engine = globalTestEngine.shallowCopy();
-    const countries: Array<Localisation["country"]> = ["france", "monaco", "luxembourg"];
-    
-    countries.forEach(country => {
+      const engine = globalTestEngine.shallowCopy();
+      const countries: Array<Localisation["country"]> = [
+        "france",
+        "monaco",
+        "luxembourg",
+      ];
+
+      countries.forEach((country) => {
         const allAides = engine.getAllAidesIn(country);
         allAides.forEach((aide) => {
-        expect(typeof aide.description, `Description should be a string for benefit: ${aide.title} (${country})`).toBe("string");
-        expect(aide.description.length, `Description cannot be empty for benefit: ${aide.title} (${country})`).toBeGreaterThan(0);
-        const innerText = aide.description
-            .replace(/<\/?[^>]+>/gi, "")
+          expect(aide.description).toBeDefined();
+          expect(
+            typeof aide.description,
+            `Description should be a string for benefit: ${aide.title} (${country})`
+          ).toBe("string");
+          expect(
+            aide.description?.length,
+            `Description cannot be empty for benefit: ${aide.title} (${country})`
+          ).toBeGreaterThan(0);
+          const innerText = aide.description
+            ?.replace(/<\/?[^>]+>/gi, "")
             .replace(/\s\s+/g, " ")
             .trim();
-        expect(innerText.length, `Description must be at least 10 characters for benefit: ${aide.title} (${country})`).toBeGreaterThanOrEqual(10);
-        if (innerText.length > 420) {
-            console.warn(`Description text length (${innerText.length}) exceeds maximum allowed length of 420 characters for benefit: ${aide.title} (${country})`);
-        }
+          expect(
+            innerText?.length,
+            `Description must be at least 10 characters for benefit: ${aide.title} (${country})`
+          ).toBeGreaterThanOrEqual(10);
+          if (innerText?.length! > 420) {
+            console.warn(
+              `Description text length (${innerText?.length}) exceeds maximum allowed length of 420 characters for benefit: ${aide.title} (${country})`
+            );
+          }
         });
+      });
     });
-    })
 
     it("should return all aids in Luxembourg if specified", () => {
       const engine = globalTestEngine.shallowCopy();


### PR DESCRIPTION
Cette PR permet de garder le type `Aide` inchangé avec le champ `description` possiblement `undefined` afin de ne pas avoir de changement cassant dans le futur si on décide d'enlever le test automatique de présence des descriptions.