### PR TITLE
Relecture des aides - avril 2025

### DIFF
--- a/.changeset/dirty-toys-jump.md
+++ b/.changeset/dirty-toys-jump.md
@@ -1,5 +1,10 @@
 ---
-"@betagouv/aides-velo": patch
+"@betagouv/aides-velo": minor
 ---
 
-Suppression - [aides Pays de la Loire, Louvigny, Côte d'Or], Mise à jour - [lien Entzheim, Ifs, Sarlat et Les Portes Briardes]
+- Suppression - Région Pays de la Loire
+- Suppression - Département Côte-d'Or
+- Suppression - Ville de Louvigny
+- Correction - Communauté de communes Les Portes Briardes Entre Villes et Forêts
+- Correction - Ville de Entzheim - Mise à jour du lien
+- Correction - Ville de Sarlat - Mise à jour du lien

--- a/.changeset/dirty-toys-jump.md
+++ b/.changeset/dirty-toys-jump.md
@@ -2,9 +2,17 @@
 "@betagouv/aides-velo": minor
 ---
 
-- Suppression - Région Pays de la Loire
-- Suppression - Département Côte-d'Or
-- Suppression - Ville de Louvigny
-- Correction - Communauté de communes Les Portes Briardes Entre Villes et Forêts
-- Correction - Ville de Entzheim - Mise à jour du lien
-- Correction - Ville de Sarlat - Mise à jour du lien
+### Aides mises à jour
+
+- Communauté de communes Les Portes Briardes Entre Villes et Forêts - Mise à jour de l'aide pour 2025
+- Ville de Entzheim - Mise à jour du lien
+- Ville de Entzheim - Mise à jour du lien
+- Ville de Longuenesse - Mise à jour du lien
+- Ville de Sarlat - Mise à jour du lien
+- Ville d'Ifs - Mise à jour du lien et des conditions d'éligibilités
+
+### Aides désactivées
+
+- Région Pays de la Loire
+- Département Côte-d'Or
+- Ville de Louvigny

--- a/.changeset/dirty-toys-jump.md
+++ b/.changeset/dirty-toys-jump.md
@@ -13,6 +13,4 @@
 
 ### Aides désactivées
 
-- Région Pays de la Loire
-- Département Côte-d'Or
 - Ville de Louvigny

--- a/.changeset/dirty-toys-jump.md
+++ b/.changeset/dirty-toys-jump.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Suppression - [aides Pays de la Loire, Louvigny, Côte d'Or], Mise à jour - [lien Entzheim, Ifs, Sarlat et Les Portes Briardes]

--- a/.changeset/nasty-onions-sleep.md
+++ b/.changeset/nasty-onions-sleep.md
@@ -1,0 +1,6 @@
+---
+"@betagouv/aides-velo": major
+---
+
+- Région Pays de la loire - Question `aides . pays de la loire . abonné TER` supprimée
+- Département Côte-d'Or - Question `aides . cote d'or . vélo assemblé ou produit localement` supprimée

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -11,10 +11,11 @@ maximiser les aides:
       valeur: vélo . prix pour maximiser les aides
       remplace:
         références à: vélo . prix
-    abonnement TER pays de la loire:
-      valeur: oui
-      remplace:
-        références à: aides . pays de la loire . abonné TER
+    # NOTE: aide désactivée pour le moment
+    # abonnement TER pays de la loire:
+    #   valeur: oui
+    #   remplace:
+    #     références à: aides . pays de la loire . abonné TER
   note: >
     Toutes les sous-questions paramétrant les conditions d'attribution des aides
     ne sont pas prises en compte ici.

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -1282,7 +1282,7 @@ aides . entzheim:
   remplace: commune
   titre: Ville de Entzheim
   description: >
-    Jusqu'au 31 décembre 2024, la commune d'Entzheim subventionne l'achat d'un
+    Jusqu'au 31 décembre 2025, la commune d'Entzheim subventionne l'achat d'un
     vélo neuf ou la réparation d'un vélo.
   applicable si: 
     toutes ces conditions:
@@ -1304,6 +1304,8 @@ aides . entzheim:
           plafond: 80€
       - sinon: 0€
   lien: https://www.entzheim.fr/demarches/subventions/velo/
+  dernière mise à jour: 10/04/2025
+  date de fin: 31/12/2025
 
 aides . geispolsheim:
   remplace: commune
@@ -1747,6 +1749,8 @@ aides . ifs:
   valeur: 10% * vélo . prix
   plafond: 150€
   lien: https://www.ville-ifs.fr/mon-quotidien/la-mobilite-et-les-transports/ifs-a-velo/
+  dernière mise à jour: 10/04/2025
+  date de fin: 31/12/2025
 
 # NOTE: informations pour 2023, à vérifier en 2025
 aides . mondeville:
@@ -2031,6 +2035,7 @@ aides . honfleur:
         valeur: 10% * vélo . prix
         plafond: 120€
   lien: https://www.ccphb.fr/amenager-et-developper/grands-projets/plan-velo/
+  dernière mise à jour: 10/04/2025
 
 # NOTE: limitée à 250 vélos depuis 2017, sûrement plus d'actualité.
 aides . istres:
@@ -2241,7 +2246,10 @@ aides . grand périgueux:
   plafond: 50% * vélo . prix
   lien: https://www.grandperigueux.fr/au-quotidien/deplacements/velo/aides-a-lachat-velo
 
-# NOTE: date de 2020 mais toujours accessible, à vérifier en 2025
+# NOTE :Appel à la mairie de Sarlat le 10/04/2025. 
+# L'aide existe toujours. 
+# Le site est en maintenance et certaines pages sont inaccessibles. 
+# Nous choisissons de mettre le lien de la page d'actualités qui présente l'aide.
 aides . sarlat:
   remplace: commune
   titre: Ville de Sarlat
@@ -2253,14 +2261,7 @@ aides . sarlat:
   valeur: 100€
   plaond: vélo . prix
   lien: https://www.sarlat.fr/actualites/100e-daide-pour-lachat-dun-velo-electrique/
-
-# NOTE: date de 2020 et non renouvable une fois l'enveloppe épuisée. Le site
-# relayant toujours l'information, nous choisissons de la conserver. A vérifier
-# en 2025.
-# NOTE :Appel à la mairie de Sarlat le 10/04/2025. 
-# L'aide existe toujours. 
-# Le site est en maintenance et certaines pages sont inaccessibles. 
-# Nous choisissons de mettre le lien de la page d'actualités qui présente l'aide.
+  dernière mise à jour: 10/04/2025
 
 aides . vallée de l'homme:
   remplace: intercommunalité
@@ -2280,6 +2281,7 @@ aides . vallée de l'homme:
         alors: 200€
       - sinon: 100€
   lien: https://www.cc-valleedelhomme.fr/mobilit%C3%A9-itin%C3%A9rance-douce/dispositifs-v%C3%A9lo/aide-%C3%A0-l-achat-pour-un-v%C3%A9lo-%C3%A9lectrique/
+  dernière mise à jour: 10/04/2025
 
 aides . sablé sur sarthe:
   remplace: commune
@@ -7288,7 +7290,8 @@ aides . baud:
   valeur: 50€
   lien: https://www.mairie-baud.fr/7252-2/
 
-# NOTE: vérification le 10/04/2025. l'aide est reconduite en 2025 (article de la voix du Nord) mais il n'y a pas encore de page d'information
+# NOTE: vérification le 10/04/2025. l'aide est reconduite en 2025 (article de
+# la voix du Nord) mais il n'y a pas encore de page d'information
 aides . longuenesse:
   remplace: commune
   titre: Ville de Longuenesse
@@ -7301,7 +7304,7 @@ aides . longuenesse:
           - vélo . adapté
   valeur: 20% * vélo . prix
   plafond: 100€
-  lien: https://ville-longuenesse.fr/fr/rb/1916787/prime-velo-2
+  lien: https://www.ville-longuenesse.fr/mon-quotidien/cadre-de-vie/developpement-durable/mobilite-douce
 
 aides . castelnau de médoc:
   remplace: commune
@@ -8182,13 +8185,15 @@ aides . cc pévèle carembault:
           plafond: 200€
   lien: https://www.pevelecarembault.fr/actualites/des-le-4-mars-demandez-votre-prime-velo-electrique
 
-# NOTE: l'aide est reconduite en 2025 (fichier pdf du règlement d'attribution pour 2025 disponible en ligne) mais la page d'information n'a pas encore été mise à jour.
+# NOTE: l'aide est reconduite en 2025 (fichier pdf du règlement d'attribution
+# pour 2025 disponible en ligne) mais la page d'information n'a pas encore été
+# mise à jour.
 aides . cc les portes briardes:
   remplace: intercommunalité
   titre: Communauté de communes Les Portes Briardes Entre Villes et Forêts
   description: >
     Aide à l'achat d'un vélo à assistance électrique ou mécanique neuf ou
-    d'occasion.
+    d'occasion. (Limitée à 400 demandes pour 2025).
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Les Portes Briardes Entre Villes et Forêts'
@@ -8200,9 +8205,19 @@ aides . cc les portes briardes:
   valeur:
     variations:
       - si: vélo . mécanique simple
-        alors: 80€
+        alors: 
+          variations:
+            - si: demandeur . âge < 25 an
+              alors: 120€
+            - sinon: 80€
+      - si:
+          toutes ces conditions:
+            - vélo . adapté
+            - demandeur . en situation de handicap
+        alors: 200€
       - sinon: 150€
-  lien: https://www.lesportesbriardes.fr/beneficiez-dune-aide-a-lachat-de-velo/
+  lien: https://www.lesportesbriardes.fr/wp-content/uploads/2025/03/Deliberation_017_2025_-_Annexe2_AideVelo_reglement_attribution_2025.pdf
+  dernière mise à jour: 10/04/2025
 
 aides . cc pays des sorgues:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -959,33 +959,6 @@ aides . saint-émilionnais:
   valeur: 200€
   lien: https://www.grand-saint-emilionnais.fr/actualites/primo-velo-2023-200e-de-subventions/
 
-aides . pays de la loire:
-  remplace: région
-  titre: Région Pays de la Loire
-  description: >
-    Aide à l'achat d'un vélo pliant ou à assistance électrique (VAE) pour les
-    abonnés Aléop.
-  applicable si:
-    toutes ces conditions:
-      - localisation . région = '52'
-      - une de ces conditions:
-          - vélo . pliant
-          - vélo . électrique
-      - abonné TER
-  valeur: 50% * vélo . prix
-  plafond: 200€
-  lien: https://www.paysdelaloire.fr/les-aides/aide-lachat-dun-velo-pliant-ou-assistance-electrique-vae-pour-les-abonnes-aleop
-  avec:
-    abonné TER:
-      type: booléen
-      question: Êtes-vous abonnés du TER Pays de la Loire ?
-      description: >
-        Sont éligibles les abonné·es de Tutti illimité, Métrocéane mensuels,
-        les abonnés annuels de Loire-Atlantique, Maine et Loire et Sarthe,
-        ainsi que les abonné·es mensuels des réseaux de Mayenne et Vendée (hors
-        scolaires).
-      par défaut: oui
-
 aides . nantes:
   remplace: intercommunalité
   titre: Nantes Métropole
@@ -1303,7 +1276,7 @@ aides . strasbourg:
       - sinon: 0€
   lien: https://www.strasbourg.eu/aides-achat
 
-# TODO: à vérifier en 2025
+# NOTE : aide vérifiée le 10/04/2025. Renouvellée pour 2025 avec une nouvelle url.
 aides . entzheim:
   remplace: commune
   titre: Ville de Entzheim
@@ -1329,7 +1302,7 @@ aides . entzheim:
           valeur: 30% * vélo . prix
           plafond: 80€
       - sinon: 0€
-  lien: http://www.entzheim.fr/fr/information/113321/aide-achat-un-velo-neuf-ou-reparation-un-velo
+  lien: https://www.entzheim.fr/demarches/subventions/velo/
 
 aides . geispolsheim:
   remplace: commune
@@ -1757,7 +1730,7 @@ aides . carpiquet:
   valeur: 150€
   lien: https://www.carpiquet.fr/wp-content/uploads/2024/01/CONVENTION-AIDE-FINANCIERE-VAE-ET-TROTTINETTE-ELECTRIQUE-ANNEE-2024.pdf
 
-# NOTE: informations pour 2023, à vérifier en 2025
+# NOTE: vérification faite le 10/04/2025. Aide reconduite en 2025. Lien corrigé.
 aides . ifs:
   remplace: commune
   titre: Ville d'Ifs
@@ -1769,12 +1742,10 @@ aides . ifs:
     toutes ces conditions:
       - localisation . code insee = '14341'
       - revenu fiscal de référence par part <= 24000€/an
-      - vélo . état . neuf
       - vélo . électrique
-      - vélo . prix <= 2500€
   valeur: 10% * vélo . prix
   plafond: 150€
-  lien: https://ville-ifs.fr/storage/app/media/DOSSIER%20SUBVENTION%20VAE-2023.pdf
+  lien: https://www.ville-ifs.fr/mon-quotidien/la-mobilite-et-les-transports/ifs-a-velo/
 
 # NOTE: informations pour 2023, à vérifier en 2025
 aides . mondeville:
@@ -2038,25 +2009,6 @@ aides . deauville:
       - sinon: 0€
   lien: https://www.mairie-deauville.fr/ville/mobilite-la-ville-renouvelle-laide-lachat-de-votre-velo
 
-# NOTE: informations pour 2021, à vérifier en 2025
-aides . louvigny:
-  remplace: commune
-  titre: Ville de Louvigny
-  description: >
-    La commune de Louvigny participe financièrement à l'achat d'un mode de déplacement doux (VAE neuf, vélo classique adulte neuf ou d'occasion)
-    pour des besoins professionnels comme personnels aux habitants de la ville.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '14383'
-      - revenu fiscal de référence par part <= 13489 €/an
-      - une de ces conditions:
-          - vélo . mécanique simple
-          - toutes ces conditions:
-              - vélo . électrique
-              - vélo . état . neuf
-  valeur: 50€
-  lien: https://ville-louvigny.fr/agenda/aide-communale-a-lacquisition-dun-velo-a-assistance-electrique-neuf-ou-velo-classique-neuf-ou-doccasion-a-la-maison-du-velo-ou-chez-un-velociste/
-
 aides . honfleur:
   remplace: intercommunalité
   titre: Communauté de communes Honfleur-Beuzeville
@@ -2299,11 +2251,16 @@ aides . sarlat:
       - vélo . électrique
   valeur: 100€
   plaond: vélo . prix
-  lien: https://www.sarlat.fr/100-e-daide-pour-lachat-dun-velo-electrique/
+  lien: https://www.sarlat.fr/actualites/100e-daide-pour-lachat-dun-velo-electrique/
 
 # NOTE: date de 2020 et non renouvable une fois l'enveloppe épuisée. Le site
 # relayant toujours l'information, nous choisissons de la conserver. A vérifier
 # en 2025.
+# NOTE :Appel à la mairie de Sarlat le 10/04/2025. 
+# L'aide existe toujours. 
+# Le site est en maintenance et certaines pages sont inaccessibles. 
+# Nous choisissons de mettre le lien de la page d'actualités qui présente l'aide.
+
 aides . vallée de l'homme:
   remplace: intercommunalité
   titre: Communauté de communes Vallée de l'Homme
@@ -3427,36 +3384,6 @@ aides . romilly-sur-seine:
       - vélo . électrique
   valeur: 100€
   lien: https://www.ville-romilly-sur-seine.fr/node/1514
-
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
-aides . cote d'or:
-  remplace: département
-  titre: Département Côte-d'Or
-  description: >
-    Une subvention de 250 € par VAE acheté dans un commerce de Côte-d'Or (pas
-    sur internet). Une bonification de 100 € est accordée pour toute
-    acquisition de VAE assemblé ou produit en Côte-d'Or, soit une aide totale
-    de 350 €.
-
-
-    Dispositif valable jusqu'au 31 décembre 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . département = '21'
-      - vélo . électrique
-      - vélo . état . neuf
-  valeur:
-    variations:
-      - si: vélo assemblé ou produit localement
-        alors: 350€
-      - sinon: 250€
-  plafond: vélo . prix
-  lien: https://www.cotedor.fr/aide/acquisition-de-velo-assistance-electrique
-  avec:
-    vélo assemblé ou produit localement:
-      question: Le vélo est-il assemblé ou produit en Côte-d'Or ?
-      type: booléen
-      par défaut: non
 
 # NOTE: valide jusqu'en 2026, à vérifier en 2027
 aides . boé:
@@ -7360,7 +7287,7 @@ aides . baud:
   valeur: 50€
   lien: https://www.mairie-baud.fr/7252-2/
 
-# NOTE: à vérifier en 2025
+# NOTE: vérification le 10/04/2025. l'aide est reconduite en 2025 (article de la voix du Nord) mais il n'y a pas encore de page d'information
 aides . longuenesse:
   remplace: commune
   titre: Ville de Longuenesse
@@ -8254,6 +8181,7 @@ aides . cc pévèle carembault:
           plafond: 200€
   lien: https://www.pevelecarembault.fr/actualites/des-le-4-mars-demandez-votre-prime-velo-electrique
 
+# NOTE: l'aide est reconduite en 2025 (fichier pdf du règlement d'attribution pour 2025 disponible en ligne) mais la page d'information n'a pas encore été mise à jour.
 aides . cc les portes briardes:
   remplace: intercommunalité
   titre: Communauté de communes Les Portes Briardes Entre Villes et Forêts
@@ -8273,7 +8201,7 @@ aides . cc les portes briardes:
       - si: vélo . mécanique simple
         alors: 80€
       - sinon: 150€
-  lien: https://www.lesportesbriardes.fr/2023/12/28/beneficiez-dune-aide-a-lachat-de-velo
+  lien: https://www.lesportesbriardes.fr/beneficiez-dune-aide-a-lachat-de-velo/
 
 aides . cc pays des sorgues:
   remplace: intercommunalité

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1212,3 +1212,77 @@ aides . vallées du clain:
   lien: https://www.valleesduclain.fr/2023/04/27/dispositif-daide-a-lachat-dun-velo-electrique/
   dernière mise à jour: 20/02/2025
 
+# NOTE: pas d'indice sur la continuité de l'aide en 2025
+aides . cote d'or:
+  remplace: département
+  titre: Département Côte-d'Or
+  description: >
+    Une subvention de 250 € par VAE acheté dans un commerce de Côte-d'Or (pas
+    sur internet). Une bonification de 100 € est accordée pour toute
+    acquisition de VAE assemblé ou produit en Côte-d'Or, soit une aide totale
+    de 350 €.
+    Dispositif valable jusqu'au 31 décembre 2024.
+  applicable si:
+    toutes ces conditions:
+      - localisation . département = '21'
+      - vélo . électrique
+      - vélo . état . neuf
+  valeur:
+    variations:
+      - si: vélo assemblé ou produit localement
+        alors: 350€
+      - sinon: 250€
+  plafond: vélo . prix
+  lien: https://www.cotedor.fr/aide/acquisition-de-velo-assistance-electrique
+  avec:
+    vélo assemblé ou produit localement:
+      question: Le vélo est-il assemblé ou produit en Côte-d'Or ?
+      type: booléen
+      par défaut: non
+
+# NOTE: pas d'indice sur la continuité de l'aide en 2025
+aides . louvigny:
+  remplace: commune
+  titre: Ville de Louvigny
+  description: >
+    La commune de Louvigny participe financièrement à l'achat d'un mode de déplacement doux (VAE neuf, vélo classique adulte neuf ou d'occasion)
+    pour des besoins professionnels comme personnels aux habitants de la ville.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '14383'
+      - revenu fiscal de référence par part <= 13489 €/an
+      - une de ces conditions:
+          - vélo . mécanique simple
+          - toutes ces conditions:
+              - vélo . électrique
+              - vélo . état . neuf
+  valeur: 50€
+  lien: https://ville-louvigny.fr/agenda/aide-communale-a-lacquisition-dun-velo-a-assistance-electrique-neuf-ou-velo-classique-neuf-ou-doccasion-a-la-maison-du-velo-ou-chez-un-velociste/
+
+# NOTE: pas d'indice sur la continuité de l'aide en 2025
+aides . pays de la loire:
+  remplace: région
+  titre: Région Pays de la Loire
+  description: >
+    Aide à l'achat d'un vélo pliant ou à assistance électrique (VAE) pour les
+    abonnés Aléop.
+  applicable si:
+    toutes ces conditions:
+      - localisation . région = '52'
+      - une de ces conditions:
+          - vélo . pliant
+          - vélo . électrique
+      - abonné TER
+  valeur: 50% * vélo . prix
+  plafond: 200€
+  lien: https://www.paysdelaloire.fr/les-aides/aide-lachat-dun-velo-pliant-ou-assistance-electrique-vae-pour-les-abonnes-aleop
+  avec:
+    abonné TER:
+      type: booléen
+      question: Êtes-vous abonnés du TER Pays de la Loire ?
+      description: >
+        Sont éligibles les abonné·es de Tutti illimité, Métrocéane mensuels,
+        les abonnés annuels de Loire-Atlantique, Maine et Loire et Sarthe,
+        ainsi que les abonné·es mensuels des réseaux de Mayenne et Vendée (hors
+        scolaires).
+      par défaut: oui

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -238,25 +238,26 @@ describe("AidesVeloEngine", () => {
         expect(contain(aides, "aides . vienne gartempe")).toBeTruthy();
       });
 
-      it("Angers - vélo électrique avec abonnement TER", async () => {
-        const engine = globalTestEngine.shallowCopy();
-        const aides = engine
-          .setInputs({
-            "localisation . code insee": "49007",
-            "localisation . epci": "CU Angers Loire Métropole",
-            "localisation . département": "49",
-            "localisation . région": "52",
-            "localisation . pays": "France",
-            "vélo . type": "électrique",
-          })
-          .computeAides();
-
-        expect(aides).toHaveLength(4);
-        expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
-        expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
-        expect(contain(aides, "aides . pays de la loire")).toBeTruthy();
-        expect(contain(aides, "aides . angers")).toBeTruthy();
-      });
+      // NOTE: aide désactivée pour le moment
+      // it("Angers - vélo électrique avec abonnement TER", async () => {
+      //   const engine = globalTestEngine.shallowCopy();
+      //   const aides = engine
+      //     .setInputs({
+      //       "localisation . code insee": "49007",
+      //       "localisation . epci": "CU Angers Loire Métropole",
+      //       "localisation . département": "49",
+      //       "localisation . région": "52",
+      //       "localisation . pays": "France",
+      //       "vélo . type": "électrique",
+      //     })
+      //     .computeAides();
+      //
+      //   expect(aides).toHaveLength(4);
+      //   expect(contain(aides, "aides . bonus vélo")).toBeTruthy();
+      //   expect(contain(aides, "aides . prime à la conversion")).toBeTruthy();
+      //   expect(contain(aides, "aides . pays de la loire")).toBeTruthy();
+      //   expect(contain(aides, "aides . angers")).toBeTruthy();
+      // });
 
       it("Angers - vélo électrique sans abonnement TER", async () => {
         const engine = globalTestEngine.shallowCopy();
@@ -269,7 +270,7 @@ describe("AidesVeloEngine", () => {
             "localisation . région": "52",
             "localisation . pays": "France",
             "vélo . type": "électrique",
-            "aides . pays de la loire . abonné TER": false,
+            // "aides . pays de la loire . abonné TER": false,
           })
           .computeAides();
 

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -243,27 +243,28 @@ describe("Aides Vélo", () => {
     });
   });
 
-  describe("Département Côte-d'Or", () => {
-    it("plus de subvention pour les vélos assemblés ou produit localement", () => {
-      const coteDorSituation = {
-        "vélo . type": "'électrique'",
-        "localisation . département": "'21'",
-        "vélo . prix": "500€",
-      };
-
-      engine.setSituation(coteDorSituation);
-      expect(engine.evaluate("aides . cote d'or").nodeValue).toEqual(250);
-
-      engine.setSituation({
-        ...coteDorSituation,
-        // TODO: use generated types instead of the json
-        // @ts-ignore
-        "aides . cote d'or . vélo assemblé ou produit localement": "oui",
-      });
-      expect(engine.evaluate("aides . cote d'or").nodeValue).toEqual(350);
-    });
-  });
-
+  // NOTE: aide désactivée pour le moment
+  // describe("Département Côte-d'Or", () => {
+  //   it("plus de subvention pour les vélos assemblés ou produit localement", () => {
+  //     const coteDorSituation = {
+  //       "vélo . type": "'électrique'",
+  //       "localisation . département": "'21'",
+  //       "vélo . prix": "500€",
+  //     };
+  //
+  //     engine.setSituation(coteDorSituation);
+  //     expect(engine.evaluate("aides . cote d'or").nodeValue).toEqual(250);
+  //
+  //     engine.setSituation({
+  //       ...coteDorSituation,
+  //       // TODO: use generated types instead of the json
+  //       // @ts-ignore
+  //       "aides . cote d'or . vélo assemblé ou produit localement": "oui",
+  //     });
+  //     expect(engine.evaluate("aides . cote d'or").nodeValue).toEqual(350);
+  //   });
+  // });
+  //
   describe("Région Occitanie", () => {
     it("ne devrait pas avoir de plafond pour l'Eco-chèque mobilité", () => {
       engine.setSituation({
@@ -1413,26 +1414,27 @@ describe("Aides Vélo", () => {
     });
   });
 
-  describe("Région Pays de la Loire", () => {
-    it("devrait être élligible uniquement pour les abonné TER", () => {
-      engine.setSituation({
-        "localisation . région": "'52'",
-        "vélo . type": "'électrique'",
-        "vélo . prix": 1000,
-      });
-      expect(engine.evaluate("aides . pays de la loire").nodeValue).toEqual(
-        200
-      );
-
-      engine.setSituation({
-        "localisation . région": "'52'",
-        "vélo . type": "'électrique'",
-        "vélo . prix": 1000,
-        "aides . pays de la loire . abonné TER": "non",
-      });
-      expect(engine.evaluate("aides . pays de la loire").nodeValue).toBeNull();
-    });
-  });
+  // NOTE: L'aide est désactivée pour le moment
+  // describe("Région Pays de la Loire", () => {
+  //   it("devrait être élligible uniquement pour les abonné TER", () => {
+  //     engine.setSituation({
+  //       "localisation . région": "'52'",
+  //       "vélo . type": "'électrique'",
+  //       "vélo . prix": 1000,
+  //     });
+  //     expect(engine.evaluate("aides . pays de la loire").nodeValue).toEqual(
+  //       200
+  //     );
+  //
+  //     engine.setSituation({
+  //       "localisation . région": "'52'",
+  //       "vélo . type": "'électrique'",
+  //       "vélo . prix": 1000,
+  //       "aides . pays de la loire . abonné TER": "non",
+  //     });
+  //     expect(engine.evaluate("aides . pays de la loire").nodeValue).toBeNull();
+  //   });
+  // });
 
   describe("Département de l'Oise", () => {
     it("devrait pas être élligible pour les personnes ayant bénéficiées de l'aide à la conversion bioéthanol", () => {


### PR DESCRIPTION
3 aides supprimées : 
- Pays de la loire
- Louvigny
- Cote d'Or

4 aides mises à jour 
- Sarlat
- Entzheim
- Portes Briardes
- Ifs