### PR TITLE
Mise en place du suivi de la couverture des aides + début relecture

### DIFF
--- a/.changeset/big-lizards-find.md
+++ b/.changeset/big-lizards-find.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression - Ville de Castelnau de Médoc

--- a/.changeset/brave-planes-vanish.md
+++ b/.changeset/brave-planes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Mise à jour - Région Centre-Val de Loire

--- a/.changeset/breezy-parents-fry.md
+++ b/.changeset/breezy-parents-fry.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Montpellier Méditerranée Métropole - vae occasion

--- a/.changeset/breezy-schools-do.md
+++ b/.changeset/breezy-schools-do.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC Loue-Lison

--- a/.changeset/bright-needles-smell.md
+++ b/.changeset/bright-needles-smell.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Commune de Barcelonnette

--- a/.changeset/chatty-women-write.md
+++ b/.changeset/chatty-women-write.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - ville de Dieppe

--- a/.changeset/clever-chairs-grow.md
+++ b/.changeset/clever-chairs-grow.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC Saône Beaujolais

--- a/.changeset/common-spies-smash.md
+++ b/.changeset/common-spies-smash.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Pays de l'Ozon

--- a/.changeset/cuddly-buckets-kiss.md
+++ b/.changeset/cuddly-buckets-kiss.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CA Châteauroux Métropole

--- a/.changeset/curvy-dogs-give.md
+++ b/.changeset/curvy-dogs-give.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Pays de Cruseilles

--- a/.changeset/cute-ghosts-rule.md
+++ b/.changeset/cute-ghosts-rule.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression - Ville de Montagnole

--- a/.changeset/cute-rivers-joke.md
+++ b/.changeset/cute-rivers-joke.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Ajout - Ville de Cébazat

--- a/.changeset/eager-horses-care.md
+++ b/.changeset/eager-horses-care.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Grand Orb Communauté de communes

--- a/.changeset/early-chairs-join.md
+++ b/.changeset/early-chairs-join.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Ville de Saint-Alban-Leysse

--- a/.changeset/eight-fans-punch.md
+++ b/.changeset/eight-fans-punch.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CA Mauges Communauté

--- a/.changeset/eighty-singers-appear.md
+++ b/.changeset/eighty-singers-appear.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Anjou Bleu Communauté

--- a/.changeset/fancy-squids-invite.md
+++ b/.changeset/fancy-squids-invite.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Ville de Longuenesse

--- a/.changeset/fast-parts-search.md
+++ b/.changeset/fast-parts-search.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Saint-Etienne Métropole

--- a/.changeset/forty-toys-worry.md
+++ b/.changeset/forty-toys-worry.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Montpellier Méditerranée Métropole - vélo cargo pro

--- a/.changeset/fresh-zoos-cough.md
+++ b/.changeset/fresh-zoos-cough.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC Pays de Forcalquier-Montagne de Lure

--- a/.changeset/full-beds-shake.md
+++ b/.changeset/full-beds-shake.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Grand Chambéry l'Agglomération

--- a/.changeset/full-coins-shout.md
+++ b/.changeset/full-coins-shout.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CU Grand Besançon Métropole

--- a/.changeset/heavy-teeth-own.md
+++ b/.changeset/heavy-teeth-own.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Bassin de Pompey

--- a/.changeset/hot-masks-care.md
+++ b/.changeset/hot-masks-care.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC Fier et Usses

--- a/.changeset/lazy-cups-pull.md
+++ b/.changeset/lazy-cups-pull.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC des Vallons du Lyonnais

--- a/.changeset/lazy-garlics-film.md
+++ b/.changeset/lazy-garlics-film.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Saumur Val de Loire Agglomération

--- a/.changeset/lemon-jokes-like.md
+++ b/.changeset/lemon-jokes-like.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC Plaine Limagne

--- a/.changeset/lemon-meals-beam.md
+++ b/.changeset/lemon-meals-beam.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Communauté de communes Val-de-Saône-Centre

--- a/.changeset/light-bars-marry.md
+++ b/.changeset/light-bars-marry.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Cholet Agglomération

--- a/.changeset/little-forks-invent.md
+++ b/.changeset/little-forks-invent.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Genevois

--- a/.changeset/long-meals-behave.md
+++ b/.changeset/long-meals-behave.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppressio - CC Riviera Française

--- a/.changeset/loose-houses-accept.md
+++ b/.changeset/loose-houses-accept.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC des Monts du Pilat

--- a/.changeset/modern-aliens-feel.md
+++ b/.changeset/modern-aliens-feel.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Agglomération Epinal

--- a/.changeset/neat-buses-pay.md
+++ b/.changeset/neat-buses-pay.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC des Portes Euréliennes d'Ile de France

--- a/.changeset/plain-swans-study.md
+++ b/.changeset/plain-swans-study.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC du Sisteronais-Buëch

--- a/.changeset/quick-oranges-marry.md
+++ b/.changeset/quick-oranges-marry.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Montluçon Communauté

--- a/.changeset/rare-moles-share.md
+++ b/.changeset/rare-moles-share.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Val de Drôme en Biovallée

--- a/.changeset/rotten-dots-unite.md
+++ b/.changeset/rotten-dots-unite.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression - Ville d'Aix-les-Bains

--- a/.changeset/rude-times-rule.md
+++ b/.changeset/rude-times-rule.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Pays des Achards

--- a/.changeset/slimy-wolves-fetch.md
+++ b/.changeset/slimy-wolves-fetch.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Communauté de communes Nièvre et Somme

--- a/.changeset/sour-spoons-yell.md
+++ b/.changeset/sour-spoons-yell.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - CC Du Pays de L'Arbresle

--- a/.changeset/spicy-beans-make.md
+++ b/.changeset/spicy-beans-make.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - Bourges Plus

--- a/.changeset/stupid-socks-cheer.md
+++ b/.changeset/stupid-socks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression - CC Luberon Mont de Vaucluse

--- a/.changeset/vast-wasps-go.md
+++ b/.changeset/vast-wasps-go.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC Lyon-Saint-Exupéry en Dauphiné

--- a/.changeset/weak-clubs-turn.md
+++ b/.changeset/weak-clubs-turn.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC de Puisaye-Forterre

--- a/.changeset/whole-bottles-speak.md
+++ b/.changeset/whole-bottles-speak.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CA Saint-Avold Synergie

--- a/.changeset/whole-chairs-divide.md
+++ b/.changeset/whole-chairs-divide.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Suppression - Montpellier Méditerranée Métropole - vélo adapté

--- a/.changeset/wicked-eggs-like.md
+++ b/.changeset/wicked-eggs-like.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Ajout - Commune de Gap

--- a/.changeset/wide-oranges-march.md
+++ b/.changeset/wide-oranges-march.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": patch
+---
+
+Mise à jour - CC du Massif du Vercors

--- a/.changeset/witty-emus-relate.md
+++ b/.changeset/witty-emus-relate.md
@@ -1,0 +1,5 @@
+---
+"@betagouv/aides-velo": minor
+---
+
+Technique - Amélioration de l'extraction de la collectivité associée à une aide

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ France.
 > l'utilisation de ce paquet. (N'hésitez pas à ouvrir une issue si vous avez
 > des suggestions ou des retours à faire).
 
+L'état de la couverture des aides par région est disponible dans `./couverture/`.
+
 ## Installation
 
 ```sh

--- a/couverture/01_Guadeloupe.md
+++ b/couverture/01_Guadeloupe.md
@@ -1,0 +1,13 @@
+# Couverture des aides en Guadeloupe (01)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Guadeloupe | 01 | ❔ | ❌ | ❌ |
+| Département | Guadeloupe | 971 | ❔ | ❌ | ❌ |
+| CA | CA CAP Excellence | 200018653 | ❔ | ❌ | ❌ |
+| CA | CA La Riviéra du Levant | 200041507 | ❔ | ❌ | ❌ |
+| CA | CA du Nord Grande Terre | 200044691 | ❔ | ❌ | ❌ |
+| CC | CC de Marie-Galante | 249710047 | ❔ | ❌ | ❌ |
+| CA | CA du Nord Basse-Terre | 249710062 | ❔ | ❌ | ❌ |
+| CA | CA Grand Sud Caraïbe | 249710070 | ❔ | ❌ | ❌ |

--- a/couverture/01_Guadeloupe.md
+++ b/couverture/01_Guadeloupe.md
@@ -3,11 +3,11 @@
 
 | Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
 | ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Guadeloupe | 01 | ❔ | ❌ | ❌ |
-| Département | Guadeloupe | 971 | ❔ | ❌ | ❌ |
-| CA | CA CAP Excellence | 200018653 | ❔ | ❌ | ❌ |
-| CA | CA La Riviéra du Levant | 200041507 | ❔ | ❌ | ❌ |
-| CA | CA du Nord Grande Terre | 200044691 | ❔ | ❌ | ❌ |
-| CC | CC de Marie-Galante | 249710047 | ❔ | ❌ | ❌ |
-| CA | CA du Nord Basse-Terre | 249710062 | ❔ | ❌ | ❌ |
-| CA | CA Grand Sud Caraïbe | 249710070 | ❔ | ❌ | ❌ |
+| Région | Guadeloupe | 01 | ❌ | ❌ | ✅ |
+| Département | Guadeloupe | 971 | ❌ | ❌ | ✅ |
+| CA | CA CAP Excellence | 200018653 | ❌ | ❌ | ✅ |
+| CA | CA La Riviéra du Levant | 200041507 | ❌ | ❌ | ✅ |
+| CA | CA du Nord Grande Terre | 200044691 | ❌ | ❌ | ✅ |
+| CC | CC de Marie-Galante | 249710047 | ❌ | ❌ | ✅ |
+| CA | CA du Nord Basse-Terre | 249710062 | ❌ | ❌ | ✅ |
+| CA | CA Grand Sud Caraïbe | 249710070 | ❌ | ❌ | ✅ |

--- a/couverture/02_Martinique.md
+++ b/couverture/02_Martinique.md
@@ -1,0 +1,10 @@
+# Couverture des aides en Martinique (02)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Martinique | 02 | ❔ | ❌ | ❌ |
+| Département | Martinique | 972 | ❔ | ❌ | ❌ |
+| CA | CA du Pays Nord Martinique | 200041788 | ❔ | ❌ | ❌ |
+| CA | CA de l'Espace Sud de la Martinique | 249720053 | ❔ | ❌ | ❌ |
+| CA | CA du Centre de la Martinique | 249720061 | ❔ | ❌ | ❌ |

--- a/couverture/03_Guyane.md
+++ b/couverture/03_Guyane.md
@@ -1,11 +1,12 @@
 # Couverture des aides en Guyane (03)
 
+- 2025 : ✅
 
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Guyane | 03 | ❌ | ❌ | ✅ |
-| Département | Guyane | 973 | ❌ | ❌ | ✅ |
-| CC | CC des Savanes | 200027548 | ❌ | ❌ | ✅ |
-| CC | CC de l'Ouest Guyanais | 249730037 | ❌ | ❌ | ✅ |
-| CA | CA du Centre Littoral | 249730045 | ✅ | ✅ | ✅ |
-| CC | CC de l'Est Guyanais | 249730052 | ❔ | ❌ | ✅ |
+| Echelle     | Nom                    | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ---------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Guyane                 | 03        | ❌               | ❌        | ✅    |
+| Département | Guyane                 | 973       | ❌               | ❌        | ✅    |
+| CC          | CC des Savanes         | 200027548 | ❌               | ❌        | ✅    |
+| CC          | CC de l'Ouest Guyanais | 249730037 | ❌               | ❌        | ✅    |
+| CA          | CA du Centre Littoral  | 249730045 | ✅               | ✅        | ✅    |
+| CC          | CC de l'Est Guyanais   | 249730052 | ❔               | ❌        | ✅    |

--- a/couverture/03_Guyane.md
+++ b/couverture/03_Guyane.md
@@ -3,9 +3,9 @@
 
 | Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
 | ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Guyane | 03 | ❔ | ❌ | ❌ |
-| Département | Guyane | 973 | ❔ | ❌ | ❌ |
-| CC | CC des Savanes | 200027548 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ouest Guyanais | 249730037 | ❔ | ❌ | ❌ |
-| CA | CA du Centre Littoral | 249730045 | ✅ | ✅ | ❌ |
-| CC | CC de l'Est Guyanais | 249730052 | ❔ | ❌ | ❌ |
+| Région | Guyane | 03 | ❌ | ❌ | ✅ |
+| Département | Guyane | 973 | ❌ | ❌ | ✅ |
+| CC | CC des Savanes | 200027548 | ❌ | ❌ | ✅ |
+| CC | CC de l'Ouest Guyanais | 249730037 | ❌ | ❌ | ✅ |
+| CA | CA du Centre Littoral | 249730045 | ✅ | ✅ | ✅ |
+| CC | CC de l'Est Guyanais | 249730052 | ❔ | ❌ | ✅ |

--- a/couverture/03_Guyane.md
+++ b/couverture/03_Guyane.md
@@ -1,0 +1,11 @@
+# Couverture des aides en Guyane (03)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Guyane | 03 | ❔ | ❌ | ❌ |
+| Département | Guyane | 973 | ❔ | ❌ | ❌ |
+| CC | CC des Savanes | 200027548 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ouest Guyanais | 249730037 | ❔ | ❌ | ❌ |
+| CA | CA du Centre Littoral | 249730045 | ✅ | ✅ | ❌ |
+| CC | CC de l'Est Guyanais | 249730052 | ❔ | ❌ | ❌ |

--- a/couverture/04_La_Réunion.md
+++ b/couverture/04_La_Réunion.md
@@ -1,0 +1,12 @@
+# Couverture des aides en La Réunion (04)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | La Réunion | 04 | ❔ | ❌ | ❌ |
+| Département | La Réunion | 974 | ❔ | ❌ | ❌ |
+| CA | CA CIVIS (Communauté Intercommunale des Villes Solidaires) | 249740077 | ❔ | ❌ | ❌ |
+| CA | CA du Sud | 249740085 | ❔ | ❌ | ❌ |
+| CA | CA Intercommunale de la Réunion Est (CIREST) | 249740093 | ❔ | ❌ | ❌ |
+| CA | CA Territoire de la Côte Ouest (TCO) | 249740101 | ✅ | ✅ | ❌ |
+| CA | CA Intercommunale du Nord de la Réunion (CINOR) | 249740119 | ❔ | ❌ | ❌ |

--- a/couverture/06_Mayotte.md
+++ b/couverture/06_Mayotte.md
@@ -1,0 +1,12 @@
+# Couverture des aides en Mayotte (06)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Mayotte | 06 | ❔ | ❌ | ❌ |
+| Département | Mayotte | 976 | ❔ | ❌ | ❌ |
+| CC | CC de Petite-Terre | 200050532 | ❔ | ❌ | ❌ |
+| CC | CC du Centre-Ouest | 200059871 | ❔ | ❌ | ❌ |
+| CA | CA de Dembeni / Mamoudzou | 200060457 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Nord de Mayotte | 200060465 | ❔ | ❌ | ❌ |
+| CC | CC du Sud | 200060473 | ❔ | ❌ | ❌ |

--- a/couverture/11_Île-de-France.md
+++ b/couverture/11_Île-de-France.md
@@ -1,77 +1,76 @@
 # Couverture des aides en Île-de-France (11)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Île-de-France | 11 | ✅ | ✅ | ✅ |
-| Département | Paris | 75 | ❌ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❌ | ❌ | ❌ |
-| Département | Seine-et-Marne | 77 | ❌ | ❌ | ❌ |
-| CC | CC Les Portes Briardes Entre Villes et Forêts | 200023125 | ✅ | ✅ | ❌ |
-| CC | CC Pays de Nemours | 200023240 | ❔ | ❌ | ❌ |
-| CC | CC Gâtinais Val de Loing | 200023919 | ❔ | ❌ | ❌ |
-| CC | CC Plaines et Monts de France | 200033090 | ❔ | ❌ | ❌ |
-| CC | CC du Provinois | 200037133 | ❔ | ❌ | ❌ |
-| CC | CC Bassée-Montois | 200040251 | ❔ | ❌ | ❌ |
-| CA | CA Roissy Pays de France | 200055655 | ❔ | ❌ | ❌ |
-| CA | CA Paris - Vallée de la Marne | 200057958 | ❔ | ❌ | ❌ |
-| CA | CA Grand Paris Sud Seine Essonne Sénart | 200059228 | ❔ | ❌ | ❌ |
-| CC | CC Brie des Rivières et Châteaux | 200070779 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Meaux | 200072130 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Fontainebleau | 200072346 | ❔ | ❌ | ❌ |
-| CC | CC des Deux Morin | 200072544 | ❔ | ❌ | ❌ |
-| CC | CC Val Briard | 200072874 | ❔ | ❌ | ❌ |
-| CA | CA Coulommiers Pays de Brie | 200090504 | ❔ | ❌ | ❌ |
-| CC | CC Moret Seine et Loing | 247700032 | ❔ | ❌ | ❌ |
-| CA | CA Melun Val de Seine | 247700057 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de l'Ourcq | 247700065 | ❔ | ❌ | ❌ |
-| CC | CC Pays de Montereau | 247700107 | ❔ | ❌ | ❌ |
-| CA | CA Val d'Europe Agglomération | 247700339 | ❔ | ❌ | ❌ |
-| CA | CA Marne et Gondoire | 247700594 | ❔ | ❌ | ❌ |
-| CC | CC l'Orée de la Brie | 247700644 | ❔ | ❌ | ❌ |
-| CC | CC Brie Nangissienne | 247700701 | ❔ | ❌ | ❌ |
-| Département | Yvelines | 78 | ❔ | ❌ | ❌ |
-| CC | CC de la Haute Vallée de Chevreuse | 200033173 | ❔ | ❌ | ❌ |
-| CC | CC Gally Mauldre | 200034130 | ❔ | ❌ | ❌ |
-| CA | CA Saint Germain Boucles de Seine | 200058519 | ❔ | ❌ | ❌ |
-| CA | CA de Saint Quentin en Yvelines | 200058782 | ❔ | ❌ | ❌ |
-| CU | CU Grand Paris Seine et Oise | 200059889 | ❔ | ❌ | ❌ |
-| CC | CC Les Portes de l'Ile de France | 200071074 | ❔ | ❌ | ❌ |
-| CA | CA Rambouillet Territoires | 200073344 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Houdanais (CCPH) | 247800550 | ❔ | ❌ | ❌ |
-| CA | CA Versailles Grand Parc (CAVGP) | 247800584 | ❔ | ❌ | ❌ |
-| CC | CC Coeur d'Yvelines | 247800618 | ❔ | ❌ | ❌ |
-| CA | CA de Cergy-Pontoise | 249500109 | ❔ | ❌ | ❌ |
-| Département | Essonne | 91 | ❔ | ❌ | ❌ |
-| CA | CA Étampois Sud Essonne | 200017846 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| CA | CA Communauté Paris-Saclay | 200056232 | ❔ | ❌ | ❌ |
-| CA | CA Coeur d'Essonne Agglomération | 200057859 | ❔ | ❌ | ❌ |
-| CA | CA Val d'Yerres Val de Seine | 200058477 | ✅ | ✅ | ❌ |
-| CA | CA Grand Paris Sud Seine Essonne Sénart | 200059228 | ❔ | ❌ | ❌ |
-| CC | CC l'Orée de la Brie | 247700644 | ❔ | ❌ | ❌ |
-| CA | CA Versailles Grand Parc (CAVGP) | 247800584 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Limours (CCPL) | 249100074 | ❔ | ❌ | ❌ |
-| CC | CC des 2 Vallées | 249100157 | ❔ | ❌ | ❌ |
-| CC | CC du Val d'Essonne (CCVE) | 249100546 | ❔ | ❌ | ❌ |
-| CC | CC Entre Juine et Renarde (CCEJR) | 249100553 | ❔ | ❌ | ❌ |
-| CC | CC le Dourdannais en Hurepoix (CCDH) | 249100595 | ❔ | ❌ | ❌ |
-| Département | Hauts-de-Seine | 92 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| Département | Seine-Saint-Denis | 93 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| Département | Val-de-Marne | 94 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| Département | Val-d'Oise | 95 | ❔ | ❌ | ❌ |
-| CC | CC Vexin Centre | 200035970 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| CA | CA Roissy Pays de France | 200055655 | ❔ | ❌ | ❌ |
-| CA | CA Plaine Vallée | 200056380 | ❔ | ❌ | ❌ |
-| CA | CA Val Parisis | 200058485 | ✅ | ✅ | ❌ |
-| CA | CA Saint Germain Boucles de Seine | 200058519 | ❔ | ❌ | ❌ |
-| CC | CC Carnelle Pays-de-France | 200073013 | ❔ | ❌ | ❌ |
-| CA | CA de Cergy-Pontoise | 249500109 | ❔ | ❌ | ❌ |
-| CC | CC Sausseron Impressionnistes | 249500430 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de l'Oise et des Trois Forêts | 249500455 | ❔ | ❌ | ❌ |
-| CC | CC du Haut Val d'Oise | 249500489 | ❔ | ❌ | ❌ |
-| CC | CC du Vexin-Val de Seine | 249500513 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                           | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | --------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Île-de-France                                 | 11        | ✅               | ✅        | ✅    |
+| Département | Paris                                         | 75        | ❌               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❌               | ❌        | ❌    |
+| Département | Seine-et-Marne                                | 77        | ❌               | ❌        | ❌    |
+| CC          | CC Les Portes Briardes Entre Villes et Forêts | 200023125 | ✅               | ✅        | ❌    |
+| CC          | CC Pays de Nemours                            | 200023240 | ❔               | ❌        | ❌    |
+| CC          | CC Gâtinais Val de Loing                      | 200023919 | ❔               | ❌        | ❌    |
+| CC          | CC Plaines et Monts de France                 | 200033090 | ❔               | ❌        | ❌    |
+| CC          | CC du Provinois                               | 200037133 | ❔               | ❌        | ❌    |
+| CC          | CC Bassée-Montois                             | 200040251 | ❔               | ❌        | ❌    |
+| CA          | CA Roissy Pays de France                      | 200055655 | ❔               | ❌        | ❌    |
+| CA          | CA Paris - Vallée de la Marne                 | 200057958 | ❔               | ❌        | ❌    |
+| CA          | CA Grand Paris Sud Seine Essonne Sénart       | 200059228 | ❔               | ❌        | ❌    |
+| CC          | CC Brie des Rivières et Châteaux              | 200070779 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Meaux                           | 200072130 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Fontainebleau                   | 200072346 | ❔               | ❌        | ❌    |
+| CC          | CC des Deux Morin                             | 200072544 | ❔               | ❌        | ❌    |
+| CC          | CC Val Briard                                 | 200072874 | ❔               | ❌        | ❌    |
+| CA          | CA Coulommiers Pays de Brie                   | 200090504 | ❔               | ❌        | ❌    |
+| CC          | CC Moret Seine et Loing                       | 247700032 | ❔               | ❌        | ❌    |
+| CA          | CA Melun Val de Seine                         | 247700057 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de l'Ourcq                         | 247700065 | ❔               | ❌        | ❌    |
+| CC          | CC Pays de Montereau                          | 247700107 | ❔               | ❌        | ❌    |
+| CA          | CA Val d'Europe Agglomération                 | 247700339 | ❔               | ❌        | ❌    |
+| CA          | CA Marne et Gondoire                          | 247700594 | ❔               | ❌        | ❌    |
+| CC          | CC l'Orée de la Brie                          | 247700644 | ❔               | ❌        | ❌    |
+| CC          | CC Brie Nangissienne                          | 247700701 | ❔               | ❌        | ❌    |
+| Département | Yvelines                                      | 78        | ❔               | ❌        | ❌    |
+| CC          | CC de la Haute Vallée de Chevreuse            | 200033173 | ❔               | ❌        | ❌    |
+| CC          | CC Gally Mauldre                              | 200034130 | ❔               | ❌        | ❌    |
+| CA          | CA Saint Germain Boucles de Seine             | 200058519 | ❔               | ❌        | ❌    |
+| CA          | CA de Saint Quentin en Yvelines               | 200058782 | ❔               | ❌        | ❌    |
+| CU          | CU Grand Paris Seine et Oise                  | 200059889 | ❔               | ❌        | ❌    |
+| CC          | CC Les Portes de l'Ile de France              | 200071074 | ❔               | ❌        | ❌    |
+| CA          | CA Rambouillet Territoires                    | 200073344 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Houdanais (CCPH)                   | 247800550 | ❔               | ❌        | ❌    |
+| CA          | CA Versailles Grand Parc (CAVGP)              | 247800584 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur d'Yvelines                           | 247800618 | ❔               | ❌        | ❌    |
+| CA          | CA de Cergy-Pontoise                          | 249500109 | ❔               | ❌        | ❌    |
+| Département | Essonne                                       | 91        | ❔               | ❌        | ❌    |
+| CA          | CA Étampois Sud Essonne                       | 200017846 | ❔               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❔               | ❌        | ❌    |
+| CA          | CA Communauté Paris-Saclay                    | 200056232 | ❔               | ❌        | ❌    |
+| CA          | CA Coeur d'Essonne Agglomération              | 200057859 | ❔               | ❌        | ❌    |
+| CA          | CA Val d'Yerres Val de Seine                  | 200058477 | ✅               | ✅        | ❌    |
+| CA          | CA Grand Paris Sud Seine Essonne Sénart       | 200059228 | ❔               | ❌        | ❌    |
+| CC          | CC l'Orée de la Brie                          | 247700644 | ❔               | ❌        | ❌    |
+| CA          | CA Versailles Grand Parc (CAVGP)              | 247800584 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Limours (CCPL)                  | 249100074 | ❔               | ❌        | ❌    |
+| CC          | CC des 2 Vallées                              | 249100157 | ❔               | ❌        | ❌    |
+| CC          | CC du Val d'Essonne (CCVE)                    | 249100546 | ❔               | ❌        | ❌    |
+| CC          | CC Entre Juine et Renarde (CCEJR)             | 249100553 | ❔               | ❌        | ❌    |
+| CC          | CC le Dourdannais en Hurepoix (CCDH)          | 249100595 | ❔               | ❌        | ❌    |
+| Département | Hauts-de-Seine                                | 92        | ❔               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❔               | ❌        | ❌    |
+| Département | Seine-Saint-Denis                             | 93        | ❔               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❔               | ❌        | ❌    |
+| Département | Val-de-Marne                                  | 94        | ❔               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❔               | ❌        | ❌    |
+| Département | Val-d'Oise                                    | 95        | ❔               | ❌        | ❌    |
+| CC          | CC Vexin Centre                               | 200035970 | ❔               | ❌        | ❌    |
+| METRO       | Métropole du Grand Paris                      | 200054781 | ❔               | ❌        | ❌    |
+| CA          | CA Roissy Pays de France                      | 200055655 | ❔               | ❌        | ❌    |
+| CA          | CA Plaine Vallée                              | 200056380 | ❔               | ❌        | ❌    |
+| CA          | CA Val Parisis                                | 200058485 | ✅               | ✅        | ❌    |
+| CA          | CA Saint Germain Boucles de Seine             | 200058519 | ❔               | ❌        | ❌    |
+| CC          | CC Carnelle Pays-de-France                    | 200073013 | ❔               | ❌        | ❌    |
+| CA          | CA de Cergy-Pontoise                          | 249500109 | ❔               | ❌        | ❌    |
+| CC          | CC Sausseron Impressionnistes                 | 249500430 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de l'Oise et des Trois Forêts | 249500455 | ❔               | ❌        | ❌    |
+| CC          | CC du Haut Val d'Oise                         | 249500489 | ❔               | ❌        | ❌    |
+| CC          | CC du Vexin-Val de Seine                      | 249500513 | ❔               | ❌        | ❌    |

--- a/couverture/11_Île-de-France.md
+++ b/couverture/11_Île-de-France.md
@@ -1,0 +1,77 @@
+# Couverture des aides en Île-de-France (11)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Île-de-France | 11 | ✅ | ✅ | ❌ |
+| Département | Paris | 75 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| Département | Seine-et-Marne | 77 | ❔ | ❌ | ❌ |
+| CC | CC Les Portes Briardes Entre Villes et Forêts | 200023125 | ✅ | ✅ | ❌ |
+| CC | CC Pays de Nemours | 200023240 | ❔ | ❌ | ❌ |
+| CC | CC Gâtinais Val de Loing | 200023919 | ❔ | ❌ | ❌ |
+| CC | CC Plaines et Monts de France | 200033090 | ❔ | ❌ | ❌ |
+| CC | CC du Provinois | 200037133 | ❔ | ❌ | ❌ |
+| CC | CC Bassée-Montois | 200040251 | ❔ | ❌ | ❌ |
+| CA | CA Roissy Pays de France | 200055655 | ❔ | ❌ | ❌ |
+| CA | CA Paris - Vallée de la Marne | 200057958 | ❔ | ❌ | ❌ |
+| CA | CA Grand Paris Sud Seine Essonne Sénart | 200059228 | ❔ | ❌ | ❌ |
+| CC | CC Brie des Rivières et Châteaux | 200070779 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Meaux | 200072130 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Fontainebleau | 200072346 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Morin | 200072544 | ❔ | ❌ | ❌ |
+| CC | CC Val Briard | 200072874 | ❔ | ❌ | ❌ |
+| CA | CA Coulommiers Pays de Brie | 200090504 | ❔ | ❌ | ❌ |
+| CC | CC Moret Seine et Loing | 247700032 | ❔ | ❌ | ❌ |
+| CA | CA Melun Val de Seine | 247700057 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de l'Ourcq | 247700065 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Montereau | 247700107 | ❔ | ❌ | ❌ |
+| CA | CA Val d'Europe Agglomération | 247700339 | ❔ | ❌ | ❌ |
+| CA | CA Marne et Gondoire | 247700594 | ❔ | ❌ | ❌ |
+| CC | CC l'Orée de la Brie | 247700644 | ❔ | ❌ | ❌ |
+| CC | CC Brie Nangissienne | 247700701 | ❔ | ❌ | ❌ |
+| Département | Yvelines | 78 | ❔ | ❌ | ❌ |
+| CC | CC de la Haute Vallée de Chevreuse | 200033173 | ❔ | ❌ | ❌ |
+| CC | CC Gally Mauldre | 200034130 | ❔ | ❌ | ❌ |
+| CA | CA Saint Germain Boucles de Seine | 200058519 | ❔ | ❌ | ❌ |
+| CA | CA de Saint Quentin en Yvelines | 200058782 | ❔ | ❌ | ❌ |
+| CU | CU Grand Paris Seine et Oise | 200059889 | ❔ | ❌ | ❌ |
+| CC | CC Les Portes de l'Ile de France | 200071074 | ❔ | ❌ | ❌ |
+| CA | CA Rambouillet Territoires | 200073344 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Houdanais (CCPH) | 247800550 | ❔ | ❌ | ❌ |
+| CA | CA Versailles Grand Parc (CAVGP) | 247800584 | ❔ | ❌ | ❌ |
+| CC | CC Coeur d'Yvelines | 247800618 | ❔ | ❌ | ❌ |
+| CA | CA de Cergy-Pontoise | 249500109 | ❔ | ❌ | ❌ |
+| Département | Essonne | 91 | ❔ | ❌ | ❌ |
+| CA | CA Étampois Sud Essonne | 200017846 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| CA | CA Communauté Paris-Saclay | 200056232 | ❔ | ❌ | ❌ |
+| CA | CA Coeur d'Essonne Agglomération | 200057859 | ❔ | ❌ | ❌ |
+| CA | CA Val d'Yerres Val de Seine | 200058477 | ✅ | ✅ | ❌ |
+| CA | CA Grand Paris Sud Seine Essonne Sénart | 200059228 | ❔ | ❌ | ❌ |
+| CC | CC l'Orée de la Brie | 247700644 | ❔ | ❌ | ❌ |
+| CA | CA Versailles Grand Parc (CAVGP) | 247800584 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Limours (CCPL) | 249100074 | ❔ | ❌ | ❌ |
+| CC | CC des 2 Vallées | 249100157 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Essonne (CCVE) | 249100546 | ❔ | ❌ | ❌ |
+| CC | CC Entre Juine et Renarde (CCEJR) | 249100553 | ❔ | ❌ | ❌ |
+| CC | CC le Dourdannais en Hurepoix (CCDH) | 249100595 | ❔ | ❌ | ❌ |
+| Département | Hauts-de-Seine | 92 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| Département | Seine-Saint-Denis | 93 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| Département | Val-de-Marne | 94 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| Département | Val-d'Oise | 95 | ❔ | ❌ | ❌ |
+| CC | CC Vexin Centre | 200035970 | ❔ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
+| CA | CA Roissy Pays de France | 200055655 | ❔ | ❌ | ❌ |
+| CA | CA Plaine Vallée | 200056380 | ❔ | ❌ | ❌ |
+| CA | CA Val Parisis | 200058485 | ✅ | ✅ | ❌ |
+| CA | CA Saint Germain Boucles de Seine | 200058519 | ❔ | ❌ | ❌ |
+| CC | CC Carnelle Pays-de-France | 200073013 | ❔ | ❌ | ❌ |
+| CA | CA de Cergy-Pontoise | 249500109 | ❔ | ❌ | ❌ |
+| CC | CC Sausseron Impressionnistes | 249500430 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de l'Oise et des Trois Forêts | 249500455 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Val d'Oise | 249500489 | ❔ | ❌ | ❌ |
+| CC | CC du Vexin-Val de Seine | 249500513 | ❔ | ❌ | ❌ |

--- a/couverture/11_Île-de-France.md
+++ b/couverture/11_Île-de-France.md
@@ -3,10 +3,10 @@
 
 | Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
 | ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Île-de-France | 11 | ✅ | ✅ | ❌ |
-| Département | Paris | 75 | ❔ | ❌ | ❌ |
-| METRO | Métropole du Grand Paris | 200054781 | ❔ | ❌ | ❌ |
-| Département | Seine-et-Marne | 77 | ❔ | ❌ | ❌ |
+| Région | Île-de-France | 11 | ✅ | ✅ | ✅ |
+| Département | Paris | 75 | ❌ | ❌ | ❌ |
+| METRO | Métropole du Grand Paris | 200054781 | ❌ | ❌ | ❌ |
+| Département | Seine-et-Marne | 77 | ❌ | ❌ | ❌ |
 | CC | CC Les Portes Briardes Entre Villes et Forêts | 200023125 | ✅ | ✅ | ❌ |
 | CC | CC Pays de Nemours | 200023240 | ❔ | ❌ | ❌ |
 | CC | CC Gâtinais Val de Loing | 200023919 | ❔ | ❌ | ❌ |

--- a/couverture/24_Centre-Val_de_Loire.md
+++ b/couverture/24_Centre-Val_de_Loire.md
@@ -3,25 +3,25 @@
 | Echelle     | Nom                                            | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ---------------------------------------------- | --------- | ---------------- | --------- | ----- |
 | Région      | Centre-Val de Loire                            | 24        | ✅               | ✅        | ✅    |
-| Département | Cher                                           | 18        | ❔               | ❌        | ❌    |
-| CC          | CC Sauldre et Sologne                          | 200000933 | ❔               | ❌        | ❌    |
-| CC          | CC Pays de Nérondes                            | 200007177 | ❔               | ❌        | ❌    |
-| CC          | CC Portes du Berry entre Loire et Val d'Aubois | 200011781 | ❔               | ❌        | ❌    |
-| CC          | CC Arnon Boischaut Cher                        | 200027076 | ❔               | ❌        | ❌    |
-| CC          | CC Berry-Loire-Vauvise                         | 200032514 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de France                             | 200036135 | ❔               | ❌        | ❌    |
-| CC          | CC Berry Grand Sud                             | 200049484 | ❔               | ❌        | ❌    |
-| CC          | CC Terres du Haut Berry                        | 200066330 | ❔               | ❌        | ❌    |
-| CC          | CC Les Bertranges                              | 200068088 | ❔               | ❌        | ❌    |
-| CC          | CC Pays Fort Sancerrois Val de Loire           | 200069227 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Berry                              | 200070571 | ❔               | ❌        | ❌    |
-| CC          | CC Vierzon-Sologne-Berry                       | 200090561 | ❔               | ❌        | ❌    |
-| CC          | CC la Septaine                                 | 241800374 | ❔               | ❌        | ❌    |
-| CC          | CC le Dunois                                   | 241800424 | ❔               | ❌        | ❌    |
-| CC          | CC les Trois Provinces                         | 241800432 | ❔               | ❌        | ❌    |
-| CC          | CC FerCher                                     | 241800457 | ❔               | ❌        | ❌    |
-| CA          | CA Bourges Plus                                | 241800507 | ✅               | ✅        | ❌    |
-| CC          | CC du Pays d'Issoudun                          | 243600236 | ❔               | ❌        | ❌    |
+| Département | Cher                                           | 18        | ❌               | ❌        | ✅    |
+| CC          | CC Sauldre et Sologne                          | 200000933 | ❌               | ❌        | ✅    |
+| CC          | CC Pays de Nérondes                            | 200007177 | ❌               | ❌        | ✅    |
+| CC          | CC Portes du Berry entre Loire et Val d'Aubois | 200011781 | ❌               | ❌        | ✅    |
+| CC          | CC Arnon Boischaut Cher                        | 200027076 | ❌               | ❌        | ✅    |
+| CC          | CC Berry-Loire-Vauvise                         | 200032514 | ❌               | ❌        | ✅    |
+| CC          | CC Coeur de France                             | 200036135 | ❌               | ❌        | ✅    |
+| CC          | CC Berry Grand Sud                             | 200049484 | ❌               | ❌        | ✅    |
+| CC          | CC Terres du Haut Berry                        | 200066330 | ❌               | ❌        | ✅    |
+| CC          | CC Les Bertranges                              | 200068088 | ❌               | ❌        | ✅    |
+| CC          | CC Pays Fort Sancerrois Val de Loire           | 200069227 | ❌               | ❌        | ✅    |
+| CC          | CC Coeur de Berry                              | 200070571 | ❌               | ❌        | ✅    |
+| CC          | CC Vierzon-Sologne-Berry                       | 200090561 | ❌               | ❌        | ✅    |
+| CC          | CC la Septaine                                 | 241800374 | ❌               | ❌        | ✅    |
+| CC          | CC le Dunois                                   | 241800424 | ❌               | ❌        | ✅    |
+| CC          | CC les Trois Provinces                         | 241800432 | ❌               | ❌        | ✅    |
+| CC          | CC FerCher                                     | 241800457 | ❌               | ❌        | ✅    |
+| CA          | CA Bourges Plus                                | 241800507 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays d'Issoudun                          | 243600236 | ❌               | ❌        | ✅    |
 | Département | Eure-et-Loir                                   | 28        | ❔               | ❌        | ❌    |
 | CC          | CC du Perche                                   | 200006971 | ❌               | ❌        | ✅    |
 | CA          | CA Chartres Métropole                          | 200033181 | ❔               | ❌        | ❌    |
@@ -36,33 +36,33 @@
 | CC          | CC du Bonnevalais                              | 242852465 | ❌               | ❌        | ✅    |
 | CC          | CC du Pays Houdanais (CCPH)                    | 247800550 | ❔               | ❌        | ❌    |
 | Département | Indre                                          | 36        | ❔               | ❌        | ❌    |
-| CC          | CC de la Marche Berrichonne                    | 200007052 | ❔               | ❌        | ❌    |
-| CC          | CC du Val de Bouzanne                          | 200018521 | ❔               | ❌        | ❌    |
+| CC          | CC de la Marche Berrichonne                    | 200007052 | ❌               | ❌        | ✅    |
+| CC          | CC du Val de Bouzanne                          | 200018521 | ❌               | ❌        | ✅    |
 | CC          | CC Marche Occitane - Val d'Anglin              | 200035137 | ❔               | ❌        | ❌    |
-| CC          | CC du Châtillonnais en Berry                   | 200035848 | ❔               | ❌        | ❌    |
-| CC          | CC Écueillé-Valençay                           | 200040558 | ❔               | ❌        | ❌    |
-| CC          | CC Éguzon - Argenton - Vallée de la Creuse     | 200068872 | ❔               | ❌        | ❌    |
-| CC          | CC Champagne Boischauts                        | 200068880 | ❔               | ❌        | ❌    |
-| CC          | CC Chabris - Pays de Bazelle                   | 243600202 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays d'Issoudun                          | 243600236 | ❔               | ❌        | ❌    |
-| CC          | CC Levroux Boischaut Champagne                 | 243600293 | ❔               | ❌        | ❌    |
-| CC          | CC Val de l'Indre - Brenne                     | 243600301 | ❔               | ❌        | ❌    |
-| CC          | CC Brenne - Val de Creuse                      | 243600319 | ❔               | ❌        | ❌    |
+| CC          | CC du Châtillonnais en Berry                   | 200035848 | ❌               | ❌        | ✅    |
+| CC          | CC Écueillé-Valençay                           | 200040558 | ❌               | ❌        | ✅    |
+| CC          | CC Éguzon - Argenton - Vallée de la Creuse     | 200068872 | ❌               | ❌        | ✅    |
+| CC          | CC Champagne Boischauts                        | 200068880 | ❌               | ❌        | ✅    |
+| CC          | CC Chabris - Pays de Bazelle                   | 243600202 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays d'Issoudun                          | 243600236 | ❌               | ❌        | ✅    |
+| CC          | CC Levroux Boischaut Champagne                 | 243600293 | ❌               | ❌        | ✅    |
+| CC          | CC Val de l'Indre - Brenne                     | 243600301 | ❌               | ❌        | ✅    |
+| CC          | CC Brenne - Val de Creuse                      | 243600319 | ❌               | ❌        | ✅    |
 | CA          | CA Châteauroux Métropole                       | 243600327 | ✅               | ✅        | ❌    |
-| CC          | CC Coeur de Brenne                             | 243600343 | ❔               | ❌        | ❌    |
-| CC          | CC de la Châtre et Sainte-Sévère               | 243600350 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Brenne                             | 243600343 | ❌               | ❌        | ✅    |
+| CC          | CC de la Châtre et Sainte-Sévère               | 243600350 | ❌               | ❌        | ✅    |
 | Département | Indre-et-Loire                                 | 37        | ❔               | ❌        | ❌    |
-| CC          | CC du Val d'Amboise                            | 200043065 | ❔               | ❌        | ❌    |
+| CC          | CC du Val d'Amboise                            | 200043065 | ❌               | ❌        | ✅    |
 | CC          | CC Chinon, Vienne et Loire                     | 200043081 | ❔               | ❌        | ❌    |
-| CC          | CC Loches Sud Touraine                         | 200071587 | ❔               | ❌        | ❌    |
-| CC          | CC Touraine Vallée de l'Indre                  | 200072650 | ❔               | ❌        | ❌    |
-| CC          | CC Touraine Val de Vienne                      | 200072668 | ❔               | ❌        | ❌    |
-| CC          | CC Touraine Ouest Val de Loire                 | 200072981 | ❔               | ❌        | ❌    |
-| CC          | CC Touraine-Est Vallées                        | 200073161 | ❔               | ❌        | ❌    |
-| CC          | CC de Gâtine-Racan                             | 200073237 | ❔               | ❌        | ❌    |
-| CC          | CC du Castelrenaudais                          | 243700499 | ❔               | ❌        | ❌    |
+| CC          | CC Loches Sud Touraine                         | 200071587 | ❌               | ❌        | ✅    |
+| CC          | CC Touraine Vallée de l'Indre                  | 200072650 | ❌               | ❌        | ✅    |
+| CC          | CC Touraine Val de Vienne                      | 200072668 | ❌               | ❌        | ✅    |
+| CC          | CC Touraine Ouest Val de Loire                 | 200072981 | ❌               | ❌        | ✅    |
+| CC          | CC Touraine-Est Vallées                        | 200073161 | ❌               | ❌        | ✅    |
+| CC          | CC de Gâtine-Racan                             | 200073237 | ❌               | ❌        | ✅    |
+| CC          | CC du Castelrenaudais                          | 243700499 | ❌               | ❌        | ✅    |
 | METRO       | Tours Métropole Val de Loire                   | 243700754 | ❔               | ❌        | ❌    |
-| CC          | CC Autour de Chenonceaux Bléré-Val de Cher     | 243700820 | ❔               | ❌        | ❌    |
+| CC          | CC Autour de Chenonceaux Bléré-Val de Cher     | 243700820 | ❌               | ❌        | ✅    |
 | Département | Loir-et-Cher                                   | 41        | ❔               | ❌        | ❌    |
 | CC          | CC Coeur de Sologne                            | 200000800 | ❌               | ❌        | ✅    |
 | CC          | CC du Romorantinais et du Monestois            | 200018406 | ❔               | ❌        | ❌    |
@@ -79,17 +79,17 @@
 | Département | Loiret                                         | 45        | ❔               | ❌        | ❌    |
 | CC          | CC des Portes de Sologne                       | 200005932 | ✅               | ✅        | ❌    |
 | CC          | CC de la Beauce Loirétaine                     | 200035764 | ❔               | ❌        | ❌    |
-| CC          | CC du Pithiverais                              | 200066280 | ❔               | ❌        | ❌    |
-| CC          | CC de la Cléry, du Betz et de l'Ouanne         | 200067668 | ❔               | ❌        | ❌    |
+| CC          | CC du Pithiverais                              | 200066280 | ❌               | ❌        | ✅    |
+| CC          | CC de la Cléry, du Betz et de l'Ouanne         | 200067668 | ❌               | ❌        | ✅    |
 | CC          | CC Canaux et Forêts en Gâtinais                | 200067676 | ❔               | ❌        | ❌    |
-| CC          | CC Berry Loire Puisaye                         | 200068278 | ❔               | ❌        | ❌    |
-| CC          | CC du Val de Sully                             | 200070100 | ❔               | ❌        | ❌    |
+| CC          | CC Berry Loire Puisaye                         | 200068278 | ❌               | ❌        | ✅    |
+| CC          | CC du Val de Sully                             | 200070100 | ❌               | ❌        | ✅    |
 | CC          | CC des Terres du Val de Loire                  | 200070183 | ❔               | ❌        | ❌    |
-| CC          | CC du Pithiverais-Gâtinais                     | 200071850 | ❔               | ❌        | ❌    |
+| CC          | CC du Pithiverais-Gâtinais                     | 200071850 | ❌               | ❌        | ✅    |
 | CA          | CA Montargoise et Rives du Loing (AME)         | 244500203 | ❔               | ❌        | ❌    |
 | CC          | CC Giennoises                                  | 244500211 | ❔               | ❌        | ❌    |
 | CC          | CC des Quatre Vallées                          | 244500419 | ❔               | ❌        | ❌    |
-| CC          | CC des Loges                                   | 244500427 | ❔               | ❌        | ❌    |
+| CC          | CC des Loges                                   | 244500427 | ❌               | ❌        | ✅    |
 | METRO       | Orléans Métropole                              | 244500468 | ❔               | ❌        | ❌    |
 | CC          | CC de la Forêt                                 | 244500484 | ❌               | ❌        | ✅    |
-| CC          | CC de la Plaine du Nord Loiret                 | 244500542 | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine du Nord Loiret                 | 244500542 | ❌               | ❌        | ✅    |

--- a/couverture/24_Centre-Val_de_Loire.md
+++ b/couverture/24_Centre-Val_de_Loire.md
@@ -1,96 +1,95 @@
 # Couverture des aides en Centre-Val de Loire (24)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Centre-Val de Loire | 24 | ✅ | ✅ | ❌ |
-| Département | Cher | 18 | ❔ | ❌ | ❌ |
-| CC | CC Sauldre et Sologne | 200000933 | ❔ | ❌ | ❌ |
-| CC | CC Pays de Nérondes | 200007177 | ❔ | ❌ | ❌ |
-| CC | CC Portes du Berry entre Loire et Val d'Aubois | 200011781 | ❔ | ❌ | ❌ |
-| CC | CC Arnon Boischaut Cher | 200027076 | ❔ | ❌ | ❌ |
-| CC | CC Berry-Loire-Vauvise | 200032514 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de France | 200036135 | ❔ | ❌ | ❌ |
-| CC | CC Berry Grand Sud | 200049484 | ❔ | ❌ | ❌ |
-| CC | CC Terres du Haut Berry | 200066330 | ❔ | ❌ | ❌ |
-| CC | CC Les Bertranges | 200068088 | ❔ | ❌ | ❌ |
-| CC | CC Pays Fort Sancerrois Val de Loire | 200069227 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Berry | 200070571 | ❔ | ❌ | ❌ |
-| CC | CC Vierzon-Sologne-Berry | 200090561 | ❔ | ❌ | ❌ |
-| CC | CC la Septaine | 241800374 | ❔ | ❌ | ❌ |
-| CC | CC le Dunois | 241800424 | ❔ | ❌ | ❌ |
-| CC | CC les Trois Provinces | 241800432 | ❔ | ❌ | ❌ |
-| CC | CC FerCher | 241800457 | ❔ | ❌ | ❌ |
-| CA | CA Bourges Plus | 241800507 | ✅ | ✅ | ❌ |
-| CC | CC du Pays d'Issoudun | 243600236 | ❔ | ❌ | ❌ |
-| Département | Eure-et-Loir | 28 | ❔ | ❌ | ❌ |
-| CC | CC du Perche | 200006971 | ❔ | ❌ | ❌ |
-| CA | CA Chartres Métropole | 200033181 | ❔ | ❌ | ❌ |
-| CA | CA Agglo du Pays de Dreux | 200040277 | ❔ | ❌ | ❌ |
-| CC | CC Entre Beauce et Perche | 200058360 | ❔ | ❌ | ❌ |
-| CC | CC Interco Normandie Sud Eure | 200066462 | ❔ | ❌ | ❌ |
-| CC | CC des Forêts du Perche | 200069912 | ❔ | ❌ | ❌ |
-| CC | CC des Portes Euréliennes d'Ile de France | 200069953 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Châteaudun | 200069961 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Beauce | 200070159 | ❔ | ❌ | ❌ |
-| CC | CC Terres de Perche | 200070167 | ❔ | ❌ | ❌ |
-| CC | CC du Bonnevalais | 242852465 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Houdanais (CCPH) | 247800550 | ❔ | ❌ | ❌ |
-| Département | Indre | 36 | ❔ | ❌ | ❌ |
-| CC | CC de la Marche Berrichonne | 200007052 | ❔ | ❌ | ❌ |
-| CC | CC du Val de Bouzanne | 200018521 | ❔ | ❌ | ❌ |
-| CC | CC Marche Occitane - Val d'Anglin | 200035137 | ❔ | ❌ | ❌ |
-| CC | CC du Châtillonnais en Berry | 200035848 | ❔ | ❌ | ❌ |
-| CC | CC Écueillé-Valençay | 200040558 | ❔ | ❌ | ❌ |
-| CC | CC Éguzon - Argenton - Vallée de la Creuse | 200068872 | ❔ | ❌ | ❌ |
-| CC | CC Champagne Boischauts | 200068880 | ❔ | ❌ | ❌ |
-| CC | CC Chabris - Pays de Bazelle | 243600202 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Issoudun | 243600236 | ❔ | ❌ | ❌ |
-| CC | CC Levroux Boischaut Champagne | 243600293 | ❔ | ❌ | ❌ |
-| CC | CC Val de l'Indre - Brenne | 243600301 | ❔ | ❌ | ❌ |
-| CC | CC Brenne - Val de Creuse | 243600319 | ❔ | ❌ | ❌ |
-| CA | CA Châteauroux Métropole | 243600327 | ✅ | ✅ | ❌ |
-| CC | CC Coeur de Brenne | 243600343 | ❔ | ❌ | ❌ |
-| CC | CC de la Châtre et Sainte-Sévère | 243600350 | ❔ | ❌ | ❌ |
-| Département | Indre-et-Loire | 37 | ❔ | ❌ | ❌ |
-| CC | CC du Val d'Amboise | 200043065 | ❔ | ❌ | ❌ |
-| CC | CC Chinon, Vienne et Loire | 200043081 | ❔ | ❌ | ❌ |
-| CC | CC Loches Sud Touraine | 200071587 | ❔ | ❌ | ❌ |
-| CC | CC Touraine Vallée de l'Indre | 200072650 | ❔ | ❌ | ❌ |
-| CC | CC Touraine Val de Vienne | 200072668 | ❔ | ❌ | ❌ |
-| CC | CC Touraine Ouest Val de Loire | 200072981 | ❔ | ❌ | ❌ |
-| CC | CC Touraine-Est Vallées | 200073161 | ❔ | ❌ | ❌ |
-| CC | CC de Gâtine-Racan | 200073237 | ❔ | ❌ | ❌ |
-| CC | CC du Castelrenaudais | 243700499 | ❔ | ❌ | ❌ |
-| METRO | Tours Métropole Val de Loire | 243700754 | ❔ | ❌ | ❌ |
-| CC | CC Autour de Chenonceaux Bléré-Val de Cher | 243700820 | ❔ | ❌ | ❌ |
-| Département | Loir-et-Cher | 41 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Sologne | 200000800 | ❔ | ❌ | ❌ |
-| CC | CC du Romorantinais et du Monestois | 200018406 | ❔ | ❌ | ❌ |
-| CA | CA de Blois ''Agglopolys'' | 200030385 | ✅ | ✅ | ❌ |
-| CC | CC du Perche et Haut Vendômois | 200040772 | ❔ | ❌ | ❌ |
-| CC | CC Beauce Val de Loire | 200055481 | ❔ | ❌ | ❌ |
-| CC | CC des Terres du Val de Loire | 200070183 | ❔ | ❌ | ❌ |
-| CC | CC Val-de-Cher-Controis | 200072064 | ❔ | ❌ | ❌ |
-| CA | CA Territoires Vendômois | 200072072 | ❔ | ❌ | ❌ |
-| CC | CC des Collines du Perche | 244100293 | ❔ | ❌ | ❌ |
-| CC | CC de la Sologne des Etangs | 244100780 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Chambord | 244100798 | ❔ | ❌ | ❌ |
-| CC | CC de la Sologne des Rivières | 244100806 | ❔ | ❌ | ❌ |
-| Département | Loiret | 45 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de Sologne | 200005932 | ✅ | ✅ | ❌ |
-| CC | CC de la Beauce Loirétaine | 200035764 | ❔ | ❌ | ❌ |
-| CC | CC du Pithiverais | 200066280 | ❔ | ❌ | ❌ |
-| CC | CC de la Cléry, du Betz et de l'Ouanne | 200067668 | ❔ | ❌ | ❌ |
-| CC | CC Canaux et Forêts en Gâtinais | 200067676 | ❔ | ❌ | ❌ |
-| CC | CC Berry Loire Puisaye | 200068278 | ❔ | ❌ | ❌ |
-| CC | CC du Val de Sully | 200070100 | ❔ | ❌ | ❌ |
-| CC | CC des Terres du Val de Loire | 200070183 | ❔ | ❌ | ❌ |
-| CC | CC du Pithiverais-Gâtinais | 200071850 | ❔ | ❌ | ❌ |
-| CA | CA Montargoise et Rives du Loing (AME) | 244500203 | ❔ | ❌ | ❌ |
-| CC | CC Giennoises | 244500211 | ❔ | ❌ | ❌ |
-| CC | CC des Quatre Vallées | 244500419 | ❔ | ❌ | ❌ |
-| CC | CC des Loges | 244500427 | ❔ | ❌ | ❌ |
-| METRO | Orléans Métropole | 244500468 | ❔ | ❌ | ❌ |
-| CC | CC de la Forêt | 244500484 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine du Nord Loiret | 244500542 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                            | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ---------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Centre-Val de Loire                            | 24        | ✅               | ✅        | ✅    |
+| Département | Cher                                           | 18        | ❔               | ❌        | ❌    |
+| CC          | CC Sauldre et Sologne                          | 200000933 | ❔               | ❌        | ❌    |
+| CC          | CC Pays de Nérondes                            | 200007177 | ❔               | ❌        | ❌    |
+| CC          | CC Portes du Berry entre Loire et Val d'Aubois | 200011781 | ❔               | ❌        | ❌    |
+| CC          | CC Arnon Boischaut Cher                        | 200027076 | ❔               | ❌        | ❌    |
+| CC          | CC Berry-Loire-Vauvise                         | 200032514 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de France                             | 200036135 | ❔               | ❌        | ❌    |
+| CC          | CC Berry Grand Sud                             | 200049484 | ❔               | ❌        | ❌    |
+| CC          | CC Terres du Haut Berry                        | 200066330 | ❔               | ❌        | ❌    |
+| CC          | CC Les Bertranges                              | 200068088 | ❔               | ❌        | ❌    |
+| CC          | CC Pays Fort Sancerrois Val de Loire           | 200069227 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Berry                              | 200070571 | ❔               | ❌        | ❌    |
+| CC          | CC Vierzon-Sologne-Berry                       | 200090561 | ❔               | ❌        | ❌    |
+| CC          | CC la Septaine                                 | 241800374 | ❔               | ❌        | ❌    |
+| CC          | CC le Dunois                                   | 241800424 | ❔               | ❌        | ❌    |
+| CC          | CC les Trois Provinces                         | 241800432 | ❔               | ❌        | ❌    |
+| CC          | CC FerCher                                     | 241800457 | ❔               | ❌        | ❌    |
+| CA          | CA Bourges Plus                                | 241800507 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays d'Issoudun                          | 243600236 | ❔               | ❌        | ❌    |
+| Département | Eure-et-Loir                                   | 28        | ❔               | ❌        | ❌    |
+| CC          | CC du Perche                                   | 200006971 | ❌               | ❌        | ✅    |
+| CA          | CA Chartres Métropole                          | 200033181 | ❔               | ❌        | ❌    |
+| CA          | CA Agglo du Pays de Dreux                      | 200040277 | ❔               | ❌        | ❌    |
+| CC          | CC Entre Beauce et Perche                      | 200058360 | ❔               | ❌        | ❌    |
+| CC          | CC Interco Normandie Sud Eure                  | 200066462 | ❔               | ❌        | ❌    |
+| CC          | CC des Forêts du Perche                        | 200069912 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes Euréliennes d'Ile de France      | 200069953 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Châteaudun                         | 200069961 | ❌               | ❌        | ✅    |
+| CC          | CC Coeur de Beauce                             | 200070159 | ❌               | ❌        | ✅    |
+| CC          | CC Terres de Perche                            | 200070167 | ❔               | ❌        | ❌    |
+| CC          | CC du Bonnevalais                              | 242852465 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays Houdanais (CCPH)                    | 247800550 | ❔               | ❌        | ❌    |
+| Département | Indre                                          | 36        | ❔               | ❌        | ❌    |
+| CC          | CC de la Marche Berrichonne                    | 200007052 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Bouzanne                          | 200018521 | ❔               | ❌        | ❌    |
+| CC          | CC Marche Occitane - Val d'Anglin              | 200035137 | ❔               | ❌        | ❌    |
+| CC          | CC du Châtillonnais en Berry                   | 200035848 | ❔               | ❌        | ❌    |
+| CC          | CC Écueillé-Valençay                           | 200040558 | ❔               | ❌        | ❌    |
+| CC          | CC Éguzon - Argenton - Vallée de la Creuse     | 200068872 | ❔               | ❌        | ❌    |
+| CC          | CC Champagne Boischauts                        | 200068880 | ❔               | ❌        | ❌    |
+| CC          | CC Chabris - Pays de Bazelle                   | 243600202 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Issoudun                          | 243600236 | ❔               | ❌        | ❌    |
+| CC          | CC Levroux Boischaut Champagne                 | 243600293 | ❔               | ❌        | ❌    |
+| CC          | CC Val de l'Indre - Brenne                     | 243600301 | ❔               | ❌        | ❌    |
+| CC          | CC Brenne - Val de Creuse                      | 243600319 | ❔               | ❌        | ❌    |
+| CA          | CA Châteauroux Métropole                       | 243600327 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur de Brenne                             | 243600343 | ❔               | ❌        | ❌    |
+| CC          | CC de la Châtre et Sainte-Sévère               | 243600350 | ❔               | ❌        | ❌    |
+| Département | Indre-et-Loire                                 | 37        | ❔               | ❌        | ❌    |
+| CC          | CC du Val d'Amboise                            | 200043065 | ❔               | ❌        | ❌    |
+| CC          | CC Chinon, Vienne et Loire                     | 200043081 | ❔               | ❌        | ❌    |
+| CC          | CC Loches Sud Touraine                         | 200071587 | ❔               | ❌        | ❌    |
+| CC          | CC Touraine Vallée de l'Indre                  | 200072650 | ❔               | ❌        | ❌    |
+| CC          | CC Touraine Val de Vienne                      | 200072668 | ❔               | ❌        | ❌    |
+| CC          | CC Touraine Ouest Val de Loire                 | 200072981 | ❔               | ❌        | ❌    |
+| CC          | CC Touraine-Est Vallées                        | 200073161 | ❔               | ❌        | ❌    |
+| CC          | CC de Gâtine-Racan                             | 200073237 | ❔               | ❌        | ❌    |
+| CC          | CC du Castelrenaudais                          | 243700499 | ❔               | ❌        | ❌    |
+| METRO       | Tours Métropole Val de Loire                   | 243700754 | ❔               | ❌        | ❌    |
+| CC          | CC Autour de Chenonceaux Bléré-Val de Cher     | 243700820 | ❔               | ❌        | ❌    |
+| Département | Loir-et-Cher                                   | 41        | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Sologne                            | 200000800 | ❌               | ❌        | ✅    |
+| CC          | CC du Romorantinais et du Monestois            | 200018406 | ❔               | ❌        | ❌    |
+| CA          | CA de Blois ''Agglopolys''                     | 200030385 | ✅               | ✅        | ❌    |
+| CC          | CC du Perche et Haut Vendômois                 | 200040772 | ❌               | ❌        | ✅    |
+| CC          | CC Beauce Val de Loire                         | 200055481 | ❌               | ❌        | ✅    |
+| CC          | CC des Terres du Val de Loire                  | 200070183 | ❔               | ❌        | ❌    |
+| CC          | CC Val-de-Cher-Controis                        | 200072064 | ❌               | ❌        | ✅    |
+| CA          | CA Territoires Vendômois                       | 200072072 | ❔               | ❌        | ❌    |
+| CC          | CC des Collines du Perche                      | 244100293 | ❌               | ❌        | ✅    |
+| CC          | CC de la Sologne des Etangs                    | 244100780 | ❌               | ❌        | ✅    |
+| CC          | CC du Grand Chambord                           | 244100798 | ❌               | ❌        | ✅    |
+| CC          | CC de la Sologne des Rivières                  | 244100806 | ❌               | ❌        | ✅    |
+| Département | Loiret                                         | 45        | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de Sologne                       | 200005932 | ✅               | ✅        | ❌    |
+| CC          | CC de la Beauce Loirétaine                     | 200035764 | ❔               | ❌        | ❌    |
+| CC          | CC du Pithiverais                              | 200066280 | ❔               | ❌        | ❌    |
+| CC          | CC de la Cléry, du Betz et de l'Ouanne         | 200067668 | ❔               | ❌        | ❌    |
+| CC          | CC Canaux et Forêts en Gâtinais                | 200067676 | ❔               | ❌        | ❌    |
+| CC          | CC Berry Loire Puisaye                         | 200068278 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Sully                             | 200070100 | ❔               | ❌        | ❌    |
+| CC          | CC des Terres du Val de Loire                  | 200070183 | ❔               | ❌        | ❌    |
+| CC          | CC du Pithiverais-Gâtinais                     | 200071850 | ❔               | ❌        | ❌    |
+| CA          | CA Montargoise et Rives du Loing (AME)         | 244500203 | ❔               | ❌        | ❌    |
+| CC          | CC Giennoises                                  | 244500211 | ❔               | ❌        | ❌    |
+| CC          | CC des Quatre Vallées                          | 244500419 | ❔               | ❌        | ❌    |
+| CC          | CC des Loges                                   | 244500427 | ❔               | ❌        | ❌    |
+| METRO       | Orléans Métropole                              | 244500468 | ❔               | ❌        | ❌    |
+| CC          | CC de la Forêt                                 | 244500484 | ❌               | ❌        | ✅    |
+| CC          | CC de la Plaine du Nord Loiret                 | 244500542 | ❔               | ❌        | ❌    |

--- a/couverture/24_Centre-Val_de_Loire.md
+++ b/couverture/24_Centre-Val_de_Loire.md
@@ -1,0 +1,96 @@
+# Couverture des aides en Centre-Val de Loire (24)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Centre-Val de Loire | 24 | ✅ | ✅ | ❌ |
+| Département | Cher | 18 | ❔ | ❌ | ❌ |
+| CC | CC Sauldre et Sologne | 200000933 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Nérondes | 200007177 | ❔ | ❌ | ❌ |
+| CC | CC Portes du Berry entre Loire et Val d'Aubois | 200011781 | ❔ | ❌ | ❌ |
+| CC | CC Arnon Boischaut Cher | 200027076 | ❔ | ❌ | ❌ |
+| CC | CC Berry-Loire-Vauvise | 200032514 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de France | 200036135 | ❔ | ❌ | ❌ |
+| CC | CC Berry Grand Sud | 200049484 | ❔ | ❌ | ❌ |
+| CC | CC Terres du Haut Berry | 200066330 | ❔ | ❌ | ❌ |
+| CC | CC Les Bertranges | 200068088 | ❔ | ❌ | ❌ |
+| CC | CC Pays Fort Sancerrois Val de Loire | 200069227 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Berry | 200070571 | ❔ | ❌ | ❌ |
+| CC | CC Vierzon-Sologne-Berry | 200090561 | ❔ | ❌ | ❌ |
+| CC | CC la Septaine | 241800374 | ❔ | ❌ | ❌ |
+| CC | CC le Dunois | 241800424 | ❔ | ❌ | ❌ |
+| CC | CC les Trois Provinces | 241800432 | ❔ | ❌ | ❌ |
+| CC | CC FerCher | 241800457 | ❔ | ❌ | ❌ |
+| CA | CA Bourges Plus | 241800507 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Issoudun | 243600236 | ❔ | ❌ | ❌ |
+| Département | Eure-et-Loir | 28 | ❔ | ❌ | ❌ |
+| CC | CC du Perche | 200006971 | ❔ | ❌ | ❌ |
+| CA | CA Chartres Métropole | 200033181 | ❔ | ❌ | ❌ |
+| CA | CA Agglo du Pays de Dreux | 200040277 | ❔ | ❌ | ❌ |
+| CC | CC Entre Beauce et Perche | 200058360 | ❔ | ❌ | ❌ |
+| CC | CC Interco Normandie Sud Eure | 200066462 | ❔ | ❌ | ❌ |
+| CC | CC des Forêts du Perche | 200069912 | ❔ | ❌ | ❌ |
+| CC | CC des Portes Euréliennes d'Ile de France | 200069953 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Châteaudun | 200069961 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Beauce | 200070159 | ❔ | ❌ | ❌ |
+| CC | CC Terres de Perche | 200070167 | ❔ | ❌ | ❌ |
+| CC | CC du Bonnevalais | 242852465 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Houdanais (CCPH) | 247800550 | ❔ | ❌ | ❌ |
+| Département | Indre | 36 | ❔ | ❌ | ❌ |
+| CC | CC de la Marche Berrichonne | 200007052 | ❔ | ❌ | ❌ |
+| CC | CC du Val de Bouzanne | 200018521 | ❔ | ❌ | ❌ |
+| CC | CC Marche Occitane - Val d'Anglin | 200035137 | ❔ | ❌ | ❌ |
+| CC | CC du Châtillonnais en Berry | 200035848 | ❔ | ❌ | ❌ |
+| CC | CC Écueillé-Valençay | 200040558 | ❔ | ❌ | ❌ |
+| CC | CC Éguzon - Argenton - Vallée de la Creuse | 200068872 | ❔ | ❌ | ❌ |
+| CC | CC Champagne Boischauts | 200068880 | ❔ | ❌ | ❌ |
+| CC | CC Chabris - Pays de Bazelle | 243600202 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Issoudun | 243600236 | ❔ | ❌ | ❌ |
+| CC | CC Levroux Boischaut Champagne | 243600293 | ❔ | ❌ | ❌ |
+| CC | CC Val de l'Indre - Brenne | 243600301 | ❔ | ❌ | ❌ |
+| CC | CC Brenne - Val de Creuse | 243600319 | ❔ | ❌ | ❌ |
+| CA | CA Châteauroux Métropole | 243600327 | ✅ | ✅ | ❌ |
+| CC | CC Coeur de Brenne | 243600343 | ❔ | ❌ | ❌ |
+| CC | CC de la Châtre et Sainte-Sévère | 243600350 | ❔ | ❌ | ❌ |
+| Département | Indre-et-Loire | 37 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Amboise | 200043065 | ❔ | ❌ | ❌ |
+| CC | CC Chinon, Vienne et Loire | 200043081 | ❔ | ❌ | ❌ |
+| CC | CC Loches Sud Touraine | 200071587 | ❔ | ❌ | ❌ |
+| CC | CC Touraine Vallée de l'Indre | 200072650 | ❔ | ❌ | ❌ |
+| CC | CC Touraine Val de Vienne | 200072668 | ❔ | ❌ | ❌ |
+| CC | CC Touraine Ouest Val de Loire | 200072981 | ❔ | ❌ | ❌ |
+| CC | CC Touraine-Est Vallées | 200073161 | ❔ | ❌ | ❌ |
+| CC | CC de Gâtine-Racan | 200073237 | ❔ | ❌ | ❌ |
+| CC | CC du Castelrenaudais | 243700499 | ❔ | ❌ | ❌ |
+| METRO | Tours Métropole Val de Loire | 243700754 | ❔ | ❌ | ❌ |
+| CC | CC Autour de Chenonceaux Bléré-Val de Cher | 243700820 | ❔ | ❌ | ❌ |
+| Département | Loir-et-Cher | 41 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Sologne | 200000800 | ❔ | ❌ | ❌ |
+| CC | CC du Romorantinais et du Monestois | 200018406 | ❔ | ❌ | ❌ |
+| CA | CA de Blois ''Agglopolys'' | 200030385 | ✅ | ✅ | ❌ |
+| CC | CC du Perche et Haut Vendômois | 200040772 | ❔ | ❌ | ❌ |
+| CC | CC Beauce Val de Loire | 200055481 | ❔ | ❌ | ❌ |
+| CC | CC des Terres du Val de Loire | 200070183 | ❔ | ❌ | ❌ |
+| CC | CC Val-de-Cher-Controis | 200072064 | ❔ | ❌ | ❌ |
+| CA | CA Territoires Vendômois | 200072072 | ❔ | ❌ | ❌ |
+| CC | CC des Collines du Perche | 244100293 | ❔ | ❌ | ❌ |
+| CC | CC de la Sologne des Etangs | 244100780 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Chambord | 244100798 | ❔ | ❌ | ❌ |
+| CC | CC de la Sologne des Rivières | 244100806 | ❔ | ❌ | ❌ |
+| Département | Loiret | 45 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de Sologne | 200005932 | ✅ | ✅ | ❌ |
+| CC | CC de la Beauce Loirétaine | 200035764 | ❔ | ❌ | ❌ |
+| CC | CC du Pithiverais | 200066280 | ❔ | ❌ | ❌ |
+| CC | CC de la Cléry, du Betz et de l'Ouanne | 200067668 | ❔ | ❌ | ❌ |
+| CC | CC Canaux et Forêts en Gâtinais | 200067676 | ❔ | ❌ | ❌ |
+| CC | CC Berry Loire Puisaye | 200068278 | ❔ | ❌ | ❌ |
+| CC | CC du Val de Sully | 200070100 | ❔ | ❌ | ❌ |
+| CC | CC des Terres du Val de Loire | 200070183 | ❔ | ❌ | ❌ |
+| CC | CC du Pithiverais-Gâtinais | 200071850 | ❔ | ❌ | ❌ |
+| CA | CA Montargoise et Rives du Loing (AME) | 244500203 | ❔ | ❌ | ❌ |
+| CC | CC Giennoises | 244500211 | ❔ | ❌ | ❌ |
+| CC | CC des Quatre Vallées | 244500419 | ❔ | ❌ | ❌ |
+| CC | CC des Loges | 244500427 | ❔ | ❌ | ❌ |
+| METRO | Orléans Métropole | 244500468 | ❔ | ❌ | ❌ |
+| CC | CC de la Forêt | 244500484 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine du Nord Loiret | 244500542 | ❔ | ❌ | ❌ |

--- a/couverture/24_Centre-Val_de_Loire.md
+++ b/couverture/24_Centre-Val_de_Loire.md
@@ -1,5 +1,7 @@
 # Couverture des aides en Centre-Val de Loire (24)
 
+- 2025 : ✅
+
 | Echelle     | Nom                                            | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ---------------------------------------------- | --------- | ---------------- | --------- | ----- |
 | Région      | Centre-Val de Loire                            | 24        | ✅               | ✅        | ✅    |
@@ -32,13 +34,13 @@
 | CC          | CC des Portes Euréliennes d'Ile de France      | 200069953 | ✅               | ✅        | ✅    |
 | CC          | CC du Grand Châteaudun                         | 200069961 | ❌               | ❌        | ✅    |
 | CC          | CC Coeur de Beauce                             | 200070159 | ❌               | ❌        | ✅    |
-| CC          | CC Terres de Perche                            | 200070167 | ❔               | ❌        | ❌    |
+| CC          | CC Terres de Perche                            | 200070167 | ❌               | ❌        | ✅    |
 | CC          | CC du Bonnevalais                              | 242852465 | ❌               | ❌        | ✅    |
-| CC          | CC du Pays Houdanais (CCPH)                    | 247800550 | ❔               | ❌        | ❌    |
-| Département | Indre                                          | 36        | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Houdanais (CCPH)                    | 247800550 | ❌               | ❌        | ✅    |
+| Département | Indre                                          | 36        | ❌               | ❌        | ✅    |
 | CC          | CC de la Marche Berrichonne                    | 200007052 | ❌               | ❌        | ✅    |
 | CC          | CC du Val de Bouzanne                          | 200018521 | ❌               | ❌        | ✅    |
-| CC          | CC Marche Occitane - Val d'Anglin              | 200035137 | ❔               | ❌        | ❌    |
+| CC          | CC Marche Occitane - Val d'Anglin              | 200035137 | ❌               | ❌        | ✅    |
 | CC          | CC du Châtillonnais en Berry                   | 200035848 | ❌               | ❌        | ✅    |
 | CC          | CC Écueillé-Valençay                           | 200040558 | ❌               | ❌        | ✅    |
 | CC          | CC Éguzon - Argenton - Vallée de la Creuse     | 200068872 | ❌               | ❌        | ✅    |
@@ -48,12 +50,12 @@
 | CC          | CC Levroux Boischaut Champagne                 | 243600293 | ❌               | ❌        | ✅    |
 | CC          | CC Val de l'Indre - Brenne                     | 243600301 | ❌               | ❌        | ✅    |
 | CC          | CC Brenne - Val de Creuse                      | 243600319 | ❌               | ❌        | ✅    |
-| CA          | CA Châteauroux Métropole                       | 243600327 | ✅               | ✅        | ❌    |
+| CA          | CA Châteauroux Métropole                       | 243600327 | ✅               | ✅        | ✅    |
 | CC          | CC Coeur de Brenne                             | 243600343 | ❌               | ❌        | ✅    |
-| CC          | CC de la Châtre et Sainte-Sévère               | 243600350 | ❌               | ❌        | ✅    |
-| Département | Indre-et-Loire                                 | 37        | ❔               | ❌        | ❌    |
+| CC          | CC de la Châtre et Sainte-Sévère               | 243600350 | ✅               | ❌        | ✅    |
+| Département | Indre-et-Loire                                 | 37        | ❌               | ❌        | ✅    |
 | CC          | CC du Val d'Amboise                            | 200043065 | ❌               | ❌        | ✅    |
-| CC          | CC Chinon, Vienne et Loire                     | 200043081 | ❔               | ❌        | ❌    |
+| CC          | CC Chinon, Vienne et Loire                     | 200043081 | ❌               | ❌        | ✅    |
 | CC          | CC Loches Sud Touraine                         | 200071587 | ❌               | ❌        | ✅    |
 | CC          | CC Touraine Vallée de l'Indre                  | 200072650 | ❌               | ❌        | ✅    |
 | CC          | CC Touraine Val de Vienne                      | 200072668 | ❌               | ❌        | ✅    |
@@ -61,35 +63,35 @@
 | CC          | CC Touraine-Est Vallées                        | 200073161 | ❌               | ❌        | ✅    |
 | CC          | CC de Gâtine-Racan                             | 200073237 | ❌               | ❌        | ✅    |
 | CC          | CC du Castelrenaudais                          | 243700499 | ❌               | ❌        | ✅    |
-| METRO       | Tours Métropole Val de Loire                   | 243700754 | ❔               | ❌        | ❌    |
+| METRO       | Tours Métropole Val de Loire                   | 243700754 | ❌               | ❌        | ✅    |
 | CC          | CC Autour de Chenonceaux Bléré-Val de Cher     | 243700820 | ❌               | ❌        | ✅    |
-| Département | Loir-et-Cher                                   | 41        | ❔               | ❌        | ❌    |
+| Département | Loir-et-Cher                                   | 41        | ❌               | ❌        | ✅    |
 | CC          | CC Coeur de Sologne                            | 200000800 | ❌               | ❌        | ✅    |
-| CC          | CC du Romorantinais et du Monestois            | 200018406 | ❔               | ❌        | ❌    |
-| CA          | CA de Blois ''Agglopolys''                     | 200030385 | ✅               | ✅        | ❌    |
+| CC          | CC du Romorantinais et du Monestois            | 200018406 | ❌               | ❌        | ✅    |
+| CA          | CA de Blois ''Agglopolys''                     | 200030385 | ✅               | ✅        | ✅    |
 | CC          | CC du Perche et Haut Vendômois                 | 200040772 | ❌               | ❌        | ✅    |
 | CC          | CC Beauce Val de Loire                         | 200055481 | ❌               | ❌        | ✅    |
-| CC          | CC des Terres du Val de Loire                  | 200070183 | ❔               | ❌        | ❌    |
+| CC          | CC des Terres du Val de Loire                  | 200070183 | ❌               | ❌        | ✅    |
 | CC          | CC Val-de-Cher-Controis                        | 200072064 | ❌               | ❌        | ✅    |
-| CA          | CA Territoires Vendômois                       | 200072072 | ❔               | ❌        | ❌    |
+| CA          | CA Territoires Vendômois                       | 200072072 | ❌               | ❌        | ✅    |
 | CC          | CC des Collines du Perche                      | 244100293 | ❌               | ❌        | ✅    |
 | CC          | CC de la Sologne des Etangs                    | 244100780 | ❌               | ❌        | ✅    |
 | CC          | CC du Grand Chambord                           | 244100798 | ❌               | ❌        | ✅    |
 | CC          | CC de la Sologne des Rivières                  | 244100806 | ❌               | ❌        | ✅    |
-| Département | Loiret                                         | 45        | ❔               | ❌        | ❌    |
-| CC          | CC des Portes de Sologne                       | 200005932 | ✅               | ✅        | ❌    |
-| CC          | CC de la Beauce Loirétaine                     | 200035764 | ❔               | ❌        | ❌    |
+| Département | Loiret                                         | 45        | ❌               | ❌        | ✅    |
+| CC          | CC des Portes de Sologne                       | 200005932 | ✅               | ✅        | ✅    |
+| CC          | CC de la Beauce Loirétaine                     | 200035764 | ❌               | ❌        | ✅    |
 | CC          | CC du Pithiverais                              | 200066280 | ❌               | ❌        | ✅    |
 | CC          | CC de la Cléry, du Betz et de l'Ouanne         | 200067668 | ❌               | ❌        | ✅    |
-| CC          | CC Canaux et Forêts en Gâtinais                | 200067676 | ❔               | ❌        | ❌    |
+| CC          | CC Canaux et Forêts en Gâtinais                | 200067676 | ❌               | ❌        | ✅    |
 | CC          | CC Berry Loire Puisaye                         | 200068278 | ❌               | ❌        | ✅    |
 | CC          | CC du Val de Sully                             | 200070100 | ❌               | ❌        | ✅    |
-| CC          | CC des Terres du Val de Loire                  | 200070183 | ❔               | ❌        | ❌    |
+| CC          | CC des Terres du Val de Loire                  | 200070183 | ❌               | ❌        | ✅    |
 | CC          | CC du Pithiverais-Gâtinais                     | 200071850 | ❌               | ❌        | ✅    |
-| CA          | CA Montargoise et Rives du Loing (AME)         | 244500203 | ❔               | ❌        | ❌    |
-| CC          | CC Giennoises                                  | 244500211 | ❔               | ❌        | ❌    |
-| CC          | CC des Quatre Vallées                          | 244500419 | ❔               | ❌        | ❌    |
+| CA          | CA Montargoise et Rives du Loing (AME)         | 244500203 | ❌               | ❌        | ✅    |
+| CC          | CC Giennoises                                  | 244500211 | ❌               | ❌        | ✅    |
+| CC          | CC des Quatre Vallées                          | 244500419 | ❌               | ❌        | ✅    |
 | CC          | CC des Loges                                   | 244500427 | ❌               | ❌        | ✅    |
-| METRO       | Orléans Métropole                              | 244500468 | ❔               | ❌        | ❌    |
+| METRO       | Orléans Métropole                              | 244500468 | ❌               | ❌        | ✅    |
 | CC          | CC de la Forêt                                 | 244500484 | ❌               | ❌        | ✅    |
 | CC          | CC de la Plaine du Nord Loiret                 | 244500542 | ❌               | ❌        | ✅    |

--- a/couverture/24_Centre-Val_de_Loire.md
+++ b/couverture/24_Centre-Val_de_Loire.md
@@ -22,14 +22,14 @@
 | CC          | CC FerCher                                     | 241800457 | ❌               | ❌        | ✅    |
 | CA          | CA Bourges Plus                                | 241800507 | ✅               | ✅        | ✅    |
 | CC          | CC du Pays d'Issoudun                          | 243600236 | ❌               | ❌        | ✅    |
-| Département | Eure-et-Loir                                   | 28        | ❔               | ❌        | ❌    |
+| Département | Eure-et-Loir                                   | 28        | ❌               | ❌        | ✅    |
 | CC          | CC du Perche                                   | 200006971 | ❌               | ❌        | ✅    |
-| CA          | CA Chartres Métropole                          | 200033181 | ❔               | ❌        | ❌    |
-| CA          | CA Agglo du Pays de Dreux                      | 200040277 | ❔               | ❌        | ❌    |
-| CC          | CC Entre Beauce et Perche                      | 200058360 | ❔               | ❌        | ❌    |
-| CC          | CC Interco Normandie Sud Eure                  | 200066462 | ❔               | ❌        | ❌    |
-| CC          | CC des Forêts du Perche                        | 200069912 | ❔               | ❌        | ❌    |
-| CC          | CC des Portes Euréliennes d'Ile de France      | 200069953 | ❔               | ❌        | ❌    |
+| CA          | CA Chartres Métropole                          | 200033181 | ❌               | ❌        | ✅    |
+| CA          | CA Agglo du Pays de Dreux                      | 200040277 | ❌               | ❌        | ✅    |
+| CC          | CC Entre Beauce et Perche                      | 200058360 | ❌               | ❌        | ✅    |
+| CC          | CC Interco Normandie Sud Eure                  | 200066462 | ❌               | ❌        | ✅    |
+| CC          | CC des Forêts du Perche                        | 200069912 | ❌               | ❌        | ✅    |
+| CC          | CC des Portes Euréliennes d'Ile de France      | 200069953 | ✅               | ✅        | ✅    |
 | CC          | CC du Grand Châteaudun                         | 200069961 | ❌               | ❌        | ✅    |
 | CC          | CC Coeur de Beauce                             | 200070159 | ❌               | ❌        | ✅    |
 | CC          | CC Terres de Perche                            | 200070167 | ❔               | ❌        | ❌    |

--- a/couverture/27_Bourgogne-Franche-Comté.md
+++ b/couverture/27_Bourgogne-Franche-Comté.md
@@ -55,8 +55,8 @@
 | CC          | CC du Val d'Amour                                       | 243900420 | ❌               | ❌        | ✅    |
 | CC          | CC Haut-Jura Arcade Communauté                          | 243900479 | ❔               | ❌        | ❌    |
 | CC          | CC Jura Nord                                            | 243900560 | ❌               | ❌        | ✅    |
-| CC          | CC la Grandvallière                                     | 243900610 | ❔               | ❌        | ❌    |
-| CC          | CC de la Plaine Jurassienne                             | 243901089 | ❔               | ❌        | ❌    |
+| CC          | CC la Grandvallière                                     | 243900610 | ❌               | ❌        | ✅    |
+| CC          | CC de la Plaine Jurassienne                             | 243901089 | ❌               | ❌        | ❌    |
 | Département | Nièvre                                                  | 58        | ❔               | ❌        | ❌    |
 | CC          | CC de Puisaye-Forterre                                  | 200067130 | ✅               | ✅        | ✅    |
 | CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❔               | ❌        | ❌    |

--- a/couverture/27_Bourgogne-Franche-Comté.md
+++ b/couverture/27_Bourgogne-Franche-Comté.md
@@ -43,7 +43,7 @@
 | CC          | CC du Pays de Villersexel                               | 247000714 | ❌               | ❌        | ✅    |
 | CC          | CC du Pays d'Héricourt                                  | 247000722 | ❌               | ❌        | ✅    |
 | Département | Jura                                                    | 39        | ❌               | ❌        | ✅    |
-| CA          | CA du Grand Dole                                        | 200010650 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Dole                                        | 200010650 | ❌               | ❌        | ✅    |
 | CC          | CC Haut-Jura Saint-Claude                               | 200026573 | ❌               | ❌        | ✅    |
 | CC          | CC Bresse Haute Seille                                  | 200069615 | ❌               | ❌        | ✅    |
 | CC          | CC Champagnole Nozeroy Jura                             | 200069623 | ❌               | ❌        | ✅    |
@@ -53,83 +53,83 @@
 | CC          | CC Terre d'Émeraude Communauté                          | 200090579 | ❌               | ❌        | ✅    |
 | CC          | CC de la Station des Rousses-Haut Jura                  | 243900354 | ❌               | ❌        | ✅    |
 | CC          | CC du Val d'Amour                                       | 243900420 | ❌               | ❌        | ✅    |
-| CC          | CC Haut-Jura Arcade Communauté                          | 243900479 | ❔               | ❌        | ❌    |
+| CC          | CC Haut-Jura Arcade Communauté                          | 243900479 | ✅               | 📧        | 📧    |
 | CC          | CC Jura Nord                                            | 243900560 | ❌               | ❌        | ✅    |
 | CC          | CC la Grandvallière                                     | 243900610 | ❌               | ❌        | ✅    |
-| CC          | CC de la Plaine Jurassienne                             | 243901089 | ❌               | ❌        | ❌    |
-| Département | Nièvre                                                  | 58        | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine Jurassienne                             | 243901089 | ❌               | ❌        | ✅    |
+| Département | Nièvre                                                  | 58        | ❌               | ❌        | ❌    |
 | CC          | CC de Puisaye-Forterre                                  | 200067130 | ✅               | ✅        | ✅    |
-| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❔               | ❌        | ❌    |
-| CC          | CC Tannay-Brinon-Corbigny                               | 200067692 | ❔               | ❌        | ❌    |
-| CC          | CC Sud Nivernais                                        | 200067700 | ❔               | ❌        | ❌    |
-| CC          | CC Bazois Loire Morvan                                  | 200067882 | ❔               | ❌        | ❌    |
-| CC          | CC Morvan Sommets et Grands Lacs                        | 200067890 | ❔               | ❌        | ❌    |
-| CC          | CC Amognes Coeur du Nivernais                           | 200067908 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Loire                                       | 200067916 | ❔               | ❌        | ❌    |
-| CC          | CC Les Bertranges                                       | 200068088 | ❔               | ❌        | ❌    |
-| CA          | CA Moulins Communauté                                   | 200071140 | ❔               | ❌        | ❌    |
-| CC          | CC Loire et Allier                                      | 245801063 | ❔               | ❌        | ❌    |
-| CA          | CA de Nevers                                            | 245804406 | ❔               | ❌        | ❌    |
-| CC          | CC du Nivernais Bourbonnais                             | 245804497 | ❔               | ❌        | ❌    |
-| Département | Haute-Saône                                             | 70        | ❔               | ❌        | ❌    |
-| CC          | CC des Hauts du Val de Saône                            | 200036150 | ❔               | ❌        | ❌    |
-| CC          | CC Val de Gray                                          | 200036549 | ❔               | ❌        | ❌    |
-| CC          | CC de la Haute Comté                                    | 200041721 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Montbozon et du Chanois                   | 200041853 | ❔               | ❌        | ❌    |
-| CC          | CC du Triangle Vert                                     | 200041861 | ❔               | ❌        | ❌    |
-| CC          | CC Terres de Saône                                      | 200041879 | ❔               | ❌        | ❌    |
-| CC          | CC du Val Marnaysien                                    | 200041887 | ❔               | ❌        | ❌    |
-| CC          | CC des Savoir-Faire                                     | 200070332 | ❔               | ❌        | ❌    |
-| CA          | CA de Vesoul                                            | 247000011 | ❔               | ❌        | ❌    |
-| CC          | CC des Combes                                           | 247000367 | ❔               | ❌        | ❌    |
-| CC          | CC des Quatre Rivières                                  | 247000623 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Lure                                      | 247000664 | ❔               | ❌        | ❌    |
-| CC          | CC des Monts de Gy                                      | 247000698 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays Riolais                                      | 247000706 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Villersexel                               | 247000714 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays d'Héricourt                                  | 247000722 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Luxeuil                                   | 247000755 | ❔               | ❌        | ❌    |
-| CC          | CC Rahin et Chérimont                                   | 247000821 | ❔               | ❌        | ❌    |
-| CC          | CC des 1000 étangs                                      | 247000854 | ❔               | ❌        | ❌    |
-| Département | Saône-et-Loire                                          | 71        | ❔               | ❌        | ❌    |
-| CA          | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔               | ❌        | ❌    |
-| CC          | CC Saône Doubs Bresse                                   | 200040038 | ❔               | ❌        | ❌    |
-| CC          | CC du Clunisois                                         | 200040293 | ❔               | ❌        | ❌    |
-| CC          | CC Bresse Revermont 71                                  | 200042414 | ❔               | ❌        | ❌    |
-| CC          | CC Mâconnais - Tournugeois                              | 200069698 | ❔               | ❌        | ❌    |
-| CA          | CA Mâconnais Beaujolais Agglomération                   | 200070308 | ❔               | ❌        | ❌    |
-| CC          | CC Entre Arroux, Loire et Somme                         | 200070316 | ❔               | ❌        | ❌    |
-| CC          | CC du Grand Autunois Morvan                             | 200070530 | ❔               | ❌        | ❌    |
-| CC          | CC Brionnais Sud Bourgogne                              | 200070548 | ❔               | ❌        | ❌    |
-| CC          | CC Terres de Bresse                                     | 200071538 | ❔               | ❌        | ❌    |
-| CC          | CC Bresse Louhannaise Intercom'                         | 200071579 | ❔               | ❌        | ❌    |
-| CC          | CC Saint Cyr Mère Boitier entre Charolais et Mâconnais  | 200071645 | ❔               | ❌        | ❌    |
-| CC          | CC Le Grand Charolais                                   | 200071884 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❌               | ❌        | ✅    |
+| CC          | CC Tannay-Brinon-Corbigny                               | 200067692 | ❌               | ❌        | ✅    |
+| CC          | CC Sud Nivernais                                        | 200067700 | ❌               | ❌        | ✅    |
+| CC          | CC Bazois Loire Morvan                                  | 200067882 | ❌               | ❌        | ✅    |
+| CC          | CC Morvan Sommets et Grands Lacs                        | 200067890 | ❌               | ❌        | ✅    |
+| CC          | CC Amognes Coeur du Nivernais                           | 200067908 | ❌               | ❌        | ✅    |
+| CC          | CC Coeur de Loire                                       | 200067916 | ❌               | ❌        | ✅    |
+| CC          | CC Les Bertranges                                       | 200068088 | ❌               | ❌        | ✅    |
+| CA          | CA Moulins Communauté                                   | 200071140 | ❌               | ❌        | ✅    |
+| CC          | CC Loire et Allier                                      | 245801063 | ❌               | ❌        | ✅    |
+| CA          | CA de Nevers                                            | 245804406 | ❌               | ❌        | ✅    |
+| CC          | CC du Nivernais Bourbonnais                             | 245804497 | ❌               | ❌        | ✅    |
+| Département | Haute-Saône                                             | 70        | ❌               | ❌        | ✅    |
+| CC          | CC des Hauts du Val de Saône                            | 200036150 | ❌               | ❌        | ✅    |
+| CC          | CC Val de Gray                                          | 200036549 | ❌               | ❌        | ✅    |
+| CC          | CC de la Haute Comté                                    | 200041721 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Montbozon et du Chanois                   | 200041853 | ❌               | ❌        | ✅    |
+| CC          | CC du Triangle Vert                                     | 200041861 | ❌               | ❌        | ✅    |
+| CC          | CC Terres de Saône                                      | 200041879 | ❌               | ❌        | ✅    |
+| CC          | CC du Val Marnaysien                                    | 200041887 | ❌               | ❌        | ✅    |
+| CC          | CC des Savoir-Faire                                     | 200070332 | ❌               | ❌        | ✅    |
+| CA          | CA de Vesoul                                            | 247000011 | ❌               | ❌        | ✅    |
+| CC          | CC des Combes                                           | 247000367 | ❌               | ❌        | ✅    |
+| CC          | CC des Quatre Rivières                                  | 247000623 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Lure                                      | 247000664 | ❌               | ❌        | ✅    |
+| CC          | CC des Monts de Gy                                      | 247000698 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays Riolais                                      | 247000706 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Villersexel                               | 247000714 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays d'Héricourt                                  | 247000722 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Luxeuil                                   | 247000755 | ❌               | ❌        | ✅    |
+| CC          | CC Rahin et Chérimont                                   | 247000821 | ❌               | ❌        | ✅    |
+| CC          | CC des 1000 étangs                                      | 247000854 | ❌               | ❌        | ✅    |
+| Département | Saône-et-Loire                                          | 71        | ❌               | ❌        | ❌    |
+| CA          | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❌               | ❌        | ✅    |
+| CC          | CC Saône Doubs Bresse                                   | 200040038 | ❌               | ❌        | ✅    |
+| CC          | CC du Clunisois                                         | 200040293 | ❌               | ❌        | ✅    |
+| CC          | CC Bresse Revermont 71                                  | 200042414 | ❌               | ❌        | ✅    |
+| CC          | CC Mâconnais - Tournugeois                              | 200069698 | ❌               | ❌        | ✅    |
+| CA          | CA Mâconnais Beaujolais Agglomération                   | 200070308 | ❌               | ❌        | ✅    |
+| CC          | CC Entre Arroux, Loire et Somme                         | 200070316 | ❌               | ❌        | ✅    |
+| CC          | CC du Grand Autunois Morvan                             | 200070530 | ❌               | ❌        | ✅    |
+| CC          | CC Brionnais Sud Bourgogne                              | 200070548 | ❌               | ❌        | ✅    |
+| CC          | CC Terres de Bresse                                     | 200071538 | ❌               | ❌        | ✅    |
+| CC          | CC Bresse Louhannaise Intercom'                         | 200071579 | ❌               | ❌        | ✅    |
+| CC          | CC Saint Cyr Mère Boitier entre Charolais et Mâconnais  | 200071645 | ❌               | ❌        | ✅    |
+| CC          | CC Le Grand Charolais                                   | 200071884 | ❌               | ❌        | ✅    |
 | CU          | CU Le Creusot Montceau-les-Mines                        | 247100290 | ✅               | ✅        | ✅    |
-| CA          | CA Le Grand Chalon                                      | 247100589 | ❔               | ❌        | ❌    |
-| CC          | CC de Marcigny                                          | 247100639 | ❔               | ❌        | ❌    |
-| CC          | CC Bresse Nord Intercom'                                | 247100647 | ❔               | ❌        | ❌    |
-| CC          | CC Entre Saône et Grosne                                | 247103765 | ❔               | ❌        | ❌    |
-| CC          | CC de Semur en Brionnais                                | 247103864 | ❔               | ❌        | ❌    |
-| CC          | CC Sud Côte Chalonnaise                                 | 247104094 | ❔               | ❌        | ❌    |
-| Département | Yonne                                                   | 89        | ❔               | ❌        | ❌    |
-| CC          | CC Le Tonnerrois en Bourgogne                           | 200039642 | ❔               | ❌        | ❌    |
-| CC          | CC du Serein                                            | 200039709 | ❔               | ❌        | ❌    |
-| CC          | CC Avallon, Vézelay, Morvan                             | 200039758 | ❔               | ❌        | ❌    |
-| CC          | CC Chablis Villages et Terroirs                         | 200067080 | ❔               | ❌        | ❌    |
-| CA          | CA de l'Auxerrois                                       | 200067114 | ❔               | ❌        | ❌    |
+| CA          | CA Le Grand Chalon                                      | 247100589 | ❌               | ❌        | ✅    |
+| CC          | CC de Marcigny                                          | 247100639 | ❌               | ❌        | ✅    |
+| CC          | CC Bresse Nord Intercom'                                | 247100647 | ❌               | ❌        | ✅    |
+| CC          | CC Entre Saône et Grosne                                | 247103765 | ❌               | ❌        | ✅    |
+| CC          | CC de Semur en Brionnais                                | 247103864 | ❌               | ❌        | ✅    |
+| CC          | CC Sud Côte Chalonnaise                                 | 247104094 | ❌               | ❌        | ✅    |
+| Département | Yonne                                                   | 89        | ❌               | ❌        | ✅    |
+| CC          | CC Le Tonnerrois en Bourgogne                           | 200039642 | ❌               | ❌        | ✅    |
+| CC          | CC du Serein                                            | 200039709 | ❌               | ❌        | ✅    |
+| CC          | CC Avallon, Vézelay, Morvan                             | 200039758 | ❌               | ❌        | ✅    |
+| CC          | CC Chablis Villages et Terroirs                         | 200067080 | ❌               | ❌        | ✅    |
+| CA          | CA de l'Auxerrois                                       | 200067114 | ❌               | ❌        | ✅    |
 | CC          | CC de Puisaye-Forterre                                  | 200067130 | ✅               | ✅        | ✅    |
-| CC          | CC Serein et Armance                                    | 200067304 | ❔               | ❌        | ❌    |
-| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❔               | ❌        | ❌    |
-| CC          | CC de la Cléry, du Betz et de l'Ouanne                  | 200067668 | ❔               | ❌        | ❌    |
-| CA          | CA du Grand Sénonais                                    | 248900334 | ❔               | ❌        | ❌    |
-| CC          | CC de l'Agglomération Migennoise                        | 248900383 | ❔               | ❌        | ❌    |
-| CC          | CC de l'Aillantais en Bourgogne                         | 248900524 | ❔               | ❌        | ❌    |
-| CC          | CC de la Vanne et du Pays d'Othe                        | 248900664 | ❔               | ❌        | ❌    |
-| CC          | CC du Gâtinais en Bourgogne                             | 248900748 | ❔               | ❌        | ❌    |
-| CC          | CC Yonne Nord                                           | 248900896 | ❔               | ❌        | ❌    |
-| CC          | CC du Jovinien                                          | 248900938 | ❔               | ❌        | ❌    |
-| Département | Territoire de Belfort                                   | 90        | ❔               | ❌        | ❌    |
-| CA          | CA Grand Belfort                                        | 200069052 | ❔               | ❌        | ❌    |
-| CC          | CC des Vosges du Sud                                    | 200069060 | ❔               | ❌        | ❌    |
-| CC          | CC du Sud Territoire                                    | 249000241 | ❔               | ❌        | ❌    |
+| CC          | CC Serein et Armance                                    | 200067304 | ❌               | ❌        | ✅    |
+| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❌               | ❌        | ✅    |
+| CC          | CC de la Cléry, du Betz et de l'Ouanne                  | 200067668 | ❌               | ❌        | ✅    |
+| CA          | CA du Grand Sénonais                                    | 248900334 | ❌               | ❌        | ✅    |
+| CC          | CC de l'Agglomération Migennoise                        | 248900383 | ❌               | ❌        | ✅    |
+| CC          | CC de l'Aillantais en Bourgogne                         | 248900524 | ❌               | ❌        | ✅    |
+| CC          | CC de la Vanne et du Pays d'Othe                        | 248900664 | ❌               | ❌        | ✅    |
+| CC          | CC du Gâtinais en Bourgogne                             | 248900748 | ❌               | ❌        | ✅    |
+| CC          | CC Yonne Nord                                           | 248900896 | ❌               | ❌        | ✅    |
+| CC          | CC du Jovinien                                          | 248900938 | ❌               | ❌        | ✅    |
+| Département | Territoire de Belfort                                   | 90        | ❌               | ❌        | ✅    |
+| CA          | CA Grand Belfort                                        | 200069052 | ❌               | ❌        | ✅    |
+| CC          | CC des Vosges du Sud                                    | 200069060 | ❌               | ❌        | ✅    |
+| CC          | CC du Sud Territoire                                    | 249000241 | ❌               | ❌        | ✅    |

--- a/couverture/27_Bourgogne-Franche-Comté.md
+++ b/couverture/27_Bourgogne-Franche-Comté.md
@@ -1,5 +1,7 @@
 # Couverture des aides en Bourgogne-Franche-Comté (27)
 
+- 2025 : ✅
+
 | Echelle     | Nom                                                     | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ------------------------------------------------------- | --------- | ---------------- | --------- | ----- |
 | Région      | Bourgogne-Franche-Comté                                 | 27        | ❌               | ❌        | ✅    |

--- a/couverture/27_Bourgogne-Franche-Comté.md
+++ b/couverture/27_Bourgogne-Franche-Comté.md
@@ -1,136 +1,135 @@
 # Couverture des aides en Bourgogne-Franche-Comté (27)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Bourgogne-Franche-Comté | 27 | ❔ | ❌ | ❌ |
-| Département | Côte-d'Or | 21 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine Dijonnaise | 200000925 | ❔ | ❌ | ❌ |
-| CA | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔ | ❌ | ❌ |
-| CC | CC Ouche et Montagne | 200039055 | ❔ | ❌ | ❌ |
-| CC | CC Forêts, Seine et Suzon | 200039063 | ❔ | ❌ | ❌ |
-| CC | CC Norge et Tille | 200069540 | ❔ | ❌ | ❌ |
-| CC | CC de Gevrey-Chambertin et de Nuits-Saint-Georges | 200070894 | ❔ | ❌ | ❌ |
-| CC | CC Auxonne Pontailler Val de Saône | 200070902 | ❔ | ❌ | ❌ |
-| CC | CC Tille et Venelle | 200070910 | ❔ | ❌ | ❌ |
-| CC | CC des Terres d'Auxois | 200071017 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Arnay Liernais | 200071173 | ❔ | ❌ | ❌ |
-| CC | CC de Pouilly-en-Auxois / Bligny-sur-Ouche | 200071207 | ❔ | ❌ | ❌ |
-| CC | CC Mirebellois et Fontenois | 200072825 | ❔ | ❌ | ❌ |
-| CC | CC des Vallées de la Tille et de l'Ignon | 242100154 | ❔ | ❌ | ❌ |
-| METRO | Dijon Métropole | 242100410 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Châtillonnais | 242101434 | ❔ | ❌ | ❌ |
-| CC | CC de Saulieu-Morvan | 242101442 | ✅ | ✅ | ❌ |
-| CC | CC du Pays d'Alésia et de la Seine | 242101459 | ❔ | ❌ | ❌ |
-| CC | CC du Montbardois | 242101491 | ❔ | ❌ | ❌ |
-| CC | CC Rives de Saône | 242101509 | ❔ | ❌ | ❌ |
-| Département | Doubs | 25 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Maîche | 200023075 | ❔ | ❌ | ❌ |
-| CC | CC du Val Marnaysien | 200041887 | ❔ | ❌ | ❌ |
-| CA | CA Pays de Montbéliard Agglomération | 200065647 | ✅ | ✅ | ❌ |
-| CC | CC Loue-Lison | 200068070 | ❔ | ❌ | ❌ |
-| CC | CC des Deux Vallées Vertes | 200068294 | ❔ | ❌ | ❌ |
-| CC | CC des Lacs et Montagnes du Haut-Doubs | 200069565 | ❔ | ❌ | ❌ |
-| CC | CC Entre Doubs et Loue | 242500320 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Pontarlier | 242500338 | ❔ | ❌ | ❌ |
-| CU | CU Grand Besançon Métropole | 242500361 | ✅ | ✅ | ❌ |
-| CC | CC du Val de Morteau | 242504116 | ❔ | ❌ | ❌ |
-| CC | CC des Portes du Haut-Doubs | 242504181 | ❔ | ❌ | ❌ |
-| CC | CC du Plateau de Russey | 242504355 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Sancey-Belleherbe | 242504371 | ❔ | ❌ | ❌ |
-| CC | CC du Doubs Baumois | 242504447 | ❔ | ❌ | ❌ |
-| CC | CC Altitude 800 | 242504488 | ❔ | ❌ | ❌ |
-| CC | CC du Plateau de Frasne et du Val de Drugeon | 242504496 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Villersexel | 247000714 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Héricourt | 247000722 | ❔ | ❌ | ❌ |
-| Département | Jura | 39 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Dole | 200010650 | ❔ | ❌ | ❌ |
-| CC | CC Haut-Jura Saint-Claude | 200026573 | ❔ | ❌ | ❌ |
-| CC | CC Bresse Haute Seille | 200069615 | ❔ | ❌ | ❌ |
-| CC | CC Champagnole Nozeroy Jura | 200069623 | ❔ | ❌ | ❌ |
-| CA | CA ECLA  (Espace Communautaire Lons Agglomération) | 200071116 | ❔ | ❌ | ❌ |
-| CC | CC Arbois, Poligny, Salins, Coeur du Jura | 200071595 | ❔ | ❌ | ❌ |
-| CC | CC Porte du Jura | 200072056 | ❔ | ❌ | ❌ |
-| CC | CC Terre d'Émeraude Communauté | 200090579 | ❔ | ❌ | ❌ |
-| CC | CC de la Station des Rousses-Haut Jura | 243900354 | ❔ | ❌ | ❌ |
-| CC | CC du Val d'Amour | 243900420 | ❔ | ❌ | ❌ |
-| CC | CC Haut-Jura Arcade Communauté | 243900479 | ❔ | ❌ | ❌ |
-| CC | CC Jura Nord | 243900560 | ❔ | ❌ | ❌ |
-| CC | CC la Grandvallière | 243900610 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine Jurassienne | 243901089 | ❔ | ❌ | ❌ |
-| Département | Nièvre | 58 | ❔ | ❌ | ❌ |
-| CC | CC de Puisaye-Forterre | 200067130 | ✅ | ✅ | ❌ |
-| CC | CC Haut Nivernais - Val d'Yonne | 200067429 | ❔ | ❌ | ❌ |
-| CC | CC Tannay-Brinon-Corbigny | 200067692 | ❔ | ❌ | ❌ |
-| CC | CC Sud Nivernais | 200067700 | ❔ | ❌ | ❌ |
-| CC | CC Bazois Loire Morvan | 200067882 | ❔ | ❌ | ❌ |
-| CC | CC Morvan Sommets et Grands Lacs | 200067890 | ❔ | ❌ | ❌ |
-| CC | CC Amognes Coeur du Nivernais | 200067908 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Loire | 200067916 | ❔ | ❌ | ❌ |
-| CC | CC Les Bertranges | 200068088 | ❔ | ❌ | ❌ |
-| CA | CA Moulins Communauté | 200071140 | ❔ | ❌ | ❌ |
-| CC | CC Loire et Allier | 245801063 | ❔ | ❌ | ❌ |
-| CA | CA de Nevers | 245804406 | ❔ | ❌ | ❌ |
-| CC | CC du Nivernais Bourbonnais | 245804497 | ❔ | ❌ | ❌ |
-| Département | Haute-Saône | 70 | ❔ | ❌ | ❌ |
-| CC | CC des Hauts du Val de Saône | 200036150 | ❔ | ❌ | ❌ |
-| CC | CC Val de Gray | 200036549 | ❔ | ❌ | ❌ |
-| CC | CC de la Haute Comté | 200041721 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Montbozon et du Chanois | 200041853 | ❔ | ❌ | ❌ |
-| CC | CC du Triangle Vert | 200041861 | ❔ | ❌ | ❌ |
-| CC | CC Terres de Saône | 200041879 | ❔ | ❌ | ❌ |
-| CC | CC du Val Marnaysien | 200041887 | ❔ | ❌ | ❌ |
-| CC | CC des Savoir-Faire | 200070332 | ❔ | ❌ | ❌ |
-| CA | CA de Vesoul | 247000011 | ❔ | ❌ | ❌ |
-| CC | CC des Combes | 247000367 | ❔ | ❌ | ❌ |
-| CC | CC des Quatre Rivières | 247000623 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Lure | 247000664 | ❔ | ❌ | ❌ |
-| CC | CC des Monts de Gy | 247000698 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Riolais | 247000706 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Villersexel | 247000714 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Héricourt | 247000722 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Luxeuil | 247000755 | ❔ | ❌ | ❌ |
-| CC | CC Rahin et Chérimont | 247000821 | ❔ | ❌ | ❌ |
-| CC | CC des 1000 étangs | 247000854 | ❔ | ❌ | ❌ |
-| Département | Saône-et-Loire | 71 | ❔ | ❌ | ❌ |
-| CA | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔ | ❌ | ❌ |
-| CC | CC Saône Doubs Bresse | 200040038 | ❔ | ❌ | ❌ |
-| CC | CC du Clunisois | 200040293 | ❔ | ❌ | ❌ |
-| CC | CC Bresse Revermont 71 | 200042414 | ❔ | ❌ | ❌ |
-| CC | CC Mâconnais - Tournugeois | 200069698 | ❔ | ❌ | ❌ |
-| CA | CA Mâconnais Beaujolais Agglomération | 200070308 | ❔ | ❌ | ❌ |
-| CC | CC Entre Arroux, Loire et Somme | 200070316 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Autunois Morvan | 200070530 | ❔ | ❌ | ❌ |
-| CC | CC Brionnais Sud Bourgogne | 200070548 | ❔ | ❌ | ❌ |
-| CC | CC Terres de Bresse | 200071538 | ❔ | ❌ | ❌ |
-| CC | CC Bresse Louhannaise Intercom' | 200071579 | ❔ | ❌ | ❌ |
-| CC | CC Saint Cyr Mère Boitier entre Charolais et Mâconnais | 200071645 | ❔ | ❌ | ❌ |
-| CC | CC Le Grand Charolais | 200071884 | ❔ | ❌ | ❌ |
-| CU | CU Le Creusot Montceau-les-Mines | 247100290 | ✅ | ✅ | ❌ |
-| CA | CA Le Grand Chalon | 247100589 | ❔ | ❌ | ❌ |
-| CC | CC de Marcigny | 247100639 | ❔ | ❌ | ❌ |
-| CC | CC Bresse Nord Intercom' | 247100647 | ❔ | ❌ | ❌ |
-| CC | CC Entre Saône et Grosne | 247103765 | ❔ | ❌ | ❌ |
-| CC | CC de Semur en Brionnais | 247103864 | ❔ | ❌ | ❌ |
-| CC | CC Sud Côte Chalonnaise | 247104094 | ❔ | ❌ | ❌ |
-| Département | Yonne | 89 | ❔ | ❌ | ❌ |
-| CC | CC Le Tonnerrois en Bourgogne | 200039642 | ❔ | ❌ | ❌ |
-| CC | CC du Serein | 200039709 | ❔ | ❌ | ❌ |
-| CC | CC Avallon, Vézelay, Morvan | 200039758 | ❔ | ❌ | ❌ |
-| CC | CC Chablis Villages et Terroirs | 200067080 | ❔ | ❌ | ❌ |
-| CA | CA de l'Auxerrois | 200067114 | ❔ | ❌ | ❌ |
-| CC | CC de Puisaye-Forterre | 200067130 | ✅ | ✅ | ❌ |
-| CC | CC Serein et Armance | 200067304 | ❔ | ❌ | ❌ |
-| CC | CC Haut Nivernais - Val d'Yonne | 200067429 | ❔ | ❌ | ❌ |
-| CC | CC de la Cléry, du Betz et de l'Ouanne | 200067668 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Sénonais | 248900334 | ❔ | ❌ | ❌ |
-| CC | CC de l'Agglomération Migennoise | 248900383 | ❔ | ❌ | ❌ |
-| CC | CC de l'Aillantais en Bourgogne | 248900524 | ❔ | ❌ | ❌ |
-| CC | CC de la Vanne et du Pays d'Othe | 248900664 | ❔ | ❌ | ❌ |
-| CC | CC du Gâtinais en Bourgogne | 248900748 | ❔ | ❌ | ❌ |
-| CC | CC Yonne Nord | 248900896 | ❔ | ❌ | ❌ |
-| CC | CC du Jovinien | 248900938 | ❔ | ❌ | ❌ |
-| Département | Territoire de Belfort | 90 | ❔ | ❌ | ❌ |
-| CA | CA Grand Belfort | 200069052 | ❔ | ❌ | ❌ |
-| CC | CC des Vosges du Sud | 200069060 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Territoire | 249000241 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                                     | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ------------------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Bourgogne-Franche-Comté                                 | 27        | ❌               | ❌        | ✅    |
+| Département | Côte-d'Or                                               | 21        | ❌               | ❌        | ✅    |
+| CC          | CC de la Plaine Dijonnaise                              | 200000925 | ❌               | ❌        | ✅    |
+| CA          | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❌               | ❌        | ✅    |
+| CC          | CC Ouche et Montagne                                    | 200039055 | ❌               | ❌        | ✅    |
+| CC          | CC Forêts, Seine et Suzon                               | 200039063 | ❌               | ❌        | ✅    |
+| CC          | CC Norge et Tille                                       | 200069540 | ❌               | ❌        | ✅    |
+| CC          | CC de Gevrey-Chambertin et de Nuits-Saint-Georges       | 200070894 | ❌               | ❌        | ✅    |
+| CC          | CC Auxonne Pontailler Val de Saône                      | 200070902 | ❌               | ❌        | ✅    |
+| CC          | CC Tille et Venelle                                     | 200070910 | ❌               | ❌        | ✅    |
+| CC          | CC des Terres d'Auxois                                  | 200071017 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays Arnay Liernais                               | 200071173 | ❌               | ❌        | ✅    |
+| CC          | CC de Pouilly-en-Auxois / Bligny-sur-Ouche              | 200071207 | ❌               | ❌        | ✅    |
+| CC          | CC Mirebellois et Fontenois                             | 200072825 | ❌               | ❌        | ✅    |
+| CC          | CC des Vallées de la Tille et de l'Ignon                | 242100154 | ❌               | ❌        | ✅    |
+| METRO       | Dijon Métropole                                         | 242100410 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays Châtillonnais                                | 242101434 | ❌               | ❌        | ✅    |
+| CC          | CC de Saulieu-Morvan                                    | 242101442 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays d'Alésia et de la Seine                      | 242101459 | ❌               | ❌        | ✅    |
+| CC          | CC du Montbardois                                       | 242101491 | ❌               | ❌        | ✅    |
+| CC          | CC Rives de Saône                                       | 242101509 | ❌               | ❌        | ✅    |
+| Département | Doubs                                                   | 25        | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Maîche                                    | 200023075 | ❌               | ❌        | ✅    |
+| CC          | CC du Val Marnaysien                                    | 200041887 | ❌               | ❌        | ✅    |
+| CA          | CA Pays de Montbéliard Agglomération                    | 200065647 | ✅               | ✅        | ✅    |
+| CC          | CC Loue-Lison                                           | 200068070 | ✅               | ✅        | ✅    |
+| CC          | CC des Deux Vallées Vertes                              | 200068294 | ❌               | ❌        | ✅    |
+| CC          | CC des Lacs et Montagnes du Haut-Doubs                  | 200069565 | ❌               | ❌        | ✅    |
+| CC          | CC Entre Doubs et Loue                                  | 242500320 | ❌               | ❌        | ✅    |
+| CC          | CC du Grand Pontarlier                                  | 242500338 | ❌               | ❌        | ✅    |
+| CU          | CU Grand Besançon Métropole                             | 242500361 | ✅               | ✅        | ✅    |
+| CC          | CC du Val de Morteau                                    | 242504116 | ❌               | ❌        | ✅    |
+| CC          | CC des Portes du Haut-Doubs                             | 242504181 | ❌               | ❌        | ✅    |
+| CC          | CC du Plateau de Russey                                 | 242504355 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Sancey-Belleherbe                         | 242504371 | ❌               | ❌        | ✅    |
+| CC          | CC du Doubs Baumois                                     | 242504447 | ❌               | ❌        | ✅    |
+| CC          | CC Altitude 800                                         | 242504488 | ❌               | ❌        | ✅    |
+| CC          | CC du Plateau de Frasne et du Val de Drugeon            | 242504496 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de Villersexel                               | 247000714 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays d'Héricourt                                  | 247000722 | ❌               | ❌        | ✅    |
+| Département | Jura                                                    | 39        | ❌               | ❌        | ✅    |
+| CA          | CA du Grand Dole                                        | 200010650 | ❔               | ❌        | ❌    |
+| CC          | CC Haut-Jura Saint-Claude                               | 200026573 | ❌               | ❌        | ✅    |
+| CC          | CC Bresse Haute Seille                                  | 200069615 | ❌               | ❌        | ✅    |
+| CC          | CC Champagnole Nozeroy Jura                             | 200069623 | ❌               | ❌        | ✅    |
+| CA          | CA ECLA (Espace Communautaire Lons Agglomération)       | 200071116 | ❌               | ❌        | ✅    |
+| CC          | CC Arbois, Poligny, Salins, Coeur du Jura               | 200071595 | ❌               | ❌        | ✅    |
+| CC          | CC Porte du Jura                                        | 200072056 | ❌               | ❌        | ✅    |
+| CC          | CC Terre d'Émeraude Communauté                          | 200090579 | ❌               | ❌        | ✅    |
+| CC          | CC de la Station des Rousses-Haut Jura                  | 243900354 | ❌               | ❌        | ✅    |
+| CC          | CC du Val d'Amour                                       | 243900420 | ❌               | ❌        | ✅    |
+| CC          | CC Haut-Jura Arcade Communauté                          | 243900479 | ❔               | ❌        | ❌    |
+| CC          | CC Jura Nord                                            | 243900560 | ❌               | ❌        | ✅    |
+| CC          | CC la Grandvallière                                     | 243900610 | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine Jurassienne                             | 243901089 | ❔               | ❌        | ❌    |
+| Département | Nièvre                                                  | 58        | ❔               | ❌        | ❌    |
+| CC          | CC de Puisaye-Forterre                                  | 200067130 | ✅               | ✅        | ✅    |
+| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❔               | ❌        | ❌    |
+| CC          | CC Tannay-Brinon-Corbigny                               | 200067692 | ❔               | ❌        | ❌    |
+| CC          | CC Sud Nivernais                                        | 200067700 | ❔               | ❌        | ❌    |
+| CC          | CC Bazois Loire Morvan                                  | 200067882 | ❔               | ❌        | ❌    |
+| CC          | CC Morvan Sommets et Grands Lacs                        | 200067890 | ❔               | ❌        | ❌    |
+| CC          | CC Amognes Coeur du Nivernais                           | 200067908 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Loire                                       | 200067916 | ❔               | ❌        | ❌    |
+| CC          | CC Les Bertranges                                       | 200068088 | ❔               | ❌        | ❌    |
+| CA          | CA Moulins Communauté                                   | 200071140 | ❔               | ❌        | ❌    |
+| CC          | CC Loire et Allier                                      | 245801063 | ❔               | ❌        | ❌    |
+| CA          | CA de Nevers                                            | 245804406 | ❔               | ❌        | ❌    |
+| CC          | CC du Nivernais Bourbonnais                             | 245804497 | ❔               | ❌        | ❌    |
+| Département | Haute-Saône                                             | 70        | ❔               | ❌        | ❌    |
+| CC          | CC des Hauts du Val de Saône                            | 200036150 | ❔               | ❌        | ❌    |
+| CC          | CC Val de Gray                                          | 200036549 | ❔               | ❌        | ❌    |
+| CC          | CC de la Haute Comté                                    | 200041721 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Montbozon et du Chanois                   | 200041853 | ❔               | ❌        | ❌    |
+| CC          | CC du Triangle Vert                                     | 200041861 | ❔               | ❌        | ❌    |
+| CC          | CC Terres de Saône                                      | 200041879 | ❔               | ❌        | ❌    |
+| CC          | CC du Val Marnaysien                                    | 200041887 | ❔               | ❌        | ❌    |
+| CC          | CC des Savoir-Faire                                     | 200070332 | ❔               | ❌        | ❌    |
+| CA          | CA de Vesoul                                            | 247000011 | ❔               | ❌        | ❌    |
+| CC          | CC des Combes                                           | 247000367 | ❔               | ❌        | ❌    |
+| CC          | CC des Quatre Rivières                                  | 247000623 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Lure                                      | 247000664 | ❔               | ❌        | ❌    |
+| CC          | CC des Monts de Gy                                      | 247000698 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Riolais                                      | 247000706 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Villersexel                               | 247000714 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Héricourt                                  | 247000722 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Luxeuil                                   | 247000755 | ❔               | ❌        | ❌    |
+| CC          | CC Rahin et Chérimont                                   | 247000821 | ❔               | ❌        | ❌    |
+| CC          | CC des 1000 étangs                                      | 247000854 | ❔               | ❌        | ❌    |
+| Département | Saône-et-Loire                                          | 71        | ❔               | ❌        | ❌    |
+| CA          | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔               | ❌        | ❌    |
+| CC          | CC Saône Doubs Bresse                                   | 200040038 | ❔               | ❌        | ❌    |
+| CC          | CC du Clunisois                                         | 200040293 | ❔               | ❌        | ❌    |
+| CC          | CC Bresse Revermont 71                                  | 200042414 | ❔               | ❌        | ❌    |
+| CC          | CC Mâconnais - Tournugeois                              | 200069698 | ❔               | ❌        | ❌    |
+| CA          | CA Mâconnais Beaujolais Agglomération                   | 200070308 | ❔               | ❌        | ❌    |
+| CC          | CC Entre Arroux, Loire et Somme                         | 200070316 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Autunois Morvan                             | 200070530 | ❔               | ❌        | ❌    |
+| CC          | CC Brionnais Sud Bourgogne                              | 200070548 | ❔               | ❌        | ❌    |
+| CC          | CC Terres de Bresse                                     | 200071538 | ❔               | ❌        | ❌    |
+| CC          | CC Bresse Louhannaise Intercom'                         | 200071579 | ❔               | ❌        | ❌    |
+| CC          | CC Saint Cyr Mère Boitier entre Charolais et Mâconnais  | 200071645 | ❔               | ❌        | ❌    |
+| CC          | CC Le Grand Charolais                                   | 200071884 | ❔               | ❌        | ❌    |
+| CU          | CU Le Creusot Montceau-les-Mines                        | 247100290 | ✅               | ✅        | ✅    |
+| CA          | CA Le Grand Chalon                                      | 247100589 | ❔               | ❌        | ❌    |
+| CC          | CC de Marcigny                                          | 247100639 | ❔               | ❌        | ❌    |
+| CC          | CC Bresse Nord Intercom'                                | 247100647 | ❔               | ❌        | ❌    |
+| CC          | CC Entre Saône et Grosne                                | 247103765 | ❔               | ❌        | ❌    |
+| CC          | CC de Semur en Brionnais                                | 247103864 | ❔               | ❌        | ❌    |
+| CC          | CC Sud Côte Chalonnaise                                 | 247104094 | ❔               | ❌        | ❌    |
+| Département | Yonne                                                   | 89        | ❔               | ❌        | ❌    |
+| CC          | CC Le Tonnerrois en Bourgogne                           | 200039642 | ❔               | ❌        | ❌    |
+| CC          | CC du Serein                                            | 200039709 | ❔               | ❌        | ❌    |
+| CC          | CC Avallon, Vézelay, Morvan                             | 200039758 | ❔               | ❌        | ❌    |
+| CC          | CC Chablis Villages et Terroirs                         | 200067080 | ❔               | ❌        | ❌    |
+| CA          | CA de l'Auxerrois                                       | 200067114 | ❔               | ❌        | ❌    |
+| CC          | CC de Puisaye-Forterre                                  | 200067130 | ✅               | ✅        | ✅    |
+| CC          | CC Serein et Armance                                    | 200067304 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Nivernais - Val d'Yonne                         | 200067429 | ❔               | ❌        | ❌    |
+| CC          | CC de la Cléry, du Betz et de l'Ouanne                  | 200067668 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Sénonais                                    | 248900334 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Agglomération Migennoise                        | 248900383 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Aillantais en Bourgogne                         | 248900524 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vanne et du Pays d'Othe                        | 248900664 | ❔               | ❌        | ❌    |
+| CC          | CC du Gâtinais en Bourgogne                             | 248900748 | ❔               | ❌        | ❌    |
+| CC          | CC Yonne Nord                                           | 248900896 | ❔               | ❌        | ❌    |
+| CC          | CC du Jovinien                                          | 248900938 | ❔               | ❌        | ❌    |
+| Département | Territoire de Belfort                                   | 90        | ❔               | ❌        | ❌    |
+| CA          | CA Grand Belfort                                        | 200069052 | ❔               | ❌        | ❌    |
+| CC          | CC des Vosges du Sud                                    | 200069060 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Territoire                                    | 249000241 | ❔               | ❌        | ❌    |

--- a/couverture/27_Bourgogne-Franche-Comté.md
+++ b/couverture/27_Bourgogne-Franche-Comté.md
@@ -1,0 +1,136 @@
+# Couverture des aides en Bourgogne-Franche-Comté (27)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Bourgogne-Franche-Comté | 27 | ❔ | ❌ | ❌ |
+| Département | Côte-d'Or | 21 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine Dijonnaise | 200000925 | ❔ | ❌ | ❌ |
+| CA | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔ | ❌ | ❌ |
+| CC | CC Ouche et Montagne | 200039055 | ❔ | ❌ | ❌ |
+| CC | CC Forêts, Seine et Suzon | 200039063 | ❔ | ❌ | ❌ |
+| CC | CC Norge et Tille | 200069540 | ❔ | ❌ | ❌ |
+| CC | CC de Gevrey-Chambertin et de Nuits-Saint-Georges | 200070894 | ❔ | ❌ | ❌ |
+| CC | CC Auxonne Pontailler Val de Saône | 200070902 | ❔ | ❌ | ❌ |
+| CC | CC Tille et Venelle | 200070910 | ❔ | ❌ | ❌ |
+| CC | CC des Terres d'Auxois | 200071017 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Arnay Liernais | 200071173 | ❔ | ❌ | ❌ |
+| CC | CC de Pouilly-en-Auxois / Bligny-sur-Ouche | 200071207 | ❔ | ❌ | ❌ |
+| CC | CC Mirebellois et Fontenois | 200072825 | ❔ | ❌ | ❌ |
+| CC | CC des Vallées de la Tille et de l'Ignon | 242100154 | ❔ | ❌ | ❌ |
+| METRO | Dijon Métropole | 242100410 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Châtillonnais | 242101434 | ❔ | ❌ | ❌ |
+| CC | CC de Saulieu-Morvan | 242101442 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Alésia et de la Seine | 242101459 | ❔ | ❌ | ❌ |
+| CC | CC du Montbardois | 242101491 | ❔ | ❌ | ❌ |
+| CC | CC Rives de Saône | 242101509 | ❔ | ❌ | ❌ |
+| Département | Doubs | 25 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Maîche | 200023075 | ❔ | ❌ | ❌ |
+| CC | CC du Val Marnaysien | 200041887 | ❔ | ❌ | ❌ |
+| CA | CA Pays de Montbéliard Agglomération | 200065647 | ✅ | ✅ | ❌ |
+| CC | CC Loue-Lison | 200068070 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Vallées Vertes | 200068294 | ❔ | ❌ | ❌ |
+| CC | CC des Lacs et Montagnes du Haut-Doubs | 200069565 | ❔ | ❌ | ❌ |
+| CC | CC Entre Doubs et Loue | 242500320 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Pontarlier | 242500338 | ❔ | ❌ | ❌ |
+| CU | CU Grand Besançon Métropole | 242500361 | ✅ | ✅ | ❌ |
+| CC | CC du Val de Morteau | 242504116 | ❔ | ❌ | ❌ |
+| CC | CC des Portes du Haut-Doubs | 242504181 | ❔ | ❌ | ❌ |
+| CC | CC du Plateau de Russey | 242504355 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Sancey-Belleherbe | 242504371 | ❔ | ❌ | ❌ |
+| CC | CC du Doubs Baumois | 242504447 | ❔ | ❌ | ❌ |
+| CC | CC Altitude 800 | 242504488 | ❔ | ❌ | ❌ |
+| CC | CC du Plateau de Frasne et du Val de Drugeon | 242504496 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Villersexel | 247000714 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Héricourt | 247000722 | ❔ | ❌ | ❌ |
+| Département | Jura | 39 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Dole | 200010650 | ❔ | ❌ | ❌ |
+| CC | CC Haut-Jura Saint-Claude | 200026573 | ❔ | ❌ | ❌ |
+| CC | CC Bresse Haute Seille | 200069615 | ❔ | ❌ | ❌ |
+| CC | CC Champagnole Nozeroy Jura | 200069623 | ❔ | ❌ | ❌ |
+| CA | CA ECLA  (Espace Communautaire Lons Agglomération) | 200071116 | ❔ | ❌ | ❌ |
+| CC | CC Arbois, Poligny, Salins, Coeur du Jura | 200071595 | ❔ | ❌ | ❌ |
+| CC | CC Porte du Jura | 200072056 | ❔ | ❌ | ❌ |
+| CC | CC Terre d'Émeraude Communauté | 200090579 | ❔ | ❌ | ❌ |
+| CC | CC de la Station des Rousses-Haut Jura | 243900354 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Amour | 243900420 | ❔ | ❌ | ❌ |
+| CC | CC Haut-Jura Arcade Communauté | 243900479 | ❔ | ❌ | ❌ |
+| CC | CC Jura Nord | 243900560 | ❔ | ❌ | ❌ |
+| CC | CC la Grandvallière | 243900610 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine Jurassienne | 243901089 | ❔ | ❌ | ❌ |
+| Département | Nièvre | 58 | ❔ | ❌ | ❌ |
+| CC | CC de Puisaye-Forterre | 200067130 | ✅ | ✅ | ❌ |
+| CC | CC Haut Nivernais - Val d'Yonne | 200067429 | ❔ | ❌ | ❌ |
+| CC | CC Tannay-Brinon-Corbigny | 200067692 | ❔ | ❌ | ❌ |
+| CC | CC Sud Nivernais | 200067700 | ❔ | ❌ | ❌ |
+| CC | CC Bazois Loire Morvan | 200067882 | ❔ | ❌ | ❌ |
+| CC | CC Morvan Sommets et Grands Lacs | 200067890 | ❔ | ❌ | ❌ |
+| CC | CC Amognes Coeur du Nivernais | 200067908 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Loire | 200067916 | ❔ | ❌ | ❌ |
+| CC | CC Les Bertranges | 200068088 | ❔ | ❌ | ❌ |
+| CA | CA Moulins Communauté | 200071140 | ❔ | ❌ | ❌ |
+| CC | CC Loire et Allier | 245801063 | ❔ | ❌ | ❌ |
+| CA | CA de Nevers | 245804406 | ❔ | ❌ | ❌ |
+| CC | CC du Nivernais Bourbonnais | 245804497 | ❔ | ❌ | ❌ |
+| Département | Haute-Saône | 70 | ❔ | ❌ | ❌ |
+| CC | CC des Hauts du Val de Saône | 200036150 | ❔ | ❌ | ❌ |
+| CC | CC Val de Gray | 200036549 | ❔ | ❌ | ❌ |
+| CC | CC de la Haute Comté | 200041721 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Montbozon et du Chanois | 200041853 | ❔ | ❌ | ❌ |
+| CC | CC du Triangle Vert | 200041861 | ❔ | ❌ | ❌ |
+| CC | CC Terres de Saône | 200041879 | ❔ | ❌ | ❌ |
+| CC | CC du Val Marnaysien | 200041887 | ❔ | ❌ | ❌ |
+| CC | CC des Savoir-Faire | 200070332 | ❔ | ❌ | ❌ |
+| CA | CA de Vesoul | 247000011 | ❔ | ❌ | ❌ |
+| CC | CC des Combes | 247000367 | ❔ | ❌ | ❌ |
+| CC | CC des Quatre Rivières | 247000623 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lure | 247000664 | ❔ | ❌ | ❌ |
+| CC | CC des Monts de Gy | 247000698 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Riolais | 247000706 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Villersexel | 247000714 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Héricourt | 247000722 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Luxeuil | 247000755 | ❔ | ❌ | ❌ |
+| CC | CC Rahin et Chérimont | 247000821 | ❔ | ❌ | ❌ |
+| CC | CC des 1000 étangs | 247000854 | ❔ | ❌ | ❌ |
+| Département | Saône-et-Loire | 71 | ❔ | ❌ | ❌ |
+| CA | CA Beaune, Côte et Sud - Communauté Beaune-Chagny-Nolay | 200006682 | ❔ | ❌ | ❌ |
+| CC | CC Saône Doubs Bresse | 200040038 | ❔ | ❌ | ❌ |
+| CC | CC du Clunisois | 200040293 | ❔ | ❌ | ❌ |
+| CC | CC Bresse Revermont 71 | 200042414 | ❔ | ❌ | ❌ |
+| CC | CC Mâconnais - Tournugeois | 200069698 | ❔ | ❌ | ❌ |
+| CA | CA Mâconnais Beaujolais Agglomération | 200070308 | ❔ | ❌ | ❌ |
+| CC | CC Entre Arroux, Loire et Somme | 200070316 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Autunois Morvan | 200070530 | ❔ | ❌ | ❌ |
+| CC | CC Brionnais Sud Bourgogne | 200070548 | ❔ | ❌ | ❌ |
+| CC | CC Terres de Bresse | 200071538 | ❔ | ❌ | ❌ |
+| CC | CC Bresse Louhannaise Intercom' | 200071579 | ❔ | ❌ | ❌ |
+| CC | CC Saint Cyr Mère Boitier entre Charolais et Mâconnais | 200071645 | ❔ | ❌ | ❌ |
+| CC | CC Le Grand Charolais | 200071884 | ❔ | ❌ | ❌ |
+| CU | CU Le Creusot Montceau-les-Mines | 247100290 | ✅ | ✅ | ❌ |
+| CA | CA Le Grand Chalon | 247100589 | ❔ | ❌ | ❌ |
+| CC | CC de Marcigny | 247100639 | ❔ | ❌ | ❌ |
+| CC | CC Bresse Nord Intercom' | 247100647 | ❔ | ❌ | ❌ |
+| CC | CC Entre Saône et Grosne | 247103765 | ❔ | ❌ | ❌ |
+| CC | CC de Semur en Brionnais | 247103864 | ❔ | ❌ | ❌ |
+| CC | CC Sud Côte Chalonnaise | 247104094 | ❔ | ❌ | ❌ |
+| Département | Yonne | 89 | ❔ | ❌ | ❌ |
+| CC | CC Le Tonnerrois en Bourgogne | 200039642 | ❔ | ❌ | ❌ |
+| CC | CC du Serein | 200039709 | ❔ | ❌ | ❌ |
+| CC | CC Avallon, Vézelay, Morvan | 200039758 | ❔ | ❌ | ❌ |
+| CC | CC Chablis Villages et Terroirs | 200067080 | ❔ | ❌ | ❌ |
+| CA | CA de l'Auxerrois | 200067114 | ❔ | ❌ | ❌ |
+| CC | CC de Puisaye-Forterre | 200067130 | ✅ | ✅ | ❌ |
+| CC | CC Serein et Armance | 200067304 | ❔ | ❌ | ❌ |
+| CC | CC Haut Nivernais - Val d'Yonne | 200067429 | ❔ | ❌ | ❌ |
+| CC | CC de la Cléry, du Betz et de l'Ouanne | 200067668 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Sénonais | 248900334 | ❔ | ❌ | ❌ |
+| CC | CC de l'Agglomération Migennoise | 248900383 | ❔ | ❌ | ❌ |
+| CC | CC de l'Aillantais en Bourgogne | 248900524 | ❔ | ❌ | ❌ |
+| CC | CC de la Vanne et du Pays d'Othe | 248900664 | ❔ | ❌ | ❌ |
+| CC | CC du Gâtinais en Bourgogne | 248900748 | ❔ | ❌ | ❌ |
+| CC | CC Yonne Nord | 248900896 | ❔ | ❌ | ❌ |
+| CC | CC du Jovinien | 248900938 | ❔ | ❌ | ❌ |
+| Département | Territoire de Belfort | 90 | ❔ | ❌ | ❌ |
+| CA | CA Grand Belfort | 200069052 | ❔ | ❌ | ❌ |
+| CC | CC des Vosges du Sud | 200069060 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Territoire | 249000241 | ❔ | ❌ | ❌ |

--- a/couverture/28_Normandie.md
+++ b/couverture/28_Normandie.md
@@ -1,0 +1,85 @@
+# Couverture des aides en Normandie (28)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Normandie | 28 | ❔ | ❌ | ❌ |
+| Département | Calvados | 14 | ❔ | ❌ | ❌ |
+| CC | CC Normandie-Cabourg-Pays d'Auge | 200065563 | ❔ | ❌ | ❌ |
+| CC | CC Val ès Dunes | 200065589 | ❔ | ❌ | ❌ |
+| CU | CU Caen la Mer | 200065597 | ✅ | ✅ | ❌ |
+| CC | CC Cingal-Suisse Normande | 200066710 | ❔ | ❌ | ❌ |
+| CC | CC Vallées de l'Orne et de l'Odon | 200066728 | ✅ | ✅ | ❌ |
+| CC | CC Isigny-Omaha Intercom | 200066801 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Honfleur-Beuzeville | 200066827 | ✅ | ✅ | ❌ |
+| CC | CC Intercom de la Vire au Noireau | 200068799 | ❔ | ❌ | ❌ |
+| CC | CC Seulles Terre et Mer | 200069516 | ❔ | ❌ | ❌ |
+| CC | CC Pré-Bocage Intercom | 200069524 | ❔ | ❌ | ❌ |
+| CA | CA Lisieux Normandie | 200069532 | ❔ | ❌ | ❌ |
+| CC | CC Coeur Côte Fleurie | 241400415 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Falaise | 241400514 | ❔ | ❌ | ❌ |
+| CC | CC de Bayeux Intercom | 241400555 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Nacre | 241400860 | ❔ | ❌ | ❌ |
+| CC | CC Terre d'Auge | 241400878 | ❔ | ❌ | ❌ |
+| Département | Eure | 27 | ❔ | ❌ | ❌ |
+| CA | CA Agglo du Pays de Dreux | 200040277 | ❔ | ❌ | ❌ |
+| CC | CC de Pont-Audemer / Val de Risle | 200065787 | ❔ | ❌ | ❌ |
+| CC | CC Lieuvin Pays d'Auge | 200066017 | ❔ | ❌ | ❌ |
+| CC | CC Roumois Seine | 200066405 | ❔ | ❌ | ❌ |
+| CC | CC Intercom Bernay Terres de Normandie | 200066413 | ❔ | ❌ | ❌ |
+| CC | CC Interco Normandie Sud Eure | 200066462 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Honfleur-Beuzeville | 200066827 | ✅ | ✅ | ❌ |
+| CC | CC des Quatre Rivières en Bray | 200069730 | ❔ | ❌ | ❌ |
+| CC | CC Lyons Andelle | 200070142 | ❔ | ❌ | ❌ |
+| CA | CA Evreux Portes de Normandie | 200071454 | ❔ | ❌ | ❌ |
+| CC | CC du Vexin Normand | 200071843 | ❔ | ❌ | ❌ |
+| CA | CA Seine Normandie Agglomération | 200072312 | ❔ | ❌ | ❌ |
+| CA | CA Seine-Eure | 200089456 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Conches | 242700276 | ❔ | ❌ | ❌ |
+| CC | CC du Pays du Neubourg | 242700607 | ❔ | ❌ | ❌ |
+| Département | Manche | 50 | ❔ | ❌ | ❌ |
+| CC | CC de Granville, Terre et Mer | 200042604 | ❔ | ❌ | ❌ |
+| CC | CC de la Baie du Cotentin | 200042729 | ❔ | ❌ | ❌ |
+| CC | CC de Villedieu Intercom | 200043354 | ❔ | ❌ | ❌ |
+| CA | CA Saint-Lô Agglo | 200066389 | ✅ | ✅ | ❌ |
+| CC | CC Coutances Mer et Bocage | 200067023 | ❔ | ❌ | ❌ |
+| CC | CC Côte Ouest Centre Manche | 200067031 | ❔ | ❌ | ❌ |
+| CA | CA du Cotentin | 200067205 | ✅ | ✅ | ❌ |
+| CA | CA Mont-Saint-Michel-Normandie | 200069425 | ❔ | ❌ | ❌ |
+| Département | Orne | 61 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de la Haute Sarthe | 200035103 | ❔ | ❌ | ❌ |
+| CC | CC des Sources de l'Orne | 200035111 | ❔ | ❌ | ❌ |
+| CA | CA Flers Agglo | 200035814 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Mortagne-au-Perche | 200036069 | ❔ | ❌ | ❌ |
+| CC | CC Coeur du Perche | 200068435 | ❔ | ❌ | ❌ |
+| CC | CC Andaine - Passais | 200068443 | ❔ | ❌ | ❌ |
+| CC | CC Terres d'Argentan Interco | 200068450 | ❔ | ❌ | ❌ |
+| CC | CC des Pays de L'Aigle | 200068468 | ❔ | ❌ | ❌ |
+| CC | CC des Hauts du Perche | 200068856 | ❔ | ❌ | ❌ |
+| CC | CC des Vallées d'Auge et du Merlerault | 200069458 | ❔ | ❌ | ❌ |
+| CC | CC des Collines du Perche Normand | 200071504 | ❔ | ❌ | ❌ |
+| CC | CC Domfront Tinchebray Interco | 200071520 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Fertois et du Bocage Carrougien | 200071652 | ❔ | ❌ | ❌ |
+| CC | CC Maine Saosnois | 200072676 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Orne | 246100390 | ❔ | ❌ | ❌ |
+| CU | CU d'Alençon | 246100663 | ❔ | ❌ | ❌ |
+| Département | Seine-Maritime | 76 | ❔ | ❌ | ❌ |
+| CA | CA Caux Seine Agglo | 200010700 | ❔ | ❌ | ❌ |
+| METRO | Métropole Rouen Normandie | 200023414 | ✅ | ✅ | ❌ |
+| CC | CC Roumois Seine | 200066405 | ❔ | ❌ | ❌ |
+| CC | CC Terroir de Caux | 200068534 | ❔ | ❌ | ❌ |
+| CC | CC Interrégionale Aumale - Blangy-sur-Bresle | 200069722 | ❔ | ❌ | ❌ |
+| CC | CC des Quatre Rivières en Bray | 200069730 | ❔ | ❌ | ❌ |
+| CA | CA Fécamp Caux Littoral Agglomération | 200069821 | ❔ | ❌ | ❌ |
+| CC | CC de la Côte d'Albâtre | 200069839 | ✅ | ✅ | ❌ |
+| CC | CC Plateau de Caux | 200069847 | ❔ | ❌ | ❌ |
+| CC | CC Bray-Eawy | 200070068 | ❔ | ❌ | ❌ |
+| CC | CC Inter-Caux-Vexin | 200070449 | ❔ | ❌ | ❌ |
+| CU | CU Le Havre Seine Métropole | 200084952 | ❔ | ❌ | ❌ |
+| CC | CC Campagne-de-Caux | 247600505 | ❔ | ❌ | ❌ |
+| CC | CC des Villes Soeurs | 247600588 | ✅ | ✅ | ❌ |
+| CC | CC de Londinières | 247600604 | ❔ | ❌ | ❌ |
+| CC | CC Yvetot Normandie | 247600620 | ❔ | ❌ | ❌ |
+| CC | CC Caux - Austreberthe | 247600646 | ❔ | ❌ | ❌ |
+| CC | CC Falaises du Talou | 247600729 | ❔ | ❌ | ❌ |
+| CA | CA de la Région Dieppoise | 247600786 | ❔ | ❌ | ❌ |

--- a/couverture/32_Hauts-de-France.md
+++ b/couverture/32_Hauts-de-France.md
@@ -1,0 +1,106 @@
+# Couverture des aides en Hauts-de-France (32)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Hauts-de-France | 32 | ❔ | ❌ | ❌ |
+| Département | Aisne | 02 | ❔ | ❌ | ❌ |
+| CC | CC du Val de l'Oise | 200040426 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Laon | 200043495 | ❔ | ❌ | ❌ |
+| CC | CC de l'Est de la Somme | 200070985 | ❔ | ❌ | ❌ |
+| CC | CC Picardie des Châteaux | 200071769 | ❔ | ❌ | ❌ |
+| CA | CA Chauny Tergnier La Fère | 200071785 | ❔ | ❌ | ❌ |
+| CA | CA du Saint-Quentinois | 200071892 | ❔ | ❌ | ❌ |
+| CC | CC Thiérache Sambre et Oise | 200071983 | ❔ | ❌ | ❌ |
+| CC | CC Retz en Valois | 200071991 | ❔ | ❌ | ❌ |
+| CA | CA de la Région de Château-Thierry | 200072031 | ❔ | ❌ | ❌ |
+| CC | CC de la Thiérache du Centre | 240200444 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de la Serre | 240200469 | ❔ | ❌ | ❌ |
+| CA | CA GrandSoissons Agglomération | 240200477 | ❔ | ❌ | ❌ |
+| CC | CC du Pays du Vermandois | 240200493 | ❔ | ❌ | ❌ |
+| CC | CC du Val de l'Aisne | 240200501 | ❔ | ❌ | ❌ |
+| CC | CC du Canton d'Oulchy-le-Château | 240200519 | ❔ | ❌ | ❌ |
+| CC | CC de la Champagne Picarde | 240200576 | ❔ | ❌ | ❌ |
+| CC | CC du Canton de Charly-sur-Marne | 240200584 | ❔ | ❌ | ❌ |
+| CC | CC du Chemin des Dames | 240200592 | ❔ | ❌ | ❌ |
+| CC | CC des Trois Rivières | 240200600 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de la Thiérache | 240200634 | ❔ | ❌ | ❌ |
+| Département | Nord | 59 | ❔ | ❌ | ❌ |
+| CA | CA du Caudrésis et du Catésis | 200030633 | ❔ | ❌ | ❌ |
+| CA | CA Coeur de Flandre | 200040947 | ❔ | ❌ | ❌ |
+| CC | CC des Hauts de Flandre | 200040954 | ❔ | ❌ | ❌ |
+| CC | CC Pévèle-Carembault | 200041960 | ✅ | ✅ | ❌ |
+| CA | CA de la Porte du Hainaut | 200042190 | ✅ | ✅ | ❌ |
+| CC | CC Coeur de l'Avesnois | 200043263 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Mormal | 200043321 | ✅ | ✅ | ❌ |
+| CA | CA Maubeuge Val de Sambre | 200043396 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Avesnois | 200043404 | ❔ | ❌ | ❌ |
+| CA | CA Douaisis Agglo | 200044618 | ❔ | ❌ | ❌ |
+| CA | CA de Cambrai | 200068500 | ✅ | ✅ | ❌ |
+| METRO | Métropole Européenne de Lille | 200093201 | ❔ | ❌ | ❌ |
+| CU | CU de Dunkerque | 245900428 | ✅ | ✅ | ❌ |
+| CC | CC Flandre Lys | 245900758 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Solesmois | 245901038 | ❔ | ❌ | ❌ |
+| CA | CA Coeur d'Ostrevent | 245901152 | ✅ | ✅ | ❌ |
+| CA | CA Valenciennes Métropole | 245901160 | ✅ | ✅ | ❌ |
+| Département | Oise | 60 | ✅ | ✅ | ❌ |
+| CC | CC Senlis Sud Oise | 200066975 | ❔ | ❌ | ❌ |
+| CA | CA de la Région de Compiègne et de la Basse Automne | 200067965 | ❔ | ❌ | ❌ |
+| CC | CC Thelloise | 200067973 | ❔ | ❌ | ❌ |
+| CA | CA du Beauvaisis | 200067999 | ✅ | ✅ | ❌ |
+| CC | CC de l'Oise Picarde | 200068005 | ❔ | ❌ | ❌ |
+| CA | CA Creil Sud Oise | 200068047 | ❔ | ❌ | ❌ |
+| CC | CC du Liancourtois | 246000129 | ❔ | ❌ | ❌ |
+| CC | CC du Clermontois | 246000376 | ❔ | ❌ | ❌ |
+| CC | CC du Plateau Picard | 246000566 | ❔ | ❌ | ❌ |
+| CC | CC des Sablons | 246000582 | ❔ | ❌ | ❌ |
+| CC | CC du Vexin-Thelle | 246000707 | ❔ | ❌ | ❌ |
+| CC | CC des Lisières de l'Oise | 246000749 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Noyonnais | 246000756 | ❔ | ❌ | ❌ |
+| CC | CC de l'Aire Cantilienne | 246000764 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Vallées | 246000772 | ❔ | ❌ | ❌ |
+| CC | CC de la Picardie Verte | 246000848 | ❔ | ❌ | ❌ |
+| CC | CC du Pays des Sources | 246000855 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Valois | 246000871 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine d'Estrées | 246000897 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Bray | 246000913 | ❔ | ❌ | ❌ |
+| CC | CC des Pays d'Oise et d'Halatte | 246000921 | ❔ | ❌ | ❌ |
+| Département | Pas-de-Calais | 62 | ❔ | ❌ | ❌ |
+| CC | CC de Desvres-Samer | 200018083 | ❔ | ❌ | ❌ |
+| CU | CU d'Arras | 200033579 | ✅ | ✅ | ❌ |
+| CC | CC du Sud Artois | 200035442 | ❔ | ❌ | ❌ |
+| CC | CC des 7 Vallées | 200044030 | ✅ | ✅ | ❌ |
+| CC | CC Osartis Marquion | 200044048 | ✅ | ✅ | ❌ |
+| CA | CA des Deux Baies en Montreuillois | 200069029 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Saint-Omer | 200069037 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Pays du Montreuillois | 200069235 | ❔ | ❌ | ❌ |
+| CC | CC des Campagnes de l'Artois | 200069482 | ✅ | ✅ | ❌ |
+| CC | CC du Ternois | 200069672 | ❔ | ❌ | ❌ |
+| CA | CA de Béthune-Bruay, Artois-Lys Romane | 200072460 | ❔ | ❌ | ❌ |
+| CC | CC Pays d'Opale | 200072478 | ❔ | ❌ | ❌ |
+| CA | CA Grand Calais Terres et Mers | 200090751 | ✅ | ✅ | ❌ |
+| CC | CC Flandre Lys | 245900758 | ❔ | ❌ | ❌ |
+| CA | CA d'Hénin-Carvin | 246200299 | ❔ | ❌ | ❌ |
+| CA | CA de Lens - Liévin | 246200364 | ❔ | ❌ | ❌ |
+| CC | CC de la Terre des Deux Caps | 246200380 | ✅ | ✅ | ❌ |
+| CA | CA du Boulonnais | 246200729 | ✅ | ✅ | ❌ |
+| CC | CC de la Région d'Audruicq | 246200844 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lumbres | 246201016 | ✅ | ✅ | ❌ |
+| Département | Somme | 80 | ✅ | ✅ | ❌ |
+| CC | CC de la Haute Somme (Combles - Péronne - Roisel) | 200037059 | ❔ | ❌ | ❌ |
+| CC | CC du Ternois | 200069672 | ❔ | ❌ | ❌ |
+| CC | CC Interrégionale Aumale - Blangy-sur-Bresle | 200069722 | ❔ | ❌ | ❌ |
+| CC | CC Terre de Picardie | 200070928 | ❔ | ❌ | ❌ |
+| CC | CC Ponthieu-Marquenterre | 200070936 | ❔ | ❌ | ❌ |
+| CC | CC du Vimeu | 200070944 | ❔ | ❌ | ❌ |
+| CC | CC du Territoire Nord Picardie | 200070951 | ❔ | ❌ | ❌ |
+| CC | CC Avre Luce Noye | 200070969 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Roye | 200070977 | ✅ | ✅ | ❌ |
+| CC | CC de l'Est de la Somme | 200070985 | ❔ | ❌ | ❌ |
+| CA | CA de la Baie de Somme | 200070993 | ❔ | ❌ | ❌ |
+| CC | CC Somme Sud-Ouest | 200071181 | ✅ | ✅ | ❌ |
+| CC | CC Nièvre et Somme | 200071223 | ❔ | ❌ | ❌ |
+| CC | CC des Villes Soeurs | 247600588 | ✅ | ✅ | ❌ |
+| CC | CC du Val de Somme | 248000499 | ❔ | ❌ | ❌ |
+| CA | CA Amiens Métropole | 248000531 | ❔ | ❌ | ❌ |
+| CC | CC du Pays du Coquelicot | 248000747 | ❔ | ❌ | ❌ |

--- a/couverture/32_Hauts-de-France.md
+++ b/couverture/32_Hauts-de-France.md
@@ -1,106 +1,105 @@
 # Couverture des aides en Hauts-de-France (32)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Hauts-de-France | 32 | ❔ | ❌ | ❌ |
-| Département | Aisne | 02 | ❔ | ❌ | ❌ |
-| CC | CC du Val de l'Oise | 200040426 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Laon | 200043495 | ❔ | ❌ | ❌ |
-| CC | CC de l'Est de la Somme | 200070985 | ❔ | ❌ | ❌ |
-| CC | CC Picardie des Châteaux | 200071769 | ❔ | ❌ | ❌ |
-| CA | CA Chauny Tergnier La Fère | 200071785 | ❔ | ❌ | ❌ |
-| CA | CA du Saint-Quentinois | 200071892 | ❔ | ❌ | ❌ |
-| CC | CC Thiérache Sambre et Oise | 200071983 | ❔ | ❌ | ❌ |
-| CC | CC Retz en Valois | 200071991 | ❔ | ❌ | ❌ |
-| CA | CA de la Région de Château-Thierry | 200072031 | ❔ | ❌ | ❌ |
-| CC | CC de la Thiérache du Centre | 240200444 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de la Serre | 240200469 | ❔ | ❌ | ❌ |
-| CA | CA GrandSoissons Agglomération | 240200477 | ❔ | ❌ | ❌ |
-| CC | CC du Pays du Vermandois | 240200493 | ❔ | ❌ | ❌ |
-| CC | CC du Val de l'Aisne | 240200501 | ❔ | ❌ | ❌ |
-| CC | CC du Canton d'Oulchy-le-Château | 240200519 | ❔ | ❌ | ❌ |
-| CC | CC de la Champagne Picarde | 240200576 | ❔ | ❌ | ❌ |
-| CC | CC du Canton de Charly-sur-Marne | 240200584 | ❔ | ❌ | ❌ |
-| CC | CC du Chemin des Dames | 240200592 | ❔ | ❌ | ❌ |
-| CC | CC des Trois Rivières | 240200600 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de la Thiérache | 240200634 | ❔ | ❌ | ❌ |
-| Département | Nord | 59 | ❔ | ❌ | ❌ |
-| CA | CA du Caudrésis et du Catésis | 200030633 | ❔ | ❌ | ❌ |
-| CA | CA Coeur de Flandre | 200040947 | ❔ | ❌ | ❌ |
-| CC | CC des Hauts de Flandre | 200040954 | ❔ | ❌ | ❌ |
-| CC | CC Pévèle-Carembault | 200041960 | ✅ | ✅ | ❌ |
-| CA | CA de la Porte du Hainaut | 200042190 | ✅ | ✅ | ❌ |
-| CC | CC Coeur de l'Avesnois | 200043263 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Mormal | 200043321 | ✅ | ✅ | ❌ |
-| CA | CA Maubeuge Val de Sambre | 200043396 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Avesnois | 200043404 | ❔ | ❌ | ❌ |
-| CA | CA Douaisis Agglo | 200044618 | ❔ | ❌ | ❌ |
-| CA | CA de Cambrai | 200068500 | ✅ | ✅ | ❌ |
-| METRO | Métropole Européenne de Lille | 200093201 | ❔ | ❌ | ❌ |
-| CU | CU de Dunkerque | 245900428 | ✅ | ✅ | ❌ |
-| CC | CC Flandre Lys | 245900758 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Solesmois | 245901038 | ❔ | ❌ | ❌ |
-| CA | CA Coeur d'Ostrevent | 245901152 | ✅ | ✅ | ❌ |
-| CA | CA Valenciennes Métropole | 245901160 | ✅ | ✅ | ❌ |
-| Département | Oise | 60 | ✅ | ✅ | ❌ |
-| CC | CC Senlis Sud Oise | 200066975 | ❔ | ❌ | ❌ |
-| CA | CA de la Région de Compiègne et de la Basse Automne | 200067965 | ❔ | ❌ | ❌ |
-| CC | CC Thelloise | 200067973 | ❔ | ❌ | ❌ |
-| CA | CA du Beauvaisis | 200067999 | ✅ | ✅ | ❌ |
-| CC | CC de l'Oise Picarde | 200068005 | ❔ | ❌ | ❌ |
-| CA | CA Creil Sud Oise | 200068047 | ❔ | ❌ | ❌ |
-| CC | CC du Liancourtois | 246000129 | ❔ | ❌ | ❌ |
-| CC | CC du Clermontois | 246000376 | ❔ | ❌ | ❌ |
-| CC | CC du Plateau Picard | 246000566 | ❔ | ❌ | ❌ |
-| CC | CC des Sablons | 246000582 | ❔ | ❌ | ❌ |
-| CC | CC du Vexin-Thelle | 246000707 | ❔ | ❌ | ❌ |
-| CC | CC des Lisières de l'Oise | 246000749 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Noyonnais | 246000756 | ❔ | ❌ | ❌ |
-| CC | CC de l'Aire Cantilienne | 246000764 | ❔ | ❌ | ❌ |
-| CC | CC des Deux Vallées | 246000772 | ❔ | ❌ | ❌ |
-| CC | CC de la Picardie Verte | 246000848 | ❔ | ❌ | ❌ |
-| CC | CC du Pays des Sources | 246000855 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Valois | 246000871 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine d'Estrées | 246000897 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Bray | 246000913 | ❔ | ❌ | ❌ |
-| CC | CC des Pays d'Oise et d'Halatte | 246000921 | ❔ | ❌ | ❌ |
-| Département | Pas-de-Calais | 62 | ❔ | ❌ | ❌ |
-| CC | CC de Desvres-Samer | 200018083 | ❔ | ❌ | ❌ |
-| CU | CU d'Arras | 200033579 | ✅ | ✅ | ❌ |
-| CC | CC du Sud Artois | 200035442 | ❔ | ❌ | ❌ |
-| CC | CC des 7 Vallées | 200044030 | ✅ | ✅ | ❌ |
-| CC | CC Osartis Marquion | 200044048 | ✅ | ✅ | ❌ |
-| CA | CA des Deux Baies en Montreuillois | 200069029 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Saint-Omer | 200069037 | ❔ | ❌ | ❌ |
-| CC | CC du Haut Pays du Montreuillois | 200069235 | ❔ | ❌ | ❌ |
-| CC | CC des Campagnes de l'Artois | 200069482 | ✅ | ✅ | ❌ |
-| CC | CC du Ternois | 200069672 | ❔ | ❌ | ❌ |
-| CA | CA de Béthune-Bruay, Artois-Lys Romane | 200072460 | ❔ | ❌ | ❌ |
-| CC | CC Pays d'Opale | 200072478 | ❔ | ❌ | ❌ |
-| CA | CA Grand Calais Terres et Mers | 200090751 | ✅ | ✅ | ❌ |
-| CC | CC Flandre Lys | 245900758 | ❔ | ❌ | ❌ |
-| CA | CA d'Hénin-Carvin | 246200299 | ❔ | ❌ | ❌ |
-| CA | CA de Lens - Liévin | 246200364 | ❔ | ❌ | ❌ |
-| CC | CC de la Terre des Deux Caps | 246200380 | ✅ | ✅ | ❌ |
-| CA | CA du Boulonnais | 246200729 | ✅ | ✅ | ❌ |
-| CC | CC de la Région d'Audruicq | 246200844 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Lumbres | 246201016 | ✅ | ✅ | ❌ |
-| Département | Somme | 80 | ✅ | ✅ | ❌ |
-| CC | CC de la Haute Somme (Combles - Péronne - Roisel) | 200037059 | ❔ | ❌ | ❌ |
-| CC | CC du Ternois | 200069672 | ❔ | ❌ | ❌ |
-| CC | CC Interrégionale Aumale - Blangy-sur-Bresle | 200069722 | ❔ | ❌ | ❌ |
-| CC | CC Terre de Picardie | 200070928 | ❔ | ❌ | ❌ |
-| CC | CC Ponthieu-Marquenterre | 200070936 | ❔ | ❌ | ❌ |
-| CC | CC du Vimeu | 200070944 | ❔ | ❌ | ❌ |
-| CC | CC du Territoire Nord Picardie | 200070951 | ❔ | ❌ | ❌ |
-| CC | CC Avre Luce Noye | 200070969 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Roye | 200070977 | ✅ | ✅ | ❌ |
-| CC | CC de l'Est de la Somme | 200070985 | ❔ | ❌ | ❌ |
-| CA | CA de la Baie de Somme | 200070993 | ❔ | ❌ | ❌ |
-| CC | CC Somme Sud-Ouest | 200071181 | ✅ | ✅ | ❌ |
-| CC | CC Nièvre et Somme | 200071223 | ❔ | ❌ | ❌ |
-| CC | CC des Villes Soeurs | 247600588 | ✅ | ✅ | ❌ |
-| CC | CC du Val de Somme | 248000499 | ❔ | ❌ | ❌ |
-| CA | CA Amiens Métropole | 248000531 | ❔ | ❌ | ❌ |
-| CC | CC du Pays du Coquelicot | 248000747 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                                 | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | --------------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Hauts-de-France                                     | 32        | ❔               | ❌        | ❌    |
+| Département | Aisne                                               | 02        | ❔               | ❌        | ❌    |
+| CC          | CC du Val de l'Oise                                 | 200040426 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Laon                                  | 200043495 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Est de la Somme                             | 200070985 | ❔               | ❌        | ❌    |
+| CC          | CC Picardie des Châteaux                            | 200071769 | ❔               | ❌        | ❌    |
+| CA          | CA Chauny Tergnier La Fère                          | 200071785 | ❔               | ❌        | ❌    |
+| CA          | CA du Saint-Quentinois                              | 200071892 | ❔               | ❌        | ❌    |
+| CC          | CC Thiérache Sambre et Oise                         | 200071983 | ❔               | ❌        | ❌    |
+| CC          | CC Retz en Valois                                   | 200071991 | ❔               | ❌        | ❌    |
+| CA          | CA de la Région de Château-Thierry                  | 200072031 | ❔               | ❌        | ❌    |
+| CC          | CC de la Thiérache du Centre                        | 240200444 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de la Serre                              | 240200469 | ❔               | ❌        | ❌    |
+| CA          | CA GrandSoissons Agglomération                      | 240200477 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays du Vermandois                            | 240200493 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de l'Aisne                                | 240200501 | ❔               | ❌        | ❌    |
+| CC          | CC du Canton d'Oulchy-le-Château                    | 240200519 | ❔               | ❌        | ❌    |
+| CC          | CC de la Champagne Picarde                          | 240200576 | ❔               | ❌        | ❌    |
+| CC          | CC du Canton de Charly-sur-Marne                    | 240200584 | ❔               | ❌        | ❌    |
+| CC          | CC du Chemin des Dames                              | 240200592 | ❔               | ❌        | ❌    |
+| CC          | CC des Trois Rivières                               | 240200600 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de la Thiérache                       | 240200634 | ❔               | ❌        | ❌    |
+| Département | Nord                                                | 59        | ❔               | ❌        | ❌    |
+| CA          | CA du Caudrésis et du Catésis                       | 200030633 | ❔               | ❌        | ❌    |
+| CA          | CA Coeur de Flandre                                 | 200040947 | ❔               | ❌        | ❌    |
+| CC          | CC des Hauts de Flandre                             | 200040954 | ❔               | ❌        | ❌    |
+| CC          | CC Pévèle-Carembault                                | 200041960 | ✅               | ✅        | ❌    |
+| CA          | CA de la Porte du Hainaut                           | 200042190 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur de l'Avesnois                              | 200043263 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Mormal                                | 200043321 | ✅               | ✅        | ❌    |
+| CA          | CA Maubeuge Val de Sambre                           | 200043396 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Avesnois                                  | 200043404 | ❔               | ❌        | ❌    |
+| CA          | CA Douaisis Agglo                                   | 200044618 | ❔               | ❌        | ❌    |
+| CA          | CA de Cambrai                                       | 200068500 | ✅               | ✅        | ❌    |
+| METRO       | Métropole Européenne de Lille                       | 200093201 | ❔               | ❌        | ❌    |
+| CU          | CU de Dunkerque                                     | 245900428 | ✅               | ✅        | ❌    |
+| CC          | CC Flandre Lys                                      | 245900758 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Solesmois                                | 245901038 | ❔               | ❌        | ❌    |
+| CA          | CA Coeur d'Ostrevent                                | 245901152 | ✅               | ✅        | ❌    |
+| CA          | CA Valenciennes Métropole                           | 245901160 | ✅               | ✅        | ❌    |
+| Département | Oise                                                | 60        | ✅               | ✅        | ❌    |
+| CC          | CC Senlis Sud Oise                                  | 200066975 | ❔               | ❌        | ❌    |
+| CA          | CA de la Région de Compiègne et de la Basse Automne | 200067965 | ❔               | ❌        | ❌    |
+| CC          | CC Thelloise                                        | 200067973 | ❔               | ❌        | ❌    |
+| CA          | CA du Beauvaisis                                    | 200067999 | ✅               | ✅        | ❌    |
+| CC          | CC de l'Oise Picarde                                | 200068005 | ❔               | ❌        | ❌    |
+| CA          | CA Creil Sud Oise                                   | 200068047 | ❔               | ❌        | ❌    |
+| CC          | CC du Liancourtois                                  | 246000129 | ❔               | ❌        | ❌    |
+| CC          | CC du Clermontois                                   | 246000376 | ❔               | ❌        | ❌    |
+| CC          | CC du Plateau Picard                                | 246000566 | ❔               | ❌        | ❌    |
+| CC          | CC des Sablons                                      | 246000582 | ❔               | ❌        | ❌    |
+| CC          | CC du Vexin-Thelle                                  | 246000707 | ❔               | ❌        | ❌    |
+| CC          | CC des Lisières de l'Oise                           | 246000749 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Noyonnais                                | 246000756 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Aire Cantilienne                            | 246000764 | ❔               | ❌        | ❌    |
+| CC          | CC des Deux Vallées                                 | 246000772 | ❔               | ❌        | ❌    |
+| CC          | CC de la Picardie Verte                             | 246000848 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays des Sources                              | 246000855 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Valois                                | 246000871 | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine d'Estrées                           | 246000897 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Bray                                  | 246000913 | ❔               | ❌        | ❌    |
+| CC          | CC des Pays d'Oise et d'Halatte                     | 246000921 | ❔               | ❌        | ❌    |
+| Département | Pas-de-Calais                                       | 62        | ❔               | ❌        | ❌    |
+| CC          | CC de Desvres-Samer                                 | 200018083 | ❔               | ❌        | ❌    |
+| CU          | CU d'Arras                                          | 200033579 | ✅               | ✅        | ❌    |
+| CC          | CC du Sud Artois                                    | 200035442 | ❔               | ❌        | ❌    |
+| CC          | CC des 7 Vallées                                    | 200044030 | ✅               | ✅        | ❌    |
+| CC          | CC Osartis Marquion                                 | 200044048 | ✅               | ✅        | ❌    |
+| CA          | CA des Deux Baies en Montreuillois                  | 200069029 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Saint-Omer                            | 200069037 | ❔               | ❌        | ❌    |
+| CC          | CC du Haut Pays du Montreuillois                    | 200069235 | ❔               | ❌        | ❌    |
+| CC          | CC des Campagnes de l'Artois                        | 200069482 | ✅               | ✅        | ❌    |
+| CC          | CC du Ternois                                       | 200069672 | ❔               | ❌        | ❌    |
+| CA          | CA de Béthune-Bruay, Artois-Lys Romane              | 200072460 | ❔               | ❌        | ❌    |
+| CC          | CC Pays d'Opale                                     | 200072478 | ❔               | ❌        | ❌    |
+| CA          | CA Grand Calais Terres et Mers                      | 200090751 | ✅               | ✅        | ❌    |
+| CC          | CC Flandre Lys                                      | 245900758 | ❔               | ❌        | ❌    |
+| CA          | CA d'Hénin-Carvin                                   | 246200299 | ❔               | ❌        | ❌    |
+| CA          | CA de Lens - Liévin                                 | 246200364 | ❔               | ❌        | ❌    |
+| CC          | CC de la Terre des Deux Caps                        | 246200380 | ✅               | ✅        | ❌    |
+| CA          | CA du Boulonnais                                    | 246200729 | ✅               | ✅        | ❌    |
+| CC          | CC de la Région d'Audruicq                          | 246200844 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Lumbres                               | 246201016 | ✅               | ✅        | ❌    |
+| Département | Somme                                               | 80        | ✅               | ✅        | ❌    |
+| CC          | CC de la Haute Somme (Combles - Péronne - Roisel)   | 200037059 | ❔               | ❌        | ❌    |
+| CC          | CC du Ternois                                       | 200069672 | ❔               | ❌        | ❌    |
+| CC          | CC Interrégionale Aumale - Blangy-sur-Bresle        | 200069722 | ❔               | ❌        | ❌    |
+| CC          | CC Terre de Picardie                                | 200070928 | ❔               | ❌        | ❌    |
+| CC          | CC Ponthieu-Marquenterre                            | 200070936 | ❔               | ❌        | ❌    |
+| CC          | CC du Vimeu                                         | 200070944 | ❔               | ❌        | ❌    |
+| CC          | CC du Territoire Nord Picardie                      | 200070951 | ❔               | ❌        | ❌    |
+| CC          | CC Avre Luce Noye                                   | 200070969 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Roye                                    | 200070977 | ✅               | ✅        | ❌    |
+| CC          | CC de l'Est de la Somme                             | 200070985 | ❔               | ❌        | ❌    |
+| CA          | CA de la Baie de Somme                              | 200070993 | ❔               | ❌        | ❌    |
+| CC          | CC Somme Sud-Ouest                                  | 200071181 | ✅               | ✅        | ❌    |
+| CC          | CC Nièvre et Somme                                  | 200071223 | ✅               | ✅        | ✅    |
+| CC          | CC des Villes Soeurs                                | 247600588 | ✅               | ✅        | ❌    |
+| CC          | CC du Val de Somme                                  | 248000499 | ❔               | ❌        | ❌    |
+| CA          | CA Amiens Métropole                                 | 248000531 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays du Coquelicot                            | 248000747 | ❔               | ❌        | ❌    |

--- a/couverture/44_Grand_Est.md
+++ b/couverture/44_Grand_Est.md
@@ -1,0 +1,175 @@
+# Couverture des aides en Grand Est (44)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Grand Est | 44 | ✅ | ✅ | ❌ |
+| Département | Ardennes | 08 | ❔ | ❌ | ❌ |
+| CC | CC Ardennes Thiérache | 200041622 | ❔ | ❌ | ❌ |
+| CA | CA Ardenne Métropole | 200041630 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Rethélois | 200043156 | ❔ | ❌ | ❌ |
+| CC | CC Vallées et Plateau d'Ardenne | 200067759 | ❔ | ❌ | ❌ |
+| CC | CC Ardenne, Rives de Meuse | 240800821 | ❔ | ❌ | ❌ |
+| CC | CC des Portes du Luxembourg | 240800847 | ✅ | ✅ | ❌ |
+| CC | CC des Crêtes Préardennaises | 240800862 | ✅ | ✅ | ❌ |
+| CC | CC de l'Argonne Ardennaise | 240800920 | ❔ | ❌ | ❌ |
+| Département | Aube | 10 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de Romilly sur Seine | 200000545 | ✅ | ✅ | ❌ |
+| CC | CC du Nogentais | 200006716 | ❔ | ❌ | ❌ |
+| CC | CC des Lacs de Champagne | 200040137 | ❔ | ❌ | ❌ |
+| CC | CC de Vendeuvre-Soulaines | 200066892 | ❔ | ❌ | ❌ |
+| CC | CC du Barséquanais en Champagne | 200069003 | ❔ | ❌ | ❌ |
+| CA | CA Troyes Champagne Métropole | 200069250 | ❔ | ❌ | ❌ |
+| CC | CC Seine et Aube | 200070126 | ❔ | ❌ | ❌ |
+| CC | CC du Chaourçois et du Val d'Armance | 200071041 | ❔ | ❌ | ❌ |
+| CC | CC d'Arcis, Mailly, Ramerupt | 200071777 | ❔ | ❌ | ❌ |
+| CC | CC Forêts, Lacs, Terres en Champagne | 241000223 | ❔ | ❌ | ❌ |
+| CC | CC de la Région de Bar sur Aube | 241000405 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Othe | 241000447 | ❔ | ❌ | ❌ |
+| CC | CC de l'Orvin et de l'Ardusson | 241000488 | ❔ | ❌ | ❌ |
+| Département | Marne | 51 | ❔ | ❌ | ❌ |
+| CC | CC de Vitry, Champagne et Der | 200034718 | ❔ | ❌ | ❌ |
+| CC | CC de la Région de Suippes | 200042620 | ❔ | ❌ | ❌ |
+| CC | CC de l'Argonne Champenoise | 200042703 | ❔ | ❌ | ❌ |
+| CC | CC Perthois-Bocage et Der | 200042992 | ❔ | ❌ | ❌ |
+| CC | CC de la Moivre à la Coole | 200043438 | ❔ | ❌ | ❌ |
+| CC | CC de Sézanne-Sud Ouest Marnais | 200066835 | ❔ | ❌ | ❌ |
+| CC | CC des Paysages de la Champagne | 200066850 | ❔ | ❌ | ❌ |
+| CA | CA de Châlons-en-Champagne | 200066876 | ❔ | ❌ | ❌ |
+| CU | CU du Grand Reims | 200067213 | ✅ | ✅ | ❌ |
+| CC | CC Côtes de Champagne et Val de Saulx | 200067379 | ❔ | ❌ | ❌ |
+| CA | CA Epernay, Coteaux et Plaine de Champagne | 200067684 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Saint-Dizier Der et Vallées | 200068666 | ❔ | ❌ | ❌ |
+| CC | CC de la Grande Vallée de la Marne | 245100615 | ❔ | ❌ | ❌ |
+| CC | CC de la Brie Champenoise | 245100888 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Marnais | 245100979 | ❔ | ❌ | ❌ |
+| Département | Haute-Marne | 52 | ❔ | ❌ | ❌ |
+| CC | CC d'Auberive Vingeanne et Montsaugeonnais | 200027308 | ❔ | ❌ | ❌ |
+| CC | CC du Bassin de Joinville en Champagne | 200044253 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ouest Vosgien | 200068559 | ✅ | ✅ | ❌ |
+| CA | CA de Chaumont | 200068658 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Saint-Dizier Der et Vallées | 200068666 | ❔ | ❌ | ❌ |
+| CC | CC Meuse Rognon | 200069664 | ❔ | ❌ | ❌ |
+| CC | CC des Savoir-Faire | 200070332 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Langres | 200072999 | ❔ | ❌ | ❌ |
+| CC | CC des Trois Forêts | 245200597 | ❔ | ❌ | ❌ |
+| Département | Meurthe-et-Moselle | 54 | ❔ | ❌ | ❌ |
+| CC | CC du Pays du Saintois | 200035772 | ❔ | ❌ | ❌ |
+| CC | CC du Bassin de Pont-à-Mousson | 200041515 | ❔ | ❌ | ❌ |
+| CC | CC Terre Lorraine du Longuyonnais | 200043693 | ❔ | ❌ | ❌ |
+| CC | CC Meurthe Mortagne Moselle | 200067643 | ❔ | ❌ | ❌ |
+| CC | CC de Vezouze en Piémont | 200069433 | ❔ | ❌ | ❌ |
+| CC | CC Coeur du Pays Haut | 200070290 | ❔ | ❌ | ❌ |
+| CC | CC du Territoire de Lunéville à Baccarat | 200070324 | ❔ | ❌ | ❌ |
+| CC | CC Terres Touloises | 200070563 | ❔ | ❌ | ❌ |
+| CC | CC de Seille et Grand Couronné | 200070589 | ❔ | ❌ | ❌ |
+| CC | CC Mad et Moselle | 200070738 | ❔ | ❌ | ❌ |
+| CC | CC Orne Lorraine Confluences | 200070845 | ✅ | ✅ | ❌ |
+| CA | CA de Saint-Dié-des-Vosges | 200071066 | ❔ | ❌ | ❌ |
+| CC | CC Moselle et Madon | 245400171 | ✅ | ✅ | ❌ |
+| CC | CC des Pays du Sel et du Vermois | 245400189 | ❔ | ❌ | ❌ |
+| CA | CA Grand Longwy Agglomération | 245400262 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Colombey et du Sud Toulois | 245400510 | ❔ | ❌ | ❌ |
+| CC | CC du Bassin de Pompey | 245400601 | ✅ | ✅ | ❌ |
+| METRO | Métropole du Grand Nancy | 245400676 | ❔ | ❌ | ❌ |
+| CC | CC du Pays du Sanon | 245400759 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Haut Val d'Alzette | 245701404 | ✅ | ✅ | ❌ |
+| Département | Meuse | 55 | ❔ | ❌ | ❌ |
+| CA | CA de Bar-le-Duc - Sud Meuse | 200033025 | ❔ | ❌ | ❌ |
+| CC | CC Côtes de Meuse Woëvre | 200034874 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Verdun | 200049187 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de Meuse | 200066108 | ❔ | ❌ | ❌ |
+| CC | CC Argonne-Meuse | 200066116 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Stenay et du Val Dunois | 200066132 | ❔ | ❌ | ❌ |
+| CC | CC de l'Aire à l'Argonne | 200066140 | ❔ | ❌ | ❌ |
+| CC | CC de Commercy - Void - Vaucouleurs | 200066157 | ❔ | ❌ | ❌ |
+| CC | CC Val de Meuse - Voie Sacrée | 200066165 | ❔ | ❌ | ❌ |
+| CC | CC de Damvillers Spincourt | 200066173 | ❔ | ❌ | ❌ |
+| CC | CC Coeur du Pays Haut | 200070290 | ❔ | ❌ | ❌ |
+| CC | CC du Sammiellois | 245500327 | ❔ | ❌ | ❌ |
+| CC | CC du Territoire de Fresnes-en-Woëvre | 245501176 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Revigny-sur-Ornain | 245501184 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Étain | 245501242 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Montmédy | 245501259 | ❔ | ❌ | ❌ |
+| Département | Moselle | 57 | ❔ | ❌ | ❌ |
+| METRO | Metz Métropole | 200039865 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Messin | 200039907 | ❔ | ❌ | ❌ |
+| CC | CC Rives de Moselle | 200039949 | ✅ | ✅ | ❌ |
+| CC | CC Bouzonvillois-Trois Frontières | 200067486 | ❔ | ❌ | ❌ |
+| CA | CA Saint-Avold Synergie | 200067502 | ✅ | ✅ | ❌ |
+| CC | CC Houve - Pays Boulageois | 200067650 | ❔ | ❌ | ❌ |
+| CC | CC Haut Chemin - Pays de Pange | 200067957 | ❔ | ❌ | ❌ |
+| CC | CC Sarrebourg Moselle Sud | 200068146 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Bitche | 200069441 | ❔ | ❌ | ❌ |
+| CC | CC Mad et Moselle | 200070738 | ❔ | ❌ | ❌ |
+| CA | CA Sarreguemines Confluences | 200070746 | ❔ | ❌ | ❌ |
+| CC | CC du District Urbain de Faulquemont (DUF) | 245700133 | ❔ | ❌ | ❌ |
+| CA | CA de Forbach Porte de France | 245700372 | ❔ | ❌ | ❌ |
+| CC | CC de Freyming-Merlebach | 245700398 | ❔ | ❌ | ❌ |
+| CC | CC de Cattenom et Environs | 245700695 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Phalsbourg | 245700950 | ❔ | ❌ | ❌ |
+| CC | CC du Warndt | 245701164 | ❔ | ❌ | ❌ |
+| CC | CC du Saulnois | 245701206 | ❔ | ❌ | ❌ |
+| CA | CA du Val de Fensch | 245701222 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Orne Moselle | 245701271 | ✅ | ✅ | ❌ |
+| CC | CC de l'Arc Mosellan | 245701354 | ❔ | ❌ | ❌ |
+| CA | CA Portes de France-Thionville | 245701362 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Haut Val d'Alzette | 245701404 | ✅ | ✅ | ❌ |
+| Département | Bas-Rhin | 67 | ❔ | ❌ | ❌ |
+| CC | CC Sauer-Pechelbronn | 200013050 | ❔ | ❌ | ❌ |
+| CC | CC du Ried de Marckolsheim | 200030526 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Barr | 200034270 | ✅ | ✅ | ❌ |
+| CC | CC du Kochersberg | 200034635 | ❔ | ❌ | ❌ |
+| CC | CC de l'Outre-Forêt | 200040178 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine du Rhin | 200041283 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Rhénan | 200041325 | ❔ | ❌ | ❌ |
+| CC | CC de Hanau-La Petite Pierre | 200067783 | ❔ | ❌ | ❌ |
+| CC | CC de l'Alsace Bossue | 200067841 | ❔ | ❌ | ❌ |
+| CA | CA de Haguenau | 200067874 | ❔ | ❌ | ❌ |
+| CC | CC du Canton d'Erstein | 200067924 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saverne | 200068112 | ✅ | ✅ | ❌ |
+| CC | CC de la Mossig et du Vignoble | 200068864 | ❔ | ❌ | ❌ |
+| CA | CA Sarreguemines Confluences | 200070746 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de la Bruche | 246700306 | ❔ | ❌ | ❌ |
+| METRO | Eurométropole de Strasbourg | 246700488 | ✅ | ✅ | ❌ |
+| CC | CC des Portes de Rosheim | 246700744 | ✅ | ✅ | ❌ |
+| CC | CC de la Vallée de Villé | 246700777 | ❔ | ❌ | ❌ |
+| CC | CC de la Basse-Zorn | 246700843 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Wissembourg | 246700926 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de la Zorn | 246700959 | ❔ | ❌ | ❌ |
+| CC | CC de Sélestat | 246700967 | ❔ | ❌ | ❌ |
+| CC | CC de la Région de Molsheim-Mutzig | 246701064 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Sainte-Odile | 246701080 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Niederbronn-les-Bains | 246701098 | ❔ | ❌ | ❌ |
+| Département | Haut-Rhin | 68 | ❔ | ❌ | ❌ |
+| CC | CC du Ried de Marckolsheim | 200030526 | ❔ | ❌ | ❌ |
+| CC | CC de Thann-Cernay | 200036465 | ❔ | ❌ | ❌ |
+| CA | CA Mulhouse Alsace Agglomération | 200066009 | ❔ | ❌ | ❌ |
+| CC | CC Alsace Rhin Brisach | 200066025 | ❔ | ❌ | ❌ |
+| CC | CC Sud Alsace Largue | 200066033 | ❔ | ❌ | ❌ |
+| CC | CC Sundgau | 200066041 | ❔ | ❌ | ❌ |
+| CA | CA Saint-Louis Agglomération | 200066058 | ✅ | ✅ | ❌ |
+| CC | CC de la Vallée de Saint-Amarin | 246800205 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Argent | 246800395 | ❔ | ❌ | ❌ |
+| CC | CC du Centre du Haut-Rhin | 246800445 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Rouffach, Vignobles et Châteaux | 246800494 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de Kaysersberg | 246800551 | ❔ | ❌ | ❌ |
+| CC | CC de la Région de Guebwiller | 246800569 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Ribeauvillé | 246800577 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de Munster | 246800585 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de la Doller et du Soultzbach | 246800676 | ❔ | ❌ | ❌ |
+| CA | CA Colmar Agglomération | 246800726 | ❔ | ❌ | ❌ |
+| Département | Vosges | 88 | ❔ | ❌ | ❌ |
+| CC | CC de la Région de Rambervillers | 200005957 | ❔ | ❌ | ❌ |
+| CC | CC des Ballons des Hautes-Vosges | 200033868 | ❔ | ❌ | ❌ |
+| CC | CC Bruyères-Vallons des Vosges | 200042000 | ❔ | ❌ | ❌ |
+| CC | CC de Mirecourt Dompaire | 200068369 | ❔ | ❌ | ❌ |
+| CC | CC de la Porte des Vosges Méridionales | 200068377 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ouest Vosgien | 200068559 | ✅ | ✅ | ❌ |
+| CC | CC Terre d'Eau | 200068682 | ✅ | ✅ | ❌ |
+| CA | CA d'Epinal | 200068757 | ✅ | ✅ | ❌ |
+| CC | CC des Vosges côté Sud Ouest | 200068773 | ❔ | ❌ | ❌ |
+| CA | CA de Saint-Dié-des-Vosges | 200071066 | ❔ | ❌ | ❌ |
+| CC | CC des Hautes Vosges | 200096634 | ❔ | ❌ | ❌ |
+| CC | CC Gérardmer Hautes Vosges | 200096642 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Colombey et du Sud Toulois | 245400510 | ❔ | ❌ | ❌ |

--- a/couverture/44_Grand_Est.md
+++ b/couverture/44_Grand_Est.md
@@ -1,175 +1,174 @@
 # Couverture des aides en Grand Est (44)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Grand Est | 44 | ✅ | ✅ | ❌ |
-| Département | Ardennes | 08 | ❔ | ❌ | ❌ |
-| CC | CC Ardennes Thiérache | 200041622 | ❔ | ❌ | ❌ |
-| CA | CA Ardenne Métropole | 200041630 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Rethélois | 200043156 | ❔ | ❌ | ❌ |
-| CC | CC Vallées et Plateau d'Ardenne | 200067759 | ❔ | ❌ | ❌ |
-| CC | CC Ardenne, Rives de Meuse | 240800821 | ❔ | ❌ | ❌ |
-| CC | CC des Portes du Luxembourg | 240800847 | ✅ | ✅ | ❌ |
-| CC | CC des Crêtes Préardennaises | 240800862 | ✅ | ✅ | ❌ |
-| CC | CC de l'Argonne Ardennaise | 240800920 | ❔ | ❌ | ❌ |
-| Département | Aube | 10 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de Romilly sur Seine | 200000545 | ✅ | ✅ | ❌ |
-| CC | CC du Nogentais | 200006716 | ❔ | ❌ | ❌ |
-| CC | CC des Lacs de Champagne | 200040137 | ❔ | ❌ | ❌ |
-| CC | CC de Vendeuvre-Soulaines | 200066892 | ❔ | ❌ | ❌ |
-| CC | CC du Barséquanais en Champagne | 200069003 | ❔ | ❌ | ❌ |
-| CA | CA Troyes Champagne Métropole | 200069250 | ❔ | ❌ | ❌ |
-| CC | CC Seine et Aube | 200070126 | ❔ | ❌ | ❌ |
-| CC | CC du Chaourçois et du Val d'Armance | 200071041 | ❔ | ❌ | ❌ |
-| CC | CC d'Arcis, Mailly, Ramerupt | 200071777 | ❔ | ❌ | ❌ |
-| CC | CC Forêts, Lacs, Terres en Champagne | 241000223 | ❔ | ❌ | ❌ |
-| CC | CC de la Région de Bar sur Aube | 241000405 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Othe | 241000447 | ❔ | ❌ | ❌ |
-| CC | CC de l'Orvin et de l'Ardusson | 241000488 | ❔ | ❌ | ❌ |
-| Département | Marne | 51 | ❔ | ❌ | ❌ |
-| CC | CC de Vitry, Champagne et Der | 200034718 | ❔ | ❌ | ❌ |
-| CC | CC de la Région de Suippes | 200042620 | ❔ | ❌ | ❌ |
-| CC | CC de l'Argonne Champenoise | 200042703 | ❔ | ❌ | ❌ |
-| CC | CC Perthois-Bocage et Der | 200042992 | ❔ | ❌ | ❌ |
-| CC | CC de la Moivre à la Coole | 200043438 | ❔ | ❌ | ❌ |
-| CC | CC de Sézanne-Sud Ouest Marnais | 200066835 | ❔ | ❌ | ❌ |
-| CC | CC des Paysages de la Champagne | 200066850 | ❔ | ❌ | ❌ |
-| CA | CA de Châlons-en-Champagne | 200066876 | ❔ | ❌ | ❌ |
-| CU | CU du Grand Reims | 200067213 | ✅ | ✅ | ❌ |
-| CC | CC Côtes de Champagne et Val de Saulx | 200067379 | ❔ | ❌ | ❌ |
-| CA | CA Epernay, Coteaux et Plaine de Champagne | 200067684 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Saint-Dizier Der et Vallées | 200068666 | ❔ | ❌ | ❌ |
-| CC | CC de la Grande Vallée de la Marne | 245100615 | ❔ | ❌ | ❌ |
-| CC | CC de la Brie Champenoise | 245100888 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Marnais | 245100979 | ❔ | ❌ | ❌ |
-| Département | Haute-Marne | 52 | ❔ | ❌ | ❌ |
-| CC | CC d'Auberive Vingeanne et Montsaugeonnais | 200027308 | ❔ | ❌ | ❌ |
-| CC | CC du Bassin de Joinville en Champagne | 200044253 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ouest Vosgien | 200068559 | ✅ | ✅ | ❌ |
-| CA | CA de Chaumont | 200068658 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Saint-Dizier Der et Vallées | 200068666 | ❔ | ❌ | ❌ |
-| CC | CC Meuse Rognon | 200069664 | ❔ | ❌ | ❌ |
-| CC | CC des Savoir-Faire | 200070332 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Langres | 200072999 | ❔ | ❌ | ❌ |
-| CC | CC des Trois Forêts | 245200597 | ❔ | ❌ | ❌ |
-| Département | Meurthe-et-Moselle | 54 | ❔ | ❌ | ❌ |
-| CC | CC du Pays du Saintois | 200035772 | ❔ | ❌ | ❌ |
-| CC | CC du Bassin de Pont-à-Mousson | 200041515 | ❔ | ❌ | ❌ |
-| CC | CC Terre Lorraine du Longuyonnais | 200043693 | ❔ | ❌ | ❌ |
-| CC | CC Meurthe Mortagne Moselle | 200067643 | ❔ | ❌ | ❌ |
-| CC | CC de Vezouze en Piémont | 200069433 | ❔ | ❌ | ❌ |
-| CC | CC Coeur du Pays Haut | 200070290 | ❔ | ❌ | ❌ |
-| CC | CC du Territoire de Lunéville à Baccarat | 200070324 | ❔ | ❌ | ❌ |
-| CC | CC Terres Touloises | 200070563 | ❔ | ❌ | ❌ |
-| CC | CC de Seille et Grand Couronné | 200070589 | ❔ | ❌ | ❌ |
-| CC | CC Mad et Moselle | 200070738 | ❔ | ❌ | ❌ |
-| CC | CC Orne Lorraine Confluences | 200070845 | ✅ | ✅ | ❌ |
-| CA | CA de Saint-Dié-des-Vosges | 200071066 | ❔ | ❌ | ❌ |
-| CC | CC Moselle et Madon | 245400171 | ✅ | ✅ | ❌ |
-| CC | CC des Pays du Sel et du Vermois | 245400189 | ❔ | ❌ | ❌ |
-| CA | CA Grand Longwy Agglomération | 245400262 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Colombey et du Sud Toulois | 245400510 | ❔ | ❌ | ❌ |
-| CC | CC du Bassin de Pompey | 245400601 | ✅ | ✅ | ❌ |
-| METRO | Métropole du Grand Nancy | 245400676 | ❔ | ❌ | ❌ |
-| CC | CC du Pays du Sanon | 245400759 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Haut Val d'Alzette | 245701404 | ✅ | ✅ | ❌ |
-| Département | Meuse | 55 | ❔ | ❌ | ❌ |
-| CA | CA de Bar-le-Duc - Sud Meuse | 200033025 | ❔ | ❌ | ❌ |
-| CC | CC Côtes de Meuse Woëvre | 200034874 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Verdun | 200049187 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de Meuse | 200066108 | ❔ | ❌ | ❌ |
-| CC | CC Argonne-Meuse | 200066116 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Stenay et du Val Dunois | 200066132 | ❔ | ❌ | ❌ |
-| CC | CC de l'Aire à l'Argonne | 200066140 | ❔ | ❌ | ❌ |
-| CC | CC de Commercy - Void - Vaucouleurs | 200066157 | ❔ | ❌ | ❌ |
-| CC | CC Val de Meuse - Voie Sacrée | 200066165 | ❔ | ❌ | ❌ |
-| CC | CC de Damvillers Spincourt | 200066173 | ❔ | ❌ | ❌ |
-| CC | CC Coeur du Pays Haut | 200070290 | ❔ | ❌ | ❌ |
-| CC | CC du Sammiellois | 245500327 | ❔ | ❌ | ❌ |
-| CC | CC du Territoire de Fresnes-en-Woëvre | 245501176 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Revigny-sur-Ornain | 245501184 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Étain | 245501242 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Montmédy | 245501259 | ❔ | ❌ | ❌ |
-| Département | Moselle | 57 | ❔ | ❌ | ❌ |
-| METRO | Metz Métropole | 200039865 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Messin | 200039907 | ❔ | ❌ | ❌ |
-| CC | CC Rives de Moselle | 200039949 | ✅ | ✅ | ❌ |
-| CC | CC Bouzonvillois-Trois Frontières | 200067486 | ❔ | ❌ | ❌ |
-| CA | CA Saint-Avold Synergie | 200067502 | ✅ | ✅ | ❌ |
-| CC | CC Houve - Pays Boulageois | 200067650 | ❔ | ❌ | ❌ |
-| CC | CC Haut Chemin - Pays de Pange | 200067957 | ❔ | ❌ | ❌ |
-| CC | CC Sarrebourg Moselle Sud | 200068146 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Bitche | 200069441 | ❔ | ❌ | ❌ |
-| CC | CC Mad et Moselle | 200070738 | ❔ | ❌ | ❌ |
-| CA | CA Sarreguemines Confluences | 200070746 | ❔ | ❌ | ❌ |
-| CC | CC du District Urbain de Faulquemont (DUF) | 245700133 | ❔ | ❌ | ❌ |
-| CA | CA de Forbach Porte de France | 245700372 | ❔ | ❌ | ❌ |
-| CC | CC de Freyming-Merlebach | 245700398 | ❔ | ❌ | ❌ |
-| CC | CC de Cattenom et Environs | 245700695 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Phalsbourg | 245700950 | ❔ | ❌ | ❌ |
-| CC | CC du Warndt | 245701164 | ❔ | ❌ | ❌ |
-| CC | CC du Saulnois | 245701206 | ❔ | ❌ | ❌ |
-| CA | CA du Val de Fensch | 245701222 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Orne Moselle | 245701271 | ✅ | ✅ | ❌ |
-| CC | CC de l'Arc Mosellan | 245701354 | ❔ | ❌ | ❌ |
-| CA | CA Portes de France-Thionville | 245701362 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Haut Val d'Alzette | 245701404 | ✅ | ✅ | ❌ |
-| Département | Bas-Rhin | 67 | ❔ | ❌ | ❌ |
-| CC | CC Sauer-Pechelbronn | 200013050 | ❔ | ❌ | ❌ |
-| CC | CC du Ried de Marckolsheim | 200030526 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Barr | 200034270 | ✅ | ✅ | ❌ |
-| CC | CC du Kochersberg | 200034635 | ❔ | ❌ | ❌ |
-| CC | CC de l'Outre-Forêt | 200040178 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine du Rhin | 200041283 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Rhénan | 200041325 | ❔ | ❌ | ❌ |
-| CC | CC de Hanau-La Petite Pierre | 200067783 | ❔ | ❌ | ❌ |
-| CC | CC de l'Alsace Bossue | 200067841 | ❔ | ❌ | ❌ |
-| CA | CA de Haguenau | 200067874 | ❔ | ❌ | ❌ |
-| CC | CC du Canton d'Erstein | 200067924 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saverne | 200068112 | ✅ | ✅ | ❌ |
-| CC | CC de la Mossig et du Vignoble | 200068864 | ❔ | ❌ | ❌ |
-| CA | CA Sarreguemines Confluences | 200070746 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de la Bruche | 246700306 | ❔ | ❌ | ❌ |
-| METRO | Eurométropole de Strasbourg | 246700488 | ✅ | ✅ | ❌ |
-| CC | CC des Portes de Rosheim | 246700744 | ✅ | ✅ | ❌ |
-| CC | CC de la Vallée de Villé | 246700777 | ❔ | ❌ | ❌ |
-| CC | CC de la Basse-Zorn | 246700843 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Wissembourg | 246700926 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de la Zorn | 246700959 | ❔ | ❌ | ❌ |
-| CC | CC de Sélestat | 246700967 | ❔ | ❌ | ❌ |
-| CC | CC de la Région de Molsheim-Mutzig | 246701064 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Sainte-Odile | 246701080 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Niederbronn-les-Bains | 246701098 | ❔ | ❌ | ❌ |
-| Département | Haut-Rhin | 68 | ❔ | ❌ | ❌ |
-| CC | CC du Ried de Marckolsheim | 200030526 | ❔ | ❌ | ❌ |
-| CC | CC de Thann-Cernay | 200036465 | ❔ | ❌ | ❌ |
-| CA | CA Mulhouse Alsace Agglomération | 200066009 | ❔ | ❌ | ❌ |
-| CC | CC Alsace Rhin Brisach | 200066025 | ❔ | ❌ | ❌ |
-| CC | CC Sud Alsace Largue | 200066033 | ❔ | ❌ | ❌ |
-| CC | CC Sundgau | 200066041 | ❔ | ❌ | ❌ |
-| CA | CA Saint-Louis Agglomération | 200066058 | ✅ | ✅ | ❌ |
-| CC | CC de la Vallée de Saint-Amarin | 246800205 | ❔ | ❌ | ❌ |
-| CC | CC du Val d'Argent | 246800395 | ❔ | ❌ | ❌ |
-| CC | CC du Centre du Haut-Rhin | 246800445 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Rouffach, Vignobles et Châteaux | 246800494 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de Kaysersberg | 246800551 | ❔ | ❌ | ❌ |
-| CC | CC de la Région de Guebwiller | 246800569 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Ribeauvillé | 246800577 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de Munster | 246800585 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de la Doller et du Soultzbach | 246800676 | ❔ | ❌ | ❌ |
-| CA | CA Colmar Agglomération | 246800726 | ❔ | ❌ | ❌ |
-| Département | Vosges | 88 | ❔ | ❌ | ❌ |
-| CC | CC de la Région de Rambervillers | 200005957 | ❔ | ❌ | ❌ |
-| CC | CC des Ballons des Hautes-Vosges | 200033868 | ❔ | ❌ | ❌ |
-| CC | CC Bruyères-Vallons des Vosges | 200042000 | ❔ | ❌ | ❌ |
-| CC | CC de Mirecourt Dompaire | 200068369 | ❔ | ❌ | ❌ |
-| CC | CC de la Porte des Vosges Méridionales | 200068377 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ouest Vosgien | 200068559 | ✅ | ✅ | ❌ |
-| CC | CC Terre d'Eau | 200068682 | ✅ | ✅ | ❌ |
-| CA | CA d'Epinal | 200068757 | ✅ | ✅ | ❌ |
-| CC | CC des Vosges côté Sud Ouest | 200068773 | ❔ | ❌ | ❌ |
-| CA | CA de Saint-Dié-des-Vosges | 200071066 | ❔ | ❌ | ❌ |
-| CC | CC des Hautes Vosges | 200096634 | ❔ | ❌ | ❌ |
-| CC | CC Gérardmer Hautes Vosges | 200096642 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Colombey et du Sud Toulois | 245400510 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                           | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | --------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Grand Est                                     | 44        | ✅               | ✅        | ❌    |
+| Département | Ardennes                                      | 08        | ❔               | ❌        | ❌    |
+| CC          | CC Ardennes Thiérache                         | 200041622 | ❔               | ❌        | ❌    |
+| CA          | CA Ardenne Métropole                          | 200041630 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Rethélois                          | 200043156 | ❔               | ❌        | ❌    |
+| CC          | CC Vallées et Plateau d'Ardenne               | 200067759 | ❔               | ❌        | ❌    |
+| CC          | CC Ardenne, Rives de Meuse                    | 240800821 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes du Luxembourg                   | 240800847 | ✅               | ✅        | ❌    |
+| CC          | CC des Crêtes Préardennaises                  | 240800862 | ✅               | ✅        | ❌    |
+| CC          | CC de l'Argonne Ardennaise                    | 240800920 | ❔               | ❌        | ❌    |
+| Département | Aube                                          | 10        | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de Romilly sur Seine            | 200000545 | ✅               | ✅        | ❌    |
+| CC          | CC du Nogentais                               | 200006716 | ❔               | ❌        | ❌    |
+| CC          | CC des Lacs de Champagne                      | 200040137 | ❔               | ❌        | ❌    |
+| CC          | CC de Vendeuvre-Soulaines                     | 200066892 | ❔               | ❌        | ❌    |
+| CC          | CC du Barséquanais en Champagne               | 200069003 | ❔               | ❌        | ❌    |
+| CA          | CA Troyes Champagne Métropole                 | 200069250 | ❔               | ❌        | ❌    |
+| CC          | CC Seine et Aube                              | 200070126 | ❔               | ❌        | ❌    |
+| CC          | CC du Chaourçois et du Val d'Armance          | 200071041 | ❔               | ❌        | ❌    |
+| CC          | CC d'Arcis, Mailly, Ramerupt                  | 200071777 | ❔               | ❌        | ❌    |
+| CC          | CC Forêts, Lacs, Terres en Champagne          | 241000223 | ❔               | ❌        | ❌    |
+| CC          | CC de la Région de Bar sur Aube               | 241000405 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Othe                             | 241000447 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Orvin et de l'Ardusson                | 241000488 | ❔               | ❌        | ❌    |
+| Département | Marne                                         | 51        | ❔               | ❌        | ❌    |
+| CC          | CC de Vitry, Champagne et Der                 | 200034718 | ❔               | ❌        | ❌    |
+| CC          | CC de la Région de Suippes                    | 200042620 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Argonne Champenoise                   | 200042703 | ❔               | ❌        | ❌    |
+| CC          | CC Perthois-Bocage et Der                     | 200042992 | ❔               | ❌        | ❌    |
+| CC          | CC de la Moivre à la Coole                    | 200043438 | ❔               | ❌        | ❌    |
+| CC          | CC de Sézanne-Sud Ouest Marnais               | 200066835 | ❔               | ❌        | ❌    |
+| CC          | CC des Paysages de la Champagne               | 200066850 | ❔               | ❌        | ❌    |
+| CA          | CA de Châlons-en-Champagne                    | 200066876 | ❔               | ❌        | ❌    |
+| CU          | CU du Grand Reims                             | 200067213 | ✅               | ✅        | ✅    |
+| CC          | CC Côtes de Champagne et Val de Saulx         | 200067379 | ❔               | ❌        | ❌    |
+| CA          | CA Epernay, Coteaux et Plaine de Champagne    | 200067684 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Saint-Dizier Der et Vallées       | 200068666 | ❔               | ❌        | ❌    |
+| CC          | CC de la Grande Vallée de la Marne            | 245100615 | ❔               | ❌        | ❌    |
+| CC          | CC de la Brie Champenoise                     | 245100888 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Marnais                             | 245100979 | ❔               | ❌        | ❌    |
+| Département | Haute-Marne                                   | 52        | ❔               | ❌        | ❌    |
+| CC          | CC d'Auberive Vingeanne et Montsaugeonnais    | 200027308 | ❔               | ❌        | ❌    |
+| CC          | CC du Bassin de Joinville en Champagne        | 200044253 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ouest Vosgien                         | 200068559 | ✅               | ✅        | ❌    |
+| CA          | CA de Chaumont                                | 200068658 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Saint-Dizier Der et Vallées       | 200068666 | ❔               | ❌        | ❌    |
+| CC          | CC Meuse Rognon                               | 200069664 | ❔               | ❌        | ❌    |
+| CC          | CC des Savoir-Faire                           | 200070332 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Langres                           | 200072999 | ❔               | ❌        | ❌    |
+| CC          | CC des Trois Forêts                           | 245200597 | ❔               | ❌        | ❌    |
+| Département | Meurthe-et-Moselle                            | 54        | ❔               | ❌        | ❌    |
+| CC          | CC du Pays du Saintois                        | 200035772 | ❔               | ❌        | ❌    |
+| CC          | CC du Bassin de Pont-à-Mousson                | 200041515 | ❔               | ❌        | ❌    |
+| CC          | CC Terre Lorraine du Longuyonnais             | 200043693 | ❔               | ❌        | ❌    |
+| CC          | CC Meurthe Mortagne Moselle                   | 200067643 | ❔               | ❌        | ❌    |
+| CC          | CC de Vezouze en Piémont                      | 200069433 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur du Pays Haut                         | 200070290 | ❔               | ❌        | ❌    |
+| CC          | CC du Territoire de Lunéville à Baccarat      | 200070324 | ❔               | ❌        | ❌    |
+| CC          | CC Terres Touloises                           | 200070563 | ❔               | ❌        | ❌    |
+| CC          | CC de Seille et Grand Couronné                | 200070589 | ❔               | ❌        | ❌    |
+| CC          | CC Mad et Moselle                             | 200070738 | ❔               | ❌        | ❌    |
+| CC          | CC Orne Lorraine Confluences                  | 200070845 | ✅               | ✅        | ❌    |
+| CA          | CA de Saint-Dié-des-Vosges                    | 200071066 | ❔               | ❌        | ❌    |
+| CC          | CC Moselle et Madon                           | 245400171 | ✅               | ✅        | ❌    |
+| CC          | CC des Pays du Sel et du Vermois              | 245400189 | ❔               | ❌        | ❌    |
+| CA          | CA Grand Longwy Agglomération                 | 245400262 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Colombey et du Sud Toulois      | 245400510 | ❔               | ❌        | ❌    |
+| CC          | CC du Bassin de Pompey                        | 245400601 | ✅               | ✅        | ❌    |
+| METRO       | Métropole du Grand Nancy                      | 245400676 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays du Sanon                           | 245400759 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Haut Val d'Alzette                 | 245701404 | ✅               | ✅        | ❌    |
+| Département | Meuse                                         | 55        | ❔               | ❌        | ❌    |
+| CA          | CA de Bar-le-Duc - Sud Meuse                  | 200033025 | ❔               | ❌        | ❌    |
+| CC          | CC Côtes de Meuse Woëvre                      | 200034874 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Verdun                            | 200049187 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de Meuse                        | 200066108 | ❔               | ❌        | ❌    |
+| CC          | CC Argonne-Meuse                              | 200066116 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Stenay et du Val Dunois         | 200066132 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Aire à l'Argonne                      | 200066140 | ❔               | ❌        | ❌    |
+| CC          | CC de Commercy - Void - Vaucouleurs           | 200066157 | ❔               | ❌        | ❌    |
+| CC          | CC Val de Meuse - Voie Sacrée                 | 200066165 | ❔               | ❌        | ❌    |
+| CC          | CC de Damvillers Spincourt                    | 200066173 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur du Pays Haut                         | 200070290 | ❔               | ❌        | ❌    |
+| CC          | CC du Sammiellois                             | 245500327 | ❔               | ❌        | ❌    |
+| CC          | CC du Territoire de Fresnes-en-Woëvre         | 245501176 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Revigny-sur-Ornain              | 245501184 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Étain                            | 245501242 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Montmédy                        | 245501259 | ❔               | ❌        | ❌    |
+| Département | Moselle                                       | 57        | ❔               | ❌        | ❌    |
+| METRO       | Metz Métropole                                | 200039865 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Messin                              | 200039907 | ❔               | ❌        | ❌    |
+| CC          | CC Rives de Moselle                           | 200039949 | ✅               | ✅        | ❌    |
+| CC          | CC Bouzonvillois-Trois Frontières             | 200067486 | ❔               | ❌        | ❌    |
+| CA          | CA Saint-Avold Synergie                       | 200067502 | ✅               | ✅        | ❌    |
+| CC          | CC Houve - Pays Boulageois                    | 200067650 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Chemin - Pays de Pange                | 200067957 | ❔               | ❌        | ❌    |
+| CC          | CC Sarrebourg Moselle Sud                     | 200068146 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Bitche                          | 200069441 | ❔               | ❌        | ❌    |
+| CC          | CC Mad et Moselle                             | 200070738 | ❔               | ❌        | ❌    |
+| CA          | CA Sarreguemines Confluences                  | 200070746 | ❔               | ❌        | ❌    |
+| CC          | CC du District Urbain de Faulquemont (DUF)    | 245700133 | ❔               | ❌        | ❌    |
+| CA          | CA de Forbach Porte de France                 | 245700372 | ❔               | ❌        | ❌    |
+| CC          | CC de Freyming-Merlebach                      | 245700398 | ❔               | ❌        | ❌    |
+| CC          | CC de Cattenom et Environs                    | 245700695 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Phalsbourg                      | 245700950 | ❔               | ❌        | ❌    |
+| CC          | CC du Warndt                                  | 245701164 | ❔               | ❌        | ❌    |
+| CC          | CC du Saulnois                                | 245701206 | ❔               | ❌        | ❌    |
+| CA          | CA du Val de Fensch                           | 245701222 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Orne Moselle                       | 245701271 | ✅               | ✅        | ❌    |
+| CC          | CC de l'Arc Mosellan                          | 245701354 | ❔               | ❌        | ❌    |
+| CA          | CA Portes de France-Thionville                | 245701362 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Haut Val d'Alzette                 | 245701404 | ✅               | ✅        | ❌    |
+| Département | Bas-Rhin                                      | 67        | ❔               | ❌        | ❌    |
+| CC          | CC Sauer-Pechelbronn                          | 200013050 | ❔               | ❌        | ❌    |
+| CC          | CC du Ried de Marckolsheim                    | 200030526 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Barr                            | 200034270 | ✅               | ✅        | ❌    |
+| CC          | CC du Kochersberg                             | 200034635 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Outre-Forêt                           | 200040178 | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine du Rhin                       | 200041283 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Rhénan                             | 200041325 | ❔               | ❌        | ❌    |
+| CC          | CC de Hanau-La Petite Pierre                  | 200067783 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Alsace Bossue                         | 200067841 | ❔               | ❌        | ❌    |
+| CA          | CA de Haguenau                                | 200067874 | ❔               | ❌        | ❌    |
+| CC          | CC du Canton d'Erstein                        | 200067924 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saverne                         | 200068112 | ✅               | ✅        | ❌    |
+| CC          | CC de la Mossig et du Vignoble                | 200068864 | ❔               | ❌        | ❌    |
+| CA          | CA Sarreguemines Confluences                  | 200070746 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de la Bruche                  | 246700306 | ❔               | ❌        | ❌    |
+| METRO       | Eurométropole de Strasbourg                   | 246700488 | ✅               | ✅        | ❌    |
+| CC          | CC des Portes de Rosheim                      | 246700744 | ✅               | ✅        | ❌    |
+| CC          | CC de la Vallée de Villé                      | 246700777 | ❔               | ❌        | ❌    |
+| CC          | CC de la Basse-Zorn                           | 246700843 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Wissembourg                     | 246700926 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de la Zorn                         | 246700959 | ❔               | ❌        | ❌    |
+| CC          | CC de Sélestat                                | 246700967 | ❔               | ❌        | ❌    |
+| CC          | CC de la Région de Molsheim-Mutzig            | 246701064 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Sainte-Odile                    | 246701080 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Niederbronn-les-Bains           | 246701098 | ❔               | ❌        | ❌    |
+| Département | Haut-Rhin                                     | 68        | ❔               | ❌        | ❌    |
+| CC          | CC du Ried de Marckolsheim                    | 200030526 | ❔               | ❌        | ❌    |
+| CC          | CC de Thann-Cernay                            | 200036465 | ❔               | ❌        | ❌    |
+| CA          | CA Mulhouse Alsace Agglomération              | 200066009 | ❔               | ❌        | ❌    |
+| CC          | CC Alsace Rhin Brisach                        | 200066025 | ❔               | ❌        | ❌    |
+| CC          | CC Sud Alsace Largue                          | 200066033 | ❔               | ❌        | ❌    |
+| CC          | CC Sundgau                                    | 200066041 | ❔               | ❌        | ❌    |
+| CA          | CA Saint-Louis Agglomération                  | 200066058 | ✅               | ✅        | ❌    |
+| CC          | CC de la Vallée de Saint-Amarin               | 246800205 | ❔               | ❌        | ❌    |
+| CC          | CC du Val d'Argent                            | 246800395 | ❔               | ❌        | ❌    |
+| CC          | CC du Centre du Haut-Rhin                     | 246800445 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Rouffach, Vignobles et Châteaux | 246800494 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de Kaysersberg                | 246800551 | ❔               | ❌        | ❌    |
+| CC          | CC de la Région de Guebwiller                 | 246800569 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Ribeauvillé                     | 246800577 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de Munster                    | 246800585 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de la Doller et du Soultzbach | 246800676 | ❔               | ❌        | ❌    |
+| CA          | CA Colmar Agglomération                       | 246800726 | ❔               | ❌        | ❌    |
+| Département | Vosges                                        | 88        | ❔               | ❌        | ❌    |
+| CC          | CC de la Région de Rambervillers              | 200005957 | ❔               | ❌        | ❌    |
+| CC          | CC des Ballons des Hautes-Vosges              | 200033868 | ❔               | ❌        | ❌    |
+| CC          | CC Bruyères-Vallons des Vosges                | 200042000 | ❔               | ❌        | ❌    |
+| CC          | CC de Mirecourt Dompaire                      | 200068369 | ❔               | ❌        | ❌    |
+| CC          | CC de la Porte des Vosges Méridionales        | 200068377 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ouest Vosgien                         | 200068559 | ✅               | ✅        | ❌    |
+| CC          | CC Terre d'Eau                                | 200068682 | ✅               | ✅        | ❌    |
+| CA          | CA d'Epinal                                   | 200068757 | ✅               | ✅        | ❌    |
+| CC          | CC des Vosges côté Sud Ouest                  | 200068773 | ❔               | ❌        | ❌    |
+| CA          | CA de Saint-Dié-des-Vosges                    | 200071066 | ❔               | ❌        | ❌    |
+| CC          | CC des Hautes Vosges                          | 200096634 | ❔               | ❌        | ❌    |
+| CC          | CC Gérardmer Hautes Vosges                    | 200096642 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Colombey et du Sud Toulois      | 245400510 | ❔               | ❌        | ❌    |

--- a/couverture/52_Pays_de_la_Loire.md
+++ b/couverture/52_Pays_de_la_Loire.md
@@ -1,84 +1,83 @@
 # Couverture des aides en Pays de la Loire (52)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Pays de la Loire | 52 | ❔ | ❌ | ❌ |
-| Département | Loire-Atlantique | 44 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Pontchâteau St-Gildas-des-Bois | 200000438 | ❔ | ❌ | ❌ |
-| CA | CA Pornic Agglo Pays de Retz | 200067346 | ✅ | ✅ | ❌ |
-| CA | CA Clisson Sèvre et Maine Agglo | 200067635 | ❔ | ❌ | ❌ |
-| CC | CC Sèvre et Loire | 200067866 | ✅ | ✅ | ❌ |
-| CC | CC Sud Retz Atlantique | 200071546 | ❔ | ❌ | ❌ |
-| CC | CC Châteaubriant-Derval | 200072726 | ❔ | ❌ | ❌ |
-| CC | CC Estuaire et Sillon | 200072734 | ❔ | ❌ | ❌ |
-| CA | CA Redon Agglomération | 243500741 | ❔ | ❌ | ❌ |
-| METRO | Nantes Métropole | 244400404 | ✅ | ✅ | ❌ |
-| CC | CC Grand Lieu Communauté | 244400438 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Blain | 244400453 | ❔ | ❌ | ❌ |
-| CC | CC d'Erdre et Gesvres | 244400503 | ❔ | ❌ | ❌ |
-| CC | CC de Nozay | 244400537 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Ancenis | 244400552 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Estuaire | 244400586 | ❔ | ❌ | ❌ |
-| CA | CA de la Presqu'île de Guérande Atlantique (Cap Atlantique) | 244400610 | ❔ | ❌ | ❌ |
-| CA | CA de la Région Nazairienne et de l'Estuaire (CARENE) | 244400644 | ❔ | ❌ | ❌ |
-| Département | Maine-et-Loire | 49 | ❔ | ❌ | ❌ |
-| CA | CA Mauges Communauté | 200060010 | ❔ | ❌ | ❌ |
-| CC | CC Anjou Loir et Sarthe | 200068955 | ❔ | ❌ | ❌ |
-| CC | CC Loire Layon Aubance | 200071553 | ✅ | ✅ | ❌ |
-| CA | CA Cholet Agglomération | 200071678 | ✅ | ✅ | ❌ |
-| CC | CC des Vallées du Haut-Anjou | 200071868 | ❔ | ❌ | ❌ |
-| CA | CA Saumur Val de Loire | 200071876 | ✅ | ✅ | ❌ |
-| CC | CC du Pays d'Ancenis | 244400552 | ❔ | ❌ | ❌ |
-| CU | CU Angers Loire Métropole | 244900015 | ✅ | ✅ | ❌ |
-| CC | CC Anjou Bleu Communauté | 244900809 | ✅ | ✅ | ❌ |
-| CC | CC Baugeois Vallée | 244900882 | ❔ | ❌ | ❌ |
-| Département | Mayenne | 53 | ❔ | ❌ | ❌ |
-| CC | CC des Coëvrons | 200033298 | ❔ | ❌ | ❌ |
-| CC | CC du Mont des Avaloirs | 200042182 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Craon | 200048551 | ❔ | ❌ | ❌ |
-| CC | CC Mayenne Communauté | 200055887 | ❔ | ❌ | ❌ |
-| CA | CA Laval Agglomération | 200083392 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Meslay-Grez | 245300223 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ernée | 245300355 | ❔ | ❌ | ❌ |
-| CC | CC du Bocage Mayennais | 245300389 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Château-Gontier | 245300447 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Sabolien | 247200090 | ❔ | ❌ | ❌ |
-| Département | Sarthe | 72 | ❔ | ❌ | ❌ |
-| CC | CC LBN Communauté | 200040475 | ❔ | ❌ | ❌ |
-| CC | CC Maine Coeur de Sarthe | 200068963 | ❔ | ❌ | ❌ |
-| CC | CC Loir-Lucé-Bercé | 200070373 | ❔ | ❌ | ❌ |
-| CC | CC Maine Saosnois | 200072676 | ❔ | ❌ | ❌ |
-| CC | CC Le Gesnois Bilurien | 200072684 | ❔ | ❌ | ❌ |
-| CC | CC des Vallées de la Braye et de l'Anille | 200072692 | ❔ | ❌ | ❌ |
-| CC | CC Haute Sarthe Alpes Mancelles | 200072700 | ❔ | ❌ | ❌ |
-| CC | CC de la Champagne Conlinoise et du Pays de Sillé | 200072718 | ❔ | ❌ | ❌ |
-| CC | CC Sud Sarthe | 200073112 | ❔ | ❌ | ❌ |
-| CU | CU d'Alençon | 246100663 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Sabolien | 247200090 | ❔ | ❌ | ❌ |
-| CU | CU Le Mans Métropole | 247200132 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Fléchois | 247200348 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Est Manceau | 247200421 | ❔ | ❌ | ❌ |
-| CC | CC Orée de Bercé - Belinois | 247200447 | ❔ | ❌ | ❌ |
-| CC | CC du Val de Sarthe | 247200629 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de l'Huisne Sarthoise | 247200686 | ❔ | ❌ | ❌ |
-| Département | Vendée | 85 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Saint-Gilles-Croix-de-Vie | 200023778 | ❔ | ❌ | ❌ |
-| CA | CA Terres de Montaigu | 200070233 | ❔ | ❌ | ❌ |
-| CA | CA Les Sables d'Olonne Agglomération | 200071165 | ✅ | ✅ | ❌ |
-| CC | CC Challans-Gois Communauté | 200071629 | ❔ | ❌ | ❌ |
-| CC | CC Vendée Grand Littoral | 200071900 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saint-Fulgent - Les Essarts | 200071918 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Fontenay-Vendée | 200071934 | ❔ | ❌ | ❌ |
-| CC | CC de Vie et Boulogne | 200072882 | ❔ | ❌ | ❌ |
-| CC | CC Sud Vendée Littoral | 200073260 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ile de Noirmoutier | 248500191 | ❔ | ❌ | ❌ |
-| CC | CC Océan Marais de Monts | 248500258 | ❔ | ❌ | ❌ |
-| CC | CC Pays de Chantonnay | 248500340 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de la Châtaigneraie | 248500415 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Pouzauges | 248500464 | ❔ | ❌ | ❌ |
-| CC | CC du Pays des Achards | 248500530 | ✅ | ✅ | ❌ |
-| CC | CC Vendée, Sèvre, Autise | 248500563 | ❔ | ❌ | ❌ |
-| CA | CA La Roche-sur-Yon - Agglomération | 248500589 | ✅ | ✅ | ❌ |
-| CC | CC du Pays des Herbiers | 248500621 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Mortagne | 248500662 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                                         | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ----------------------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Pays de la Loire                                            | 52        | ❔               | ❌        | ❌    |
+| Département | Loire-Atlantique                                            | 44        | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Pontchâteau St-Gildas-des-Bois                | 200000438 | ❔               | ❌        | ❌    |
+| CA          | CA Pornic Agglo Pays de Retz                                | 200067346 | ✅               | ✅        | ❌    |
+| CA          | CA Clisson Sèvre et Maine Agglo                             | 200067635 | ❔               | ❌        | ❌    |
+| CC          | CC Sèvre et Loire                                           | 200067866 | ✅               | ✅        | ❌    |
+| CC          | CC Sud Retz Atlantique                                      | 200071546 | ❔               | ❌        | ❌    |
+| CC          | CC Châteaubriant-Derval                                     | 200072726 | ❔               | ❌        | ❌    |
+| CC          | CC Estuaire et Sillon                                       | 200072734 | ❔               | ❌        | ❌    |
+| CA          | CA Redon Agglomération                                      | 243500741 | ❔               | ❌        | ❌    |
+| METRO       | Nantes Métropole                                            | 244400404 | ✅               | ✅        | ❌    |
+| CC          | CC Grand Lieu Communauté                                    | 244400438 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Blain                                         | 244400453 | ❔               | ❌        | ❌    |
+| CC          | CC d'Erdre et Gesvres                                       | 244400503 | ❔               | ❌        | ❌    |
+| CC          | CC de Nozay                                                 | 244400537 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Ancenis                                        | 244400552 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Estuaire                                          | 244400586 | ❔               | ❌        | ❌    |
+| CA          | CA de la Presqu'île de Guérande Atlantique (Cap Atlantique) | 244400610 | ❔               | ❌        | ❌    |
+| CA          | CA de la Région Nazairienne et de l'Estuaire (CARENE)       | 244400644 | ❔               | ❌        | ❌    |
+| Département | Maine-et-Loire                                              | 49        | ❔               | ❌        | ❌    |
+| CA          | CA Mauges Communauté                                        | 200060010 | ❔               | ❌        | ❌    |
+| CC          | CC Anjou Loir et Sarthe                                     | 200068955 | ❔               | ❌        | ❌    |
+| CC          | CC Loire Layon Aubance                                      | 200071553 | ✅               | ✅        | ✅    |
+| CA          | CA Cholet Agglomération                                     | 200071678 | ✅               | ✅        | ❌    |
+| CC          | CC des Vallées du Haut-Anjou                                | 200071868 | ❔               | ❌        | ❌    |
+| CA          | CA Saumur Val de Loire                                      | 200071876 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays d'Ancenis                                        | 244400552 | ❔               | ❌        | ❌    |
+| CU          | CU Angers Loire Métropole                                   | 244900015 | ✅               | ✅        | ❌    |
+| CC          | CC Anjou Bleu Communauté                                    | 244900809 | ✅               | ✅        | ❌    |
+| CC          | CC Baugeois Vallée                                          | 244900882 | ❔               | ❌        | ❌    |
+| Département | Mayenne                                                     | 53        | ❔               | ❌        | ❌    |
+| CC          | CC des Coëvrons                                             | 200033298 | ❔               | ❌        | ❌    |
+| CC          | CC du Mont des Avaloirs                                     | 200042182 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Craon                                         | 200048551 | ❔               | ❌        | ❌    |
+| CC          | CC Mayenne Communauté                                       | 200055887 | ❔               | ❌        | ❌    |
+| CA          | CA Laval Agglomération                                      | 200083392 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Meslay-Grez                                   | 245300223 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ernée                                               | 245300355 | ❔               | ❌        | ❌    |
+| CC          | CC du Bocage Mayennais                                      | 245300389 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Château-Gontier                               | 245300447 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Sabolien                                         | 247200090 | ❔               | ❌        | ❌    |
+| Département | Sarthe                                                      | 72        | ❔               | ❌        | ❌    |
+| CC          | CC LBN Communauté                                           | 200040475 | ❔               | ❌        | ❌    |
+| CC          | CC Maine Coeur de Sarthe                                    | 200068963 | ❔               | ❌        | ❌    |
+| CC          | CC Loir-Lucé-Bercé                                          | 200070373 | ❔               | ❌        | ❌    |
+| CC          | CC Maine Saosnois                                           | 200072676 | ❔               | ❌        | ❌    |
+| CC          | CC Le Gesnois Bilurien                                      | 200072684 | ❔               | ❌        | ❌    |
+| CC          | CC des Vallées de la Braye et de l'Anille                   | 200072692 | ❔               | ❌        | ❌    |
+| CC          | CC Haute Sarthe Alpes Mancelles                             | 200072700 | ❔               | ❌        | ❌    |
+| CC          | CC de la Champagne Conlinoise et du Pays de Sillé           | 200072718 | ❔               | ❌        | ❌    |
+| CC          | CC Sud Sarthe                                               | 200073112 | ❔               | ❌        | ❌    |
+| CU          | CU d'Alençon                                                | 246100663 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Sabolien                                         | 247200090 | ❔               | ❌        | ❌    |
+| CU          | CU Le Mans Métropole                                        | 247200132 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Fléchois                                         | 247200348 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Est Manceau                                       | 247200421 | ❔               | ❌        | ❌    |
+| CC          | CC Orée de Bercé - Belinois                                 | 247200447 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Sarthe                                         | 247200629 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de l'Huisne Sarthoise                            | 247200686 | ❔               | ❌        | ❌    |
+| Département | Vendée                                                      | 85        | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Saint-Gilles-Croix-de-Vie                     | 200023778 | ❔               | ❌        | ❌    |
+| CA          | CA Terres de Montaigu                                       | 200070233 | ❔               | ❌        | ❌    |
+| CA          | CA Les Sables d'Olonne Agglomération                        | 200071165 | ✅               | ✅        | ✅    |
+| CC          | CC Challans-Gois Communauté                                 | 200071629 | ❔               | ❌        | ❌    |
+| CC          | CC Vendée Grand Littoral                                    | 200071900 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saint-Fulgent - Les Essarts                   | 200071918 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Fontenay-Vendée                               | 200071934 | ❔               | ❌        | ❌    |
+| CC          | CC de Vie et Boulogne                                       | 200072882 | ❔               | ❌        | ❌    |
+| CC          | CC Sud Vendée Littoral                                      | 200073260 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ile de Noirmoutier                                  | 248500191 | ❔               | ❌        | ❌    |
+| CC          | CC Océan Marais de Monts                                    | 248500258 | ❔               | ❌        | ❌    |
+| CC          | CC Pays de Chantonnay                                       | 248500340 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de la Châtaigneraie                              | 248500415 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Pouzauges                                     | 248500464 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays des Achards                                      | 248500530 | ✅               | ✅        | ❌    |
+| CC          | CC Vendée, Sèvre, Autise                                    | 248500563 | ❔               | ❌        | ❌    |
+| CA          | CA La Roche-sur-Yon - Agglomération                         | 248500589 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays des Herbiers                                     | 248500621 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays de Mortagne                                      | 248500662 | ❔               | ❌        | ❌    |

--- a/couverture/52_Pays_de_la_Loire.md
+++ b/couverture/52_Pays_de_la_Loire.md
@@ -1,0 +1,84 @@
+# Couverture des aides en Pays de la Loire (52)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Pays de la Loire | 52 | ❔ | ❌ | ❌ |
+| Département | Loire-Atlantique | 44 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Pontchâteau St-Gildas-des-Bois | 200000438 | ❔ | ❌ | ❌ |
+| CA | CA Pornic Agglo Pays de Retz | 200067346 | ✅ | ✅ | ❌ |
+| CA | CA Clisson Sèvre et Maine Agglo | 200067635 | ❔ | ❌ | ❌ |
+| CC | CC Sèvre et Loire | 200067866 | ✅ | ✅ | ❌ |
+| CC | CC Sud Retz Atlantique | 200071546 | ❔ | ❌ | ❌ |
+| CC | CC Châteaubriant-Derval | 200072726 | ❔ | ❌ | ❌ |
+| CC | CC Estuaire et Sillon | 200072734 | ❔ | ❌ | ❌ |
+| CA | CA Redon Agglomération | 243500741 | ❔ | ❌ | ❌ |
+| METRO | Nantes Métropole | 244400404 | ✅ | ✅ | ❌ |
+| CC | CC Grand Lieu Communauté | 244400438 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Blain | 244400453 | ❔ | ❌ | ❌ |
+| CC | CC d'Erdre et Gesvres | 244400503 | ❔ | ❌ | ❌ |
+| CC | CC de Nozay | 244400537 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Ancenis | 244400552 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Estuaire | 244400586 | ❔ | ❌ | ❌ |
+| CA | CA de la Presqu'île de Guérande Atlantique (Cap Atlantique) | 244400610 | ❔ | ❌ | ❌ |
+| CA | CA de la Région Nazairienne et de l'Estuaire (CARENE) | 244400644 | ❔ | ❌ | ❌ |
+| Département | Maine-et-Loire | 49 | ❔ | ❌ | ❌ |
+| CA | CA Mauges Communauté | 200060010 | ❔ | ❌ | ❌ |
+| CC | CC Anjou Loir et Sarthe | 200068955 | ❔ | ❌ | ❌ |
+| CC | CC Loire Layon Aubance | 200071553 | ✅ | ✅ | ❌ |
+| CA | CA Cholet Agglomération | 200071678 | ✅ | ✅ | ❌ |
+| CC | CC des Vallées du Haut-Anjou | 200071868 | ❔ | ❌ | ❌ |
+| CA | CA Saumur Val de Loire | 200071876 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Ancenis | 244400552 | ❔ | ❌ | ❌ |
+| CU | CU Angers Loire Métropole | 244900015 | ✅ | ✅ | ❌ |
+| CC | CC Anjou Bleu Communauté | 244900809 | ✅ | ✅ | ❌ |
+| CC | CC Baugeois Vallée | 244900882 | ❔ | ❌ | ❌ |
+| Département | Mayenne | 53 | ❔ | ❌ | ❌ |
+| CC | CC des Coëvrons | 200033298 | ❔ | ❌ | ❌ |
+| CC | CC du Mont des Avaloirs | 200042182 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Craon | 200048551 | ❔ | ❌ | ❌ |
+| CC | CC Mayenne Communauté | 200055887 | ❔ | ❌ | ❌ |
+| CA | CA Laval Agglomération | 200083392 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Meslay-Grez | 245300223 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ernée | 245300355 | ❔ | ❌ | ❌ |
+| CC | CC du Bocage Mayennais | 245300389 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Château-Gontier | 245300447 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Sabolien | 247200090 | ❔ | ❌ | ❌ |
+| Département | Sarthe | 72 | ❔ | ❌ | ❌ |
+| CC | CC LBN Communauté | 200040475 | ❔ | ❌ | ❌ |
+| CC | CC Maine Coeur de Sarthe | 200068963 | ❔ | ❌ | ❌ |
+| CC | CC Loir-Lucé-Bercé | 200070373 | ❔ | ❌ | ❌ |
+| CC | CC Maine Saosnois | 200072676 | ❔ | ❌ | ❌ |
+| CC | CC Le Gesnois Bilurien | 200072684 | ❔ | ❌ | ❌ |
+| CC | CC des Vallées de la Braye et de l'Anille | 200072692 | ❔ | ❌ | ❌ |
+| CC | CC Haute Sarthe Alpes Mancelles | 200072700 | ❔ | ❌ | ❌ |
+| CC | CC de la Champagne Conlinoise et du Pays de Sillé | 200072718 | ❔ | ❌ | ❌ |
+| CC | CC Sud Sarthe | 200073112 | ❔ | ❌ | ❌ |
+| CU | CU d'Alençon | 246100663 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Sabolien | 247200090 | ❔ | ❌ | ❌ |
+| CU | CU Le Mans Métropole | 247200132 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Fléchois | 247200348 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Est Manceau | 247200421 | ❔ | ❌ | ❌ |
+| CC | CC Orée de Bercé - Belinois | 247200447 | ❔ | ❌ | ❌ |
+| CC | CC du Val de Sarthe | 247200629 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de l'Huisne Sarthoise | 247200686 | ❔ | ❌ | ❌ |
+| Département | Vendée | 85 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Saint-Gilles-Croix-de-Vie | 200023778 | ❔ | ❌ | ❌ |
+| CA | CA Terres de Montaigu | 200070233 | ❔ | ❌ | ❌ |
+| CA | CA Les Sables d'Olonne Agglomération | 200071165 | ✅ | ✅ | ❌ |
+| CC | CC Challans-Gois Communauté | 200071629 | ❔ | ❌ | ❌ |
+| CC | CC Vendée Grand Littoral | 200071900 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saint-Fulgent - Les Essarts | 200071918 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Fontenay-Vendée | 200071934 | ❔ | ❌ | ❌ |
+| CC | CC de Vie et Boulogne | 200072882 | ❔ | ❌ | ❌ |
+| CC | CC Sud Vendée Littoral | 200073260 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ile de Noirmoutier | 248500191 | ❔ | ❌ | ❌ |
+| CC | CC Océan Marais de Monts | 248500258 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Chantonnay | 248500340 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de la Châtaigneraie | 248500415 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Pouzauges | 248500464 | ❔ | ❌ | ❌ |
+| CC | CC du Pays des Achards | 248500530 | ✅ | ✅ | ❌ |
+| CC | CC Vendée, Sèvre, Autise | 248500563 | ❔ | ❌ | ❌ |
+| CA | CA La Roche-sur-Yon - Agglomération | 248500589 | ✅ | ✅ | ❌ |
+| CC | CC du Pays des Herbiers | 248500621 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Mortagne | 248500662 | ❔ | ❌ | ❌ |

--- a/couverture/52_Pays_de_la_Loire.md
+++ b/couverture/52_Pays_de_la_Loire.md
@@ -22,7 +22,7 @@
 | CA          | CA de la Presqu'île de Guérande Atlantique (Cap Atlantique) | 244400610 | ❔               | ❌        | ❌    |
 | CA          | CA de la Région Nazairienne et de l'Estuaire (CARENE)       | 244400644 | ❔               | ❌        | ❌    |
 | Département | Maine-et-Loire                                              | 49        | ❔               | ❌        | ❌    |
-| CA          | CA Mauges Communauté                                        | 200060010 | ❔               | ❌        | ❌    |
+| CA          | CA Mauges Communauté                                        | 200060010 | ✅               | ✅        | ✅    |
 | CC          | CC Anjou Loir et Sarthe                                     | 200068955 | ❔               | ❌        | ❌    |
 | CC          | CC Loire Layon Aubance                                      | 200071553 | ✅               | ✅        | ✅    |
 | CA          | CA Cholet Agglomération                                     | 200071678 | ✅               | ✅        | ❌    |

--- a/couverture/52_Pays_de_la_Loire.md
+++ b/couverture/52_Pays_de_la_Loire.md
@@ -23,15 +23,15 @@
 | CA          | CA de la Région Nazairienne et de l'Estuaire (CARENE)       | 244400644 | ❔               | ❌        | ❌    |
 | Département | Maine-et-Loire                                              | 49        | ❔               | ❌        | ❌    |
 | CA          | CA Mauges Communauté                                        | 200060010 | ✅               | ✅        | ✅    |
-| CC          | CC Anjou Loir et Sarthe                                     | 200068955 | ❔               | ❌        | ❌    |
+| CC          | CC Anjou Loir et Sarthe                                     | 200068955 | ❌               | ❌        | ✅    |
 | CC          | CC Loire Layon Aubance                                      | 200071553 | ✅               | ✅        | ✅    |
-| CA          | CA Cholet Agglomération                                     | 200071678 | ✅               | ✅        | ❌    |
-| CC          | CC des Vallées du Haut-Anjou                                | 200071868 | ❔               | ❌        | ❌    |
-| CA          | CA Saumur Val de Loire                                      | 200071876 | ✅               | ✅        | ❌    |
-| CC          | CC du Pays d'Ancenis                                        | 244400552 | ❔               | ❌        | ❌    |
-| CU          | CU Angers Loire Métropole                                   | 244900015 | ✅               | ✅        | ❌    |
-| CC          | CC Anjou Bleu Communauté                                    | 244900809 | ✅               | ✅        | ❌    |
-| CC          | CC Baugeois Vallée                                          | 244900882 | ❔               | ❌        | ❌    |
+| CA          | CA Cholet Agglomération                                     | 200071678 | ✅               | ✅        | ✅    |
+| CC          | CC des Vallées du Haut-Anjou                                | 200071868 | ❌               | ❌        | ✅    |
+| CA          | CA Saumur Val de Loire                                      | 200071876 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays d'Ancenis                                        | 244400552 | ❌               | ❌        | ✅    |
+| CU          | CU Angers Loire Métropole                                   | 244900015 | ✅               | ✅        | ✅    |
+| CC          | CC Anjou Bleu Communauté                                    | 244900809 | ✅               | ✅        | ✅    |
+| CC          | CC Baugeois Vallée                                          | 244900882 | ❌               | ❌        | ✅    |
 | Département | Mayenne                                                     | 53        | ❔               | ❌        | ❌    |
 | CC          | CC des Coëvrons                                             | 200033298 | ❔               | ❌        | ❌    |
 | CC          | CC du Mont des Avaloirs                                     | 200042182 | ❔               | ❌        | ❌    |

--- a/couverture/53_Bretagne.md
+++ b/couverture/53_Bretagne.md
@@ -1,0 +1,75 @@
+# Couverture des aides en Bretagne (53)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Bretagne | 53 | ❔ | ❌ | ❌ |
+| Département | Côtes-d'Armor | 22 | ❔ | ❌ | ❌ |
+| CA | CA Lannion-Trégor Communauté | 200065928 | ✅ | ✅ | ❌ |
+| CC | CC Loudéac Communauté - Bretagne Centre | 200067460 | ❔ | ❌ | ❌ |
+| CA | CA Guingamp-Paimpol Agglomération de l'Armor à l'Argoat | 200067981 | ❔ | ❌ | ❌ |
+| CA | CA Dinan Agglomération | 200068989 | ❔ | ❌ | ❌ |
+| CC | CC Leff Armor Communauté | 200069086 | ❔ | ❌ | ❌ |
+| CA | CA Lamballe Terre et Mer | 200069391 | ❔ | ❌ | ❌ |
+| CA | CA Saint-Brieuc Armor Agglomération | 200069409 | ✅ | ✅ | ❌ |
+| CC | CC du Kreiz-Breizh (CCKB) | 242200715 | ✅ | ✅ | ❌ |
+| CC | CC Poher Communauté | 242900744 | ✅ | ✅ | ❌ |
+| CC | CC Côte d'Emeraude | 243500725 | ✅ | ✅ | ❌ |
+| CC | CC Pontivy Communauté | 245614433 | ✅ | ✅ | ❌ |
+| Département | Finistère | 29 | ❔ | ❌ | ❌ |
+| CC | CC Presqu'île de Crozon-Aulne maritime | 200066868 | ✅ | ✅ | ❌ |
+| CC | CC Haut-Léon Communauté | 200067072 | ❔ | ❌ | ❌ |
+| CC | CC Monts d'Arrée Communauté | 200067197 | ❔ | ❌ | ❌ |
+| CC | CC Pleyben-Châteaulin-Porzay | 200067247 | ❔ | ❌ | ❌ |
+| CA | CA Quimper Bretagne Occidentale | 200068120 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Iroise | 242900074 | ✅ | ✅ | ❌ |
+| METRO | Brest Métropole | 242900314 | ✅ | ✅ | ❌ |
+| CC | CC du Pays des Abers | 242900553 | ❔ | ❌ | ❌ |
+| CC | CC de Haute Cornouaille | 242900561 | ✅ | ✅ | ❌ |
+| CC | CC Cap Sizun - Pointe du Raz | 242900629 | ❔ | ❌ | ❌ |
+| CC | CC Douarnenez Communauté | 242900645 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Fouesnantais | 242900660 | ❔ | ❌ | ❌ |
+| CA | CA Quimperlé Communauté | 242900694 | ✅ | ✅ | ❌ |
+| CC | CC du Pays Bigouden Sud | 242900702 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Pays Bigouden | 242900710 | ❔ | ❌ | ❌ |
+| CC | CC Poher Communauté | 242900744 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Landivisiau | 242900751 | ❔ | ❌ | ❌ |
+| CA | CA Concarneau Cornouaille Agglomération | 242900769 | ❔ | ❌ | ❌ |
+| CC | CC Communauté Lesneven Côte des Légendes | 242900793 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Landerneau-Daoulas | 242900801 | ❔ | ❌ | ❌ |
+| CA | CA Morlaix Communauté | 242900835 | ✅ | ✅ | ❌ |
+| Département | Ille-et-Vilaine | 35 | ❔ | ❌ | ❌ |
+| CC | CC de Saint-Méen Montauban | 200038990 | ❔ | ❌ | ❌ |
+| CA | CA Vitré Communauté | 200039022 | ❔ | ❌ | ❌ |
+| CC | CC Vallons de Haute-Bretagne Communauté | 200043990 | ✅ | ✅ | ❌ |
+| CC | CC Bretagne Porte de Loire Communauté | 200070662 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Dol et de la Baie du Mont Saint-Michel | 200070670 | ✅ | ✅ | ❌ |
+| CC | CC Couesnon Marches de Bretagne | 200070688 | ✅ | ✅ | ❌ |
+| CA | CA Fougères Agglomération | 200072452 | ✅ | ✅ | ❌ |
+| METRO | Rennes Métropole | 243500139 | ❔ | ❌ | ❌ |
+| CC | CC Montfort Communauté | 243500550 | ✅ | ✅ | ❌ |
+| CC | CC Brocéliande Communauté | 243500618 | ❔ | ❌ | ❌ |
+| CC | CC Roche aux Fées Communauté | 243500634 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Châteaugiron Communauté | 243500659 | ✅ | ✅ | ❌ |
+| CC | CC Val d'Ille-Aubigné | 243500667 | ❔ | ❌ | ❌ |
+| CC | CC Côte d'Emeraude | 243500725 | ✅ | ✅ | ❌ |
+| CC | CC Bretagne Romantique | 243500733 | ✅ | ✅ | ❌ |
+| CA | CA Redon Agglomération | 243500741 | ❔ | ❌ | ❌ |
+| CC | CC Liffré-Cormier Communauté | 243500774 | ✅ | ✅ | ❌ |
+| CA | CA du Pays de Saint Malo Agglomération | 243500782 | ❔ | ❌ | ❌ |
+| Département | Morbihan | 56 | ❔ | ❌ | ❌ |
+| CC | CC Arc Sud Bretagne | 200027027 | ✅ | ✅ | ❌ |
+| CA | CA Lorient Agglomération | 200042174 | ✅ | ✅ | ❌ |
+| CC | CC Auray Quiberon Terre Atlantique | 200043123 | ✅ | ✅ | ❌ |
+| CC | CC Ploërmel Communauté | 200066777 | ❔ | ❌ | ❌ |
+| CC | CC de l'Oust à Brocéliande | 200066785 | ❔ | ❌ | ❌ |
+| CA | CA Golfe du Morbihan - Vannes Agglomération | 200067932 | ❔ | ❌ | ❌ |
+| CC | CC Baud Communauté | 200096675 | ❔ | ❌ | ❌ |
+| CC | CC Centre Morbihan Communauté | 200096683 | ❔ | ❌ | ❌ |
+| CA | CA Redon Agglomération | 243500741 | ❔ | ❌ | ❌ |
+| CA | CA de la Presqu'île de Guérande Atlantique (Cap Atlantique) | 244400610 | ❔ | ❌ | ❌ |
+| CC | CC Blavet Bellevue Océan | 245600440 | ❔ | ❌ | ❌ |
+| CC | CC de Belle Ile en Mer | 245600465 | ❔ | ❌ | ❌ |
+| CC | CC Questembert Communauté | 245614383 | ❔ | ❌ | ❌ |
+| CC | CC Roi Morvan Communauté | 245614417 | ❔ | ❌ | ❌ |
+| CC | CC Pontivy Communauté | 245614433 | ✅ | ✅ | ❌ |

--- a/couverture/75_Nouvelle-Aquitaine.md
+++ b/couverture/75_Nouvelle-Aquitaine.md
@@ -1,178 +1,177 @@
 # Couverture des aides en Nouvelle-Aquitaine (75)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Nouvelle-Aquitaine | 75 | ❔ | ❌ | ❌ |
-| Département | Charente | 16 | ❔ | ❌ | ❌ |
-| CC | CC des 4B Sud Charente | 200029734 | ❔ | ❌ | ❌ |
-| CC | CC Val de Charente | 200043016 | ❔ | ❌ | ❌ |
-| CC | CC La Rochefoucauld Porte du Périgord | 200068914 | ❔ | ❌ | ❌ |
-| CC | CC Lavalette Tude Dronne | 200070282 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Cognac | 200070514 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Angoulême | 200071827 | ✅ | ✅ | ❌ |
-| CC | CC Coeur de Charente | 200072023 | ❔ | ❌ | ❌ |
-| CC | CC de Charente Limousine | 200072049 | ❔ | ❌ | ❌ |
-| CC | CC du Rouillacais | 241600303 | ❔ | ❌ | ❌ |
-| Département | Charente-Maritime | 17 | ❔ | ❌ | ❌ |
-| CA | CA "Saintes - Grandes Rives - L'Agglo" | 200036473 | ✅ | ✅ | ❌ |
-| CC | CC Aunis Atlantique | 200041499 | ✅ | ✅ | ❌ |
-| CC | CC de la Haute Saintonge | 200041523 | ❔ | ❌ | ❌ |
-| CC | CC Aunis Sud | 200041614 | ❔ | ❌ | ❌ |
-| CC | CC Vals de Saintonge Communauté | 200041689 | ❔ | ❌ | ❌ |
-| CA | CA Rochefort Océan | 200041762 | ✅ | ✅ | ❌ |
-| CA | CA de La Rochelle | 241700434 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ile de Ré | 241700459 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Saintonge | 241700517 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ile d'Oléron | 241700624 | ❔ | ❌ | ❌ |
-| CC | CC de Gémozac et de la Saintonge Viticole | 241700632 | ❔ | ❌ | ❌ |
-| CA | CA Royan Atlantique | 241700640 | ❔ | ❌ | ❌ |
-| CC | CC du Bassin de Marennes | 241700699 | ❔ | ❌ | ❌ |
-| Département | Corrèze | 19 | ❔ | ❌ | ❌ |
-| CA | CA du Bassin de Brive | 200043172 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Lubersac-Pompadour | 200066603 | ❔ | ❌ | ❌ |
-| CC | CC Vézère-Monédières-Millesources | 200066645 | ❔ | ❌ | ❌ |
-| CC | CC Haute-Corrèze Communauté | 200066744 | ❔ | ❌ | ❌ |
-| CC | CC Xaintrie Val'Dordogne | 200066751 | ❔ | ❌ | ❌ |
-| CC | CC Midi Corrézien | 200066769 | ❔ | ❌ | ❌ |
-| CC | CC de Ventadour - Egletons - Monédières | 241900133 | ❔ | ❌ | ❌ |
-| CA | CA Tulle Agglo | 241927201 | ✅ | ✅ | ❌ |
-| CC | CC du Pays d'Uzerche | 241927243 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saint Yrieix | 248700189 | ❔ | ❌ | ❌ |
-| Département | Creuse | 23 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Guéret | 200034825 | ❔ | ❌ | ❌ |
-| CC | CC Portes de la Creuse en Marche | 200041556 | ❔ | ❌ | ❌ |
-| CC | CC Creuse Grand Sud | 200044014 | ❔ | ❌ | ❌ |
-| CC | CC Haute-Corrèze Communauté | 200066744 | ❔ | ❌ | ❌ |
-| CC | CC Creuse Sud Ouest | 200067189 | ❔ | ❌ | ❌ |
-| CC | CC Creuse Confluence | 200067544 | ❔ | ❌ | ❌ |
-| CC | CC Marche et Combraille en Aquitaine | 200067593 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Sostranien | 242300135 | ❔ | ❌ | ❌ |
-| CC | CC de Bénévent Grand Bourg | 242320000 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Dunois | 242320109 | ❔ | ❌ | ❌ |
-| Département | Dordogne | 24 | ❔ | ❌ | ❌ |
-| CC | CC Sarlat-Périgord Noir | 200027217 | ❔ | ❌ | ❌ |
-| CC | CC de Montaigne Montravel et Gurson | 200034197 | ❔ | ❌ | ❌ |
-| CC | CC des Bastides Dordogne-Périgord | 200034833 | ❔ | ❌ | ❌ |
-| CC | CC Isle Vern Salembre en Périgord | 200040095 | ❔ | ❌ | ❌ |
-| CC | CC Isle Double Landais | 200040384 | ❔ | ❌ | ❌ |
-| CA | CA Le Grand Périgueux | 200040392 | ✅ | ✅ | ❌ |
-| CC | CC du Périgord Ribéracois | 200040400 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Fénelon | 200040830 | ❔ | ❌ | ❌ |
-| CC | CC de Portes Sud Périgord | 200040889 | ❔ | ❌ | ❌ |
-| CC | CC Vallée de la Dordogne et Forêt Bessède | 200041051 | ❔ | ❌ | ❌ |
-| CC | CC Terrassonnais Haut Périgord Noir | 200041150 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de l'Homme | 200041168 | ✅ | ✅ | ❌ |
-| CC | CC de Domme- Villefranche du Périgord | 200041440 | ❔ | ❌ | ❌ |
-| CC | CC Dronne et Belle | 200041572 | ❔ | ❌ | ❌ |
-| CC | CC Isle et Crempse en Périgord | 200069094 | ❔ | ❌ | ❌ |
-| CA | CA Bergeracoise | 200070647 | ❔ | ❌ | ❌ |
-| CC | CC du Périgord Nontronnais | 200071819 | ❔ | ❌ | ❌ |
-| CC | CC Périgord-Limousin | 242400752 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saint Aulaye | 242400935 | ❔ | ❌ | ❌ |
-| CC | CC Isle-Loue-Auvézère en Périgord | 242401024 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Foyen | 243301371 | ❔ | ❌ | ❌ |
-| CC | CC Castillon/Pujols | 243301454 | ❔ | ❌ | ❌ |
-| Département | Gironde | 33 | ❔ | ❌ | ❌ |
-| CC | CC de Blaye | 200023794 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Saint Emilionnais | 200035533 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Gironde | 200043974 | ❔ | ❌ | ❌ |
-| CC | CC du Bazadais | 200043982 | ❔ | ❌ | ❌ |
-| CC | CC du Réolais en Sud Gironde | 200044394 | ❔ | ❌ | ❌ |
-| CC | CC Convergence Garonne | 200069581 | ❔ | ❌ | ❌ |
-| CC | CC Rurales de l'Entre-Deux-Mers | 200069599 | ❔ | ❌ | ❌ |
-| CC | CC Médoc Coeur de Presqu'île | 200069995 | ❔ | ❌ | ❌ |
-| CA | CA du Libournais | 200070092 | ✅ | ✅ | ❌ |
-| CC | CC Médoc Atlantique | 200070720 | ❔ | ❌ | ❌ |
-| METRO | Bordeaux Métropole | 243300316 | ✅ | ✅ | ❌ |
-| CA | CA Bassin d'Arcachon Sud (COBAS) | 243300563 | ❔ | ❌ | ❌ |
-| CC | CC de l'Estuaire | 243300811 | ❔ | ❌ | ❌ |
-| CC | CC Jalle-Eau-Bourde | 243301165 | ❔ | ❌ | ❌ |
-| CC | CC Latitude Nord Gironde | 243301181 | ❔ | ❌ | ❌ |
-| CC | CC du Créonnais | 243301215 | ❔ | ❌ | ❌ |
-| CC | CC du Grand Cubzaguais | 243301223 | ✅ | ✅ | ❌ |
-| CC | CC Les Rives de la Laurence | 243301249 | ❔ | ❌ | ❌ |
-| CC | CC de Montesquieu | 243301264 | ❔ | ❌ | ❌ |
-| CC | CC les Coteaux Bordelais | 243301355 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Foyen | 243301371 | ❔ | ❌ | ❌ |
-| CC | CC Médullienne | 243301389 | ❔ | ❌ | ❌ |
-| CC | CC du Fronsadais | 243301397 | ❔ | ❌ | ❌ |
-| CC | CC du Val de l'Eyre | 243301405 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de l'Entre-Deux-Mers | 243301439 | ❔ | ❌ | ❌ |
-| CC | CC Médoc Estuaire | 243301447 | ❔ | ❌ | ❌ |
-| CC | CC Castillon/Pujols | 243301454 | ❔ | ❌ | ❌ |
-| CA | CA du Bassin d'Arcachon Nord (COBAN) | 243301504 | ❔ | ❌ | ❌ |
-| Département | Landes | 40 | ❔ | ❌ | ❌ |
-| CC | CC d'Aire-sur-l'Adour | 200030435 | ❔ | ❌ | ❌ |
-| CC | CC des Landes d'Armagnac | 200035541 | ❔ | ❌ | ❌ |
-| CC | CC Pays d'Orthe et Arrigans | 200069417 | ❔ | ❌ | ❌ |
-| CC | CC Terres de Chalosse | 200069631 | ❔ | ❌ | ❌ |
-| CC | CC Chalosse Tursan | 200069649 | ❔ | ❌ | ❌ |
-| CC | CC Coeur Haute Lande | 200069656 | ❔ | ❌ | ❌ |
-| CC | CC de Mimizan | 244000543 | ❔ | ❌ | ❌ |
-| CC | CC du Seignanx | 244000659 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Dax | 244000675 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Morcenais | 244000691 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Tarusate | 244000766 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Villeneuve en Armagnac Landais | 244000774 | ❔ | ❌ | ❌ |
-| CA | CA Mont de Marsan Agglomération | 244000808 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Grenadois | 244000824 | ❔ | ❌ | ❌ |
-| CC | CC Côte Landes Nature | 244000857 | ❔ | ❌ | ❌ |
-| CC | CC Maremne Adour Côte Sud | 244000865 | ❔ | ❌ | ❌ |
-| CC | CC des Grands Lacs | 244000873 | ❔ | ❌ | ❌ |
-| CC | CC Coteaux et Vallées des Luys | 244000881 | ❔ | ❌ | ❌ |
-| Département | Lot-et-Garonne | 47 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Villeneuvois | 200023307 | ✅ | ✅ | ❌ |
-| CA | CA Val de Garonne Agglomération | 200030674 | ❔ | ❌ | ❌ |
-| CC | CC des Bastides en Haut Agenais Périgord | 200036523 | ❔ | ❌ | ❌ |
-| CC | CC du Confluent et des Coteaux de Prayssas | 200068922 | ❔ | ❌ | ❌ |
-| CC | CC Fumel Vallée du Lot | 200068930 | ❔ | ❌ | ❌ |
-| CC | CC Albret Communauté | 200068948 | ❔ | ❌ | ❌ |
-| CA | CA Agglomération d'Agen | 200096956 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Duras | 244700449 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Lauzun | 244700464 | ❔ | ❌ | ❌ |
-| CC | CC des Coteaux et Landes de Gascogne | 244701355 | ❔ | ❌ | ❌ |
-| CC | CC Lot et Tolzac | 244701405 | ❔ | ❌ | ❌ |
-| CC | CC des Deux Rives | 248200016 | ❔ | ❌ | ❌ |
-| Département | Pyrénées-Atlantiques | 64 | ❔ | ❌ | ❌ |
-| CC | CC de Lacq-Orthez | 200039204 | ❔ | ❌ | ❌ |
-| CA | CA du Pays Basque | 200067106 | ❔ | ❌ | ❌ |
-| CC | CC des Luys en Béarn | 200067239 | ❔ | ❌ | ❌ |
-| CA | CA Pau Béarn Pyrénées | 200067254 | ✅ | ✅ | ❌ |
-| CC | CC du Haut Béarn | 200067262 | ✅ | ✅ | ❌ |
-| CC | CC du Béarn des Gaves | 200067288 | ❔ | ❌ | ❌ |
-| CC | CC du Nord Est Béarn | 200067296 | ❔ | ❌ | ❌ |
-| CC | CC Adour Madiran | 200072106 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée d'Ossau | 246400337 | ✅ | ✅ | ❌ |
-| CC | CC Pays de Nay | 246401756 | ❔ | ❌ | ❌ |
-| Département | Deux-Sèvres | 79 | ❔ | ❌ | ❌ |
-| CA | CA du Bocage Bressuirais | 200040244 | ❔ | ❌ | ❌ |
-| CA | CA du Niortais | 200041317 | ❔ | ❌ | ❌ |
-| CC | CC de Parthenay-Gâtine | 200041333 | ❔ | ❌ | ❌ |
-| CC | CC Airvaudais-Val du Thouet | 200041416 | ❔ | ❌ | ❌ |
-| CC | CC Haut Val de Sèvre | 200041994 | ✅ | ✅ | ❌ |
-| CC | CC Val de Gâtine | 200069748 | ❔ | ❌ | ❌ |
-| CC | CC Mellois en Poitou | 200069755 | ❔ | ❌ | ❌ |
-| CC | CC du Thouarsais | 247900798 | ❔ | ❌ | ❌ |
-| Département | Vienne | 86 | ❔ | ❌ | ❌ |
-| CC | CC des Vallées du Clain | 200043628 | ❔ | ❌ | ❌ |
-| CC | CC du Haut Poitou | 200069763 | ❔ | ❌ | ❌ |
-| CU | CU du Grand Poitiers | 200069854 | ✅ | ✅ | ❌ |
-| CC | CC du Civraisien en Poitou | 200070035 | ❔ | ❌ | ❌ |
-| CC | CC Vienne et Gartempe | 200070043 | ✅ | ✅ | ❌ |
-| CA | CA Grand Châtellerault | 248600413 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Loudunais | 248600447 | ❔ | ❌ | ❌ |
-| Département | Haute-Vienne | 87 | ❔ | ❌ | ❌ |
-| CC | CC Briance Sud Haute Vienne | 200040814 | ❔ | ❌ | ❌ |
-| CC | CC Porte Océane du Limousin | 200059400 | ❔ | ❌ | ❌ |
-| CC | CC Élan Limousin Avenir Nature | 200066512 | ❔ | ❌ | ❌ |
-| CC | CC Ouest Limousin | 200066520 | ❔ | ❌ | ❌ |
-| CC | CC Pays de Nexon Monts de Chalus | 200070506 | ❔ | ❌ | ❌ |
-| CC | CC Haut Limousin en Marche | 200071942 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saint Yrieix | 248700189 | ❔ | ❌ | ❌ |
-| CC | CC Gartempe - Saint Pardoux | 248719262 | ❔ | ❌ | ❌ |
-| CC | CC du Val de Vienne | 248719288 | ❔ | ❌ | ❌ |
-| CU | CU Limoges Métropole | 248719312 | ✅ | ✅ | ❌ |
-| CC | CC Briance-Combade | 248719338 | ❔ | ❌ | ❌ |
-| CC | CC des Portes de Vassivière | 248719353 | ❔ | ❌ | ❌ |
-| CC | CC de Noblat | 248719361 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                          | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | -------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Nouvelle-Aquitaine                           | 75        | ❔               | ❌        | ❌    |
+| Département | Charente                                     | 16        | ❔               | ❌        | ❌    |
+| CC          | CC des 4B Sud Charente                       | 200029734 | ❔               | ❌        | ❌    |
+| CC          | CC Val de Charente                           | 200043016 | ❔               | ❌        | ❌    |
+| CC          | CC La Rochefoucauld Porte du Périgord        | 200068914 | ❔               | ❌        | ❌    |
+| CC          | CC Lavalette Tude Dronne                     | 200070282 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Cognac                           | 200070514 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Angoulême                        | 200071827 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur de Charente                         | 200072023 | ❔               | ❌        | ❌    |
+| CC          | CC de Charente Limousine                     | 200072049 | ❔               | ❌        | ❌    |
+| CC          | CC du Rouillacais                            | 241600303 | ❔               | ❌        | ❌    |
+| Département | Charente-Maritime                            | 17        | ❔               | ❌        | ❌    |
+| CA          | CA "Saintes - Grandes Rives - L'Agglo"       | 200036473 | ✅               | ✅        | ❌    |
+| CC          | CC Aunis Atlantique                          | 200041499 | ✅               | ✅        | ❌    |
+| CC          | CC de la Haute Saintonge                     | 200041523 | ❔               | ❌        | ❌    |
+| CC          | CC Aunis Sud                                 | 200041614 | ❔               | ❌        | ❌    |
+| CC          | CC Vals de Saintonge Communauté              | 200041689 | ❔               | ❌        | ❌    |
+| CA          | CA Rochefort Océan                           | 200041762 | ✅               | ✅        | ❌    |
+| CA          | CA de La Rochelle                            | 241700434 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ile de Ré                            | 241700459 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Saintonge                        | 241700517 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Ile d'Oléron                         | 241700624 | ❔               | ❌        | ❌    |
+| CC          | CC de Gémozac et de la Saintonge Viticole    | 241700632 | ❔               | ❌        | ❌    |
+| CA          | CA Royan Atlantique                          | 241700640 | ❔               | ❌        | ❌    |
+| CC          | CC du Bassin de Marennes                     | 241700699 | ❔               | ❌        | ❌    |
+| Département | Corrèze                                      | 19        | ❔               | ❌        | ❌    |
+| CA          | CA du Bassin de Brive                        | 200043172 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Lubersac-Pompadour             | 200066603 | ❔               | ❌        | ❌    |
+| CC          | CC Vézère-Monédières-Millesources            | 200066645 | ❔               | ❌        | ❌    |
+| CC          | CC Haute-Corrèze Communauté                  | 200066744 | ❔               | ❌        | ❌    |
+| CC          | CC Xaintrie Val'Dordogne                     | 200066751 | ❔               | ❌        | ❌    |
+| CC          | CC Midi Corrézien                            | 200066769 | ❔               | ❌        | ❌    |
+| CC          | CC de Ventadour - Egletons - Monédières      | 241900133 | ❔               | ❌        | ❌    |
+| CA          | CA Tulle Agglo                               | 241927201 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays d'Uzerche                         | 241927243 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saint Yrieix                   | 248700189 | ❔               | ❌        | ❌    |
+| Département | Creuse                                       | 23        | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Guéret                           | 200034825 | ❔               | ❌        | ❌    |
+| CC          | CC Portes de la Creuse en Marche             | 200041556 | ❔               | ❌        | ❌    |
+| CC          | CC Creuse Grand Sud                          | 200044014 | ❔               | ❌        | ❌    |
+| CC          | CC Haute-Corrèze Communauté                  | 200066744 | ❔               | ❌        | ❌    |
+| CC          | CC Creuse Sud Ouest                          | 200067189 | ❔               | ❌        | ❌    |
+| CC          | CC Creuse Confluence                         | 200067544 | ❔               | ❌        | ❌    |
+| CC          | CC Marche et Combraille en Aquitaine         | 200067593 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Sostranien                        | 242300135 | ❔               | ❌        | ❌    |
+| CC          | CC de Bénévent Grand Bourg                   | 242320000 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Dunois                            | 242320109 | ❔               | ❌        | ❌    |
+| Département | Dordogne                                     | 24        | ❔               | ❌        | ❌    |
+| CC          | CC Sarlat-Périgord Noir                      | 200027217 | ❔               | ❌        | ❌    |
+| CC          | CC de Montaigne Montravel et Gurson          | 200034197 | ❔               | ❌        | ❌    |
+| CC          | CC des Bastides Dordogne-Périgord            | 200034833 | ❔               | ❌        | ❌    |
+| CC          | CC Isle Vern Salembre en Périgord            | 200040095 | ❔               | ❌        | ❌    |
+| CC          | CC Isle Double Landais                       | 200040384 | ❔               | ❌        | ❌    |
+| CA          | CA Le Grand Périgueux                        | 200040392 | ✅               | ✅        | ❌    |
+| CC          | CC du Périgord Ribéracois                    | 200040400 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Fénelon                        | 200040830 | ❔               | ❌        | ❌    |
+| CC          | CC de Portes Sud Périgord                    | 200040889 | ❔               | ❌        | ❌    |
+| CC          | CC Vallée de la Dordogne et Forêt Bessède    | 200041051 | ❔               | ❌        | ❌    |
+| CC          | CC Terrassonnais Haut Périgord Noir          | 200041150 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de l'Homme                   | 200041168 | ✅               | ✅        | ❌    |
+| CC          | CC de Domme- Villefranche du Périgord        | 200041440 | ❔               | ❌        | ❌    |
+| CC          | CC Dronne et Belle                           | 200041572 | ❔               | ❌        | ❌    |
+| CC          | CC Isle et Crempse en Périgord               | 200069094 | ❔               | ❌        | ❌    |
+| CA          | CA Bergeracoise                              | 200070647 | ❔               | ❌        | ❌    |
+| CC          | CC du Périgord Nontronnais                   | 200071819 | ❔               | ❌        | ❌    |
+| CC          | CC Périgord-Limousin                         | 242400752 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saint Aulaye                   | 242400935 | ❔               | ❌        | ❌    |
+| CC          | CC Isle-Loue-Auvézère en Périgord            | 242401024 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Foyen                             | 243301371 | ❔               | ❌        | ❌    |
+| CC          | CC Castillon/Pujols                          | 243301454 | ❔               | ❌        | ❌    |
+| Département | Gironde                                      | 33        | ❔               | ❌        | ❌    |
+| CC          | CC de Blaye                                  | 200023794 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Saint Emilionnais                | 200035533 | ❔               | ❌        | ❌    |
+| CC          | CC du Sud Gironde                            | 200043974 | ❔               | ❌        | ❌    |
+| CC          | CC du Bazadais                               | 200043982 | ❔               | ❌        | ❌    |
+| CC          | CC du Réolais en Sud Gironde                 | 200044394 | ❔               | ❌        | ❌    |
+| CC          | CC Convergence Garonne                       | 200069581 | ❔               | ❌        | ❌    |
+| CC          | CC Rurales de l'Entre-Deux-Mers              | 200069599 | ❔               | ❌        | ❌    |
+| CC          | CC Médoc Coeur de Presqu'île                 | 200069995 | ❔               | ❌        | ❌    |
+| CA          | CA du Libournais                             | 200070092 | ✅               | ✅        | ❌    |
+| CC          | CC Médoc Atlantique                          | 200070720 | ❔               | ❌        | ❌    |
+| METRO       | Bordeaux Métropole                           | 243300316 | ✅               | ✅        | ❌    |
+| CA          | CA Bassin d'Arcachon Sud (COBAS)             | 243300563 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Estuaire                             | 243300811 | ❔               | ❌        | ❌    |
+| CC          | CC Jalle-Eau-Bourde                          | 243301165 | ❔               | ❌        | ❌    |
+| CC          | CC Latitude Nord Gironde                     | 243301181 | ❔               | ❌        | ❌    |
+| CC          | CC du Créonnais                              | 243301215 | ❔               | ❌        | ❌    |
+| CC          | CC du Grand Cubzaguais                       | 243301223 | ✅               | ✅        | ❌    |
+| CC          | CC Les Rives de la Laurence                  | 243301249 | ❔               | ❌        | ❌    |
+| CC          | CC de Montesquieu                            | 243301264 | ❔               | ❌        | ❌    |
+| CC          | CC les Coteaux Bordelais                     | 243301355 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Foyen                             | 243301371 | ❔               | ❌        | ❌    |
+| CC          | CC Médullienne                               | 243301389 | ❔               | ❌        | ❌    |
+| CC          | CC du Fronsadais                             | 243301397 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de l'Eyre                          | 243301405 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de l'Entre-Deux-Mers           | 243301439 | ❔               | ❌        | ❌    |
+| CC          | CC Médoc Estuaire                            | 243301447 | ❔               | ❌        | ❌    |
+| CC          | CC Castillon/Pujols                          | 243301454 | ❔               | ❌        | ❌    |
+| CA          | CA du Bassin d'Arcachon Nord (COBAN)         | 243301504 | ❔               | ❌        | ❌    |
+| Département | Landes                                       | 40        | ❔               | ❌        | ❌    |
+| CC          | CC d'Aire-sur-l'Adour                        | 200030435 | ❔               | ❌        | ❌    |
+| CC          | CC des Landes d'Armagnac                     | 200035541 | ❔               | ❌        | ❌    |
+| CC          | CC Pays d'Orthe et Arrigans                  | 200069417 | ❔               | ❌        | ❌    |
+| CC          | CC Terres de Chalosse                        | 200069631 | ❔               | ❌        | ❌    |
+| CC          | CC Chalosse Tursan                           | 200069649 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur Haute Lande                         | 200069656 | ❔               | ❌        | ❌    |
+| CC          | CC de Mimizan                                | 244000543 | ❔               | ❌        | ❌    |
+| CC          | CC du Seignanx                               | 244000659 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Dax                              | 244000675 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Morcenais                         | 244000691 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Tarusate                          | 244000766 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Villeneuve en Armagnac Landais | 244000774 | ❔               | ❌        | ❌    |
+| CA          | CA Mont de Marsan Agglomération              | 244000808 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Grenadois                         | 244000824 | ❔               | ❌        | ❌    |
+| CC          | CC Côte Landes Nature                        | 244000857 | ❔               | ❌        | ❌    |
+| CC          | CC Maremne Adour Côte Sud                    | 244000865 | ❔               | ❌        | ❌    |
+| CC          | CC des Grands Lacs                           | 244000873 | ❔               | ❌        | ❌    |
+| CC          | CC Coteaux et Vallées des Luys               | 244000881 | ❔               | ❌        | ❌    |
+| Département | Lot-et-Garonne                               | 47        | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Villeneuvois                     | 200023307 | ✅               | ✅        | ❌    |
+| CA          | CA Val de Garonne Agglomération              | 200030674 | ❔               | ❌        | ❌    |
+| CC          | CC des Bastides en Haut Agenais Périgord     | 200036523 | ❔               | ❌        | ❌    |
+| CC          | CC du Confluent et des Coteaux de Prayssas   | 200068922 | ❔               | ❌        | ❌    |
+| CC          | CC Fumel Vallée du Lot                       | 200068930 | ❔               | ❌        | ❌    |
+| CC          | CC Albret Communauté                         | 200068948 | ❔               | ❌        | ❌    |
+| CA          | CA Agglomération d'Agen                      | 200096956 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Duras                          | 244700449 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Lauzun                         | 244700464 | ❔               | ❌        | ❌    |
+| CC          | CC des Coteaux et Landes de Gascogne         | 244701355 | ❔               | ❌        | ❌    |
+| CC          | CC Lot et Tolzac                             | 244701405 | ❔               | ❌        | ❌    |
+| CC          | CC des Deux Rives                            | 248200016 | ❔               | ❌        | ❌    |
+| Département | Pyrénées-Atlantiques                         | 64        | ❔               | ❌        | ❌    |
+| CC          | CC de Lacq-Orthez                            | 200039204 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays Basque                            | 200067106 | ❔               | ❌        | ❌    |
+| CC          | CC des Luys en Béarn                         | 200067239 | ❔               | ❌        | ❌    |
+| CA          | CA Pau Béarn Pyrénées                        | 200067254 | ✅               | ✅        | ❌    |
+| CC          | CC du Haut Béarn                             | 200067262 | ✅               | ✅        | ❌    |
+| CC          | CC du Béarn des Gaves                        | 200067288 | ❔               | ❌        | ❌    |
+| CC          | CC du Nord Est Béarn                         | 200067296 | ❔               | ❌        | ❌    |
+| CC          | CC Adour Madiran                             | 200072106 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée d'Ossau                      | 246400337 | ✅               | ✅        | ❌    |
+| CC          | CC Pays de Nay                               | 246401756 | ❔               | ❌        | ❌    |
+| Département | Deux-Sèvres                                  | 79        | ❔               | ❌        | ❌    |
+| CA          | CA du Bocage Bressuirais                     | 200040244 | ❔               | ❌        | ❌    |
+| CA          | CA du Niortais                               | 200041317 | ❔               | ❌        | ❌    |
+| CC          | CC de Parthenay-Gâtine                       | 200041333 | ❔               | ❌        | ❌    |
+| CC          | CC Airvaudais-Val du Thouet                  | 200041416 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Val de Sèvre                         | 200041994 | ✅               | ✅        | ❌    |
+| CC          | CC Val de Gâtine                             | 200069748 | ❔               | ❌        | ❌    |
+| CC          | CC Mellois en Poitou                         | 200069755 | ❔               | ❌        | ❌    |
+| CC          | CC du Thouarsais                             | 247900798 | ❔               | ❌        | ❌    |
+| Département | Vienne                                       | 86        | ❔               | ❌        | ❌    |
+| CC          | CC des Vallées du Clain                      | 200043628 | ❔               | ❌        | ❌    |
+| CC          | CC du Haut Poitou                            | 200069763 | ❔               | ❌        | ❌    |
+| CU          | CU du Grand Poitiers                         | 200069854 | ✅               | ✅        | ❌    |
+| CC          | CC du Civraisien en Poitou                   | 200070035 | ❔               | ❌        | ❌    |
+| CC          | CC Vienne et Gartempe                        | 200070043 | ✅               | ✅        | ❌    |
+| CA          | CA Grand Châtellerault                       | 248600413 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Loudunais                         | 248600447 | ❔               | ❌        | ❌    |
+| Département | Haute-Vienne                                 | 87        | ❔               | ❌        | ❌    |
+| CC          | CC Briance Sud Haute Vienne                  | 200040814 | ❔               | ❌        | ❌    |
+| CC          | CC Porte Océane du Limousin                  | 200059400 | ❔               | ❌        | ❌    |
+| CC          | CC Élan Limousin Avenir Nature               | 200066512 | ❔               | ❌        | ❌    |
+| CC          | CC Ouest Limousin                            | 200066520 | ❔               | ❌        | ❌    |
+| CC          | CC Pays de Nexon Monts de Chalus             | 200070506 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Limousin en Marche                   | 200071942 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saint Yrieix                   | 248700189 | ❔               | ❌        | ❌    |
+| CC          | CC Gartempe - Saint Pardoux                  | 248719262 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Vienne                          | 248719288 | ❔               | ❌        | ❌    |
+| CU          | CU Limoges Métropole                         | 248719312 | ✅               | ✅        | ❌    |
+| CC          | CC Briance-Combade                           | 248719338 | ❔               | ❌        | ❌    |
+| CC          | CC des Portes de Vassivière                  | 248719353 | ❔               | ❌        | ❌    |
+| CC          | CC de Noblat                                 | 248719361 | ❔               | ❌        | ❌    |

--- a/couverture/75_Nouvelle-Aquitaine.md
+++ b/couverture/75_Nouvelle-Aquitaine.md
@@ -1,0 +1,178 @@
+# Couverture des aides en Nouvelle-Aquitaine (75)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Nouvelle-Aquitaine | 75 | ❔ | ❌ | ❌ |
+| Département | Charente | 16 | ❔ | ❌ | ❌ |
+| CC | CC des 4B Sud Charente | 200029734 | ❔ | ❌ | ❌ |
+| CC | CC Val de Charente | 200043016 | ❔ | ❌ | ❌ |
+| CC | CC La Rochefoucauld Porte du Périgord | 200068914 | ❔ | ❌ | ❌ |
+| CC | CC Lavalette Tude Dronne | 200070282 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Cognac | 200070514 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Angoulême | 200071827 | ✅ | ✅ | ❌ |
+| CC | CC Coeur de Charente | 200072023 | ❔ | ❌ | ❌ |
+| CC | CC de Charente Limousine | 200072049 | ❔ | ❌ | ❌ |
+| CC | CC du Rouillacais | 241600303 | ❔ | ❌ | ❌ |
+| Département | Charente-Maritime | 17 | ❔ | ❌ | ❌ |
+| CA | CA "Saintes - Grandes Rives - L'Agglo" | 200036473 | ✅ | ✅ | ❌ |
+| CC | CC Aunis Atlantique | 200041499 | ✅ | ✅ | ❌ |
+| CC | CC de la Haute Saintonge | 200041523 | ❔ | ❌ | ❌ |
+| CC | CC Aunis Sud | 200041614 | ❔ | ❌ | ❌ |
+| CC | CC Vals de Saintonge Communauté | 200041689 | ❔ | ❌ | ❌ |
+| CA | CA Rochefort Océan | 200041762 | ✅ | ✅ | ❌ |
+| CA | CA de La Rochelle | 241700434 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ile de Ré | 241700459 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Saintonge | 241700517 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ile d'Oléron | 241700624 | ❔ | ❌ | ❌ |
+| CC | CC de Gémozac et de la Saintonge Viticole | 241700632 | ❔ | ❌ | ❌ |
+| CA | CA Royan Atlantique | 241700640 | ❔ | ❌ | ❌ |
+| CC | CC du Bassin de Marennes | 241700699 | ❔ | ❌ | ❌ |
+| Département | Corrèze | 19 | ❔ | ❌ | ❌ |
+| CA | CA du Bassin de Brive | 200043172 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lubersac-Pompadour | 200066603 | ❔ | ❌ | ❌ |
+| CC | CC Vézère-Monédières-Millesources | 200066645 | ❔ | ❌ | ❌ |
+| CC | CC Haute-Corrèze Communauté | 200066744 | ❔ | ❌ | ❌ |
+| CC | CC Xaintrie Val'Dordogne | 200066751 | ❔ | ❌ | ❌ |
+| CC | CC Midi Corrézien | 200066769 | ❔ | ❌ | ❌ |
+| CC | CC de Ventadour - Egletons - Monédières | 241900133 | ❔ | ❌ | ❌ |
+| CA | CA Tulle Agglo | 241927201 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Uzerche | 241927243 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saint Yrieix | 248700189 | ❔ | ❌ | ❌ |
+| Département | Creuse | 23 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Guéret | 200034825 | ❔ | ❌ | ❌ |
+| CC | CC Portes de la Creuse en Marche | 200041556 | ❔ | ❌ | ❌ |
+| CC | CC Creuse Grand Sud | 200044014 | ❔ | ❌ | ❌ |
+| CC | CC Haute-Corrèze Communauté | 200066744 | ❔ | ❌ | ❌ |
+| CC | CC Creuse Sud Ouest | 200067189 | ❔ | ❌ | ❌ |
+| CC | CC Creuse Confluence | 200067544 | ❔ | ❌ | ❌ |
+| CC | CC Marche et Combraille en Aquitaine | 200067593 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Sostranien | 242300135 | ❔ | ❌ | ❌ |
+| CC | CC de Bénévent Grand Bourg | 242320000 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Dunois | 242320109 | ❔ | ❌ | ❌ |
+| Département | Dordogne | 24 | ❔ | ❌ | ❌ |
+| CC | CC Sarlat-Périgord Noir | 200027217 | ❔ | ❌ | ❌ |
+| CC | CC de Montaigne Montravel et Gurson | 200034197 | ❔ | ❌ | ❌ |
+| CC | CC des Bastides Dordogne-Périgord | 200034833 | ❔ | ❌ | ❌ |
+| CC | CC Isle Vern Salembre en Périgord | 200040095 | ❔ | ❌ | ❌ |
+| CC | CC Isle Double Landais | 200040384 | ❔ | ❌ | ❌ |
+| CA | CA Le Grand Périgueux | 200040392 | ✅ | ✅ | ❌ |
+| CC | CC du Périgord Ribéracois | 200040400 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Fénelon | 200040830 | ❔ | ❌ | ❌ |
+| CC | CC de Portes Sud Périgord | 200040889 | ❔ | ❌ | ❌ |
+| CC | CC Vallée de la Dordogne et Forêt Bessède | 200041051 | ❔ | ❌ | ❌ |
+| CC | CC Terrassonnais Haut Périgord Noir | 200041150 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de l'Homme | 200041168 | ✅ | ✅ | ❌ |
+| CC | CC de Domme- Villefranche du Périgord | 200041440 | ❔ | ❌ | ❌ |
+| CC | CC Dronne et Belle | 200041572 | ❔ | ❌ | ❌ |
+| CC | CC Isle et Crempse en Périgord | 200069094 | ❔ | ❌ | ❌ |
+| CA | CA Bergeracoise | 200070647 | ❔ | ❌ | ❌ |
+| CC | CC du Périgord Nontronnais | 200071819 | ❔ | ❌ | ❌ |
+| CC | CC Périgord-Limousin | 242400752 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saint Aulaye | 242400935 | ❔ | ❌ | ❌ |
+| CC | CC Isle-Loue-Auvézère en Périgord | 242401024 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Foyen | 243301371 | ❔ | ❌ | ❌ |
+| CC | CC Castillon/Pujols | 243301454 | ❔ | ❌ | ❌ |
+| Département | Gironde | 33 | ❔ | ❌ | ❌ |
+| CC | CC de Blaye | 200023794 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Saint Emilionnais | 200035533 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Gironde | 200043974 | ❔ | ❌ | ❌ |
+| CC | CC du Bazadais | 200043982 | ❔ | ❌ | ❌ |
+| CC | CC du Réolais en Sud Gironde | 200044394 | ❔ | ❌ | ❌ |
+| CC | CC Convergence Garonne | 200069581 | ❔ | ❌ | ❌ |
+| CC | CC Rurales de l'Entre-Deux-Mers | 200069599 | ❔ | ❌ | ❌ |
+| CC | CC Médoc Coeur de Presqu'île | 200069995 | ❔ | ❌ | ❌ |
+| CA | CA du Libournais | 200070092 | ✅ | ✅ | ❌ |
+| CC | CC Médoc Atlantique | 200070720 | ❔ | ❌ | ❌ |
+| METRO | Bordeaux Métropole | 243300316 | ✅ | ✅ | ❌ |
+| CA | CA Bassin d'Arcachon Sud (COBAS) | 243300563 | ❔ | ❌ | ❌ |
+| CC | CC de l'Estuaire | 243300811 | ❔ | ❌ | ❌ |
+| CC | CC Jalle-Eau-Bourde | 243301165 | ❔ | ❌ | ❌ |
+| CC | CC Latitude Nord Gironde | 243301181 | ❔ | ❌ | ❌ |
+| CC | CC du Créonnais | 243301215 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Cubzaguais | 243301223 | ✅ | ✅ | ❌ |
+| CC | CC Les Rives de la Laurence | 243301249 | ❔ | ❌ | ❌ |
+| CC | CC de Montesquieu | 243301264 | ❔ | ❌ | ❌ |
+| CC | CC les Coteaux Bordelais | 243301355 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Foyen | 243301371 | ❔ | ❌ | ❌ |
+| CC | CC Médullienne | 243301389 | ❔ | ❌ | ❌ |
+| CC | CC du Fronsadais | 243301397 | ❔ | ❌ | ❌ |
+| CC | CC du Val de l'Eyre | 243301405 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de l'Entre-Deux-Mers | 243301439 | ❔ | ❌ | ❌ |
+| CC | CC Médoc Estuaire | 243301447 | ❔ | ❌ | ❌ |
+| CC | CC Castillon/Pujols | 243301454 | ❔ | ❌ | ❌ |
+| CA | CA du Bassin d'Arcachon Nord (COBAN) | 243301504 | ❔ | ❌ | ❌ |
+| Département | Landes | 40 | ❔ | ❌ | ❌ |
+| CC | CC d'Aire-sur-l'Adour | 200030435 | ❔ | ❌ | ❌ |
+| CC | CC des Landes d'Armagnac | 200035541 | ❔ | ❌ | ❌ |
+| CC | CC Pays d'Orthe et Arrigans | 200069417 | ❔ | ❌ | ❌ |
+| CC | CC Terres de Chalosse | 200069631 | ❔ | ❌ | ❌ |
+| CC | CC Chalosse Tursan | 200069649 | ❔ | ❌ | ❌ |
+| CC | CC Coeur Haute Lande | 200069656 | ❔ | ❌ | ❌ |
+| CC | CC de Mimizan | 244000543 | ❔ | ❌ | ❌ |
+| CC | CC du Seignanx | 244000659 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Dax | 244000675 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Morcenais | 244000691 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Tarusate | 244000766 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Villeneuve en Armagnac Landais | 244000774 | ❔ | ❌ | ❌ |
+| CA | CA Mont de Marsan Agglomération | 244000808 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Grenadois | 244000824 | ❔ | ❌ | ❌ |
+| CC | CC Côte Landes Nature | 244000857 | ❔ | ❌ | ❌ |
+| CC | CC Maremne Adour Côte Sud | 244000865 | ❔ | ❌ | ❌ |
+| CC | CC des Grands Lacs | 244000873 | ❔ | ❌ | ❌ |
+| CC | CC Coteaux et Vallées des Luys | 244000881 | ❔ | ❌ | ❌ |
+| Département | Lot-et-Garonne | 47 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Villeneuvois | 200023307 | ✅ | ✅ | ❌ |
+| CA | CA Val de Garonne Agglomération | 200030674 | ❔ | ❌ | ❌ |
+| CC | CC des Bastides en Haut Agenais Périgord | 200036523 | ❔ | ❌ | ❌ |
+| CC | CC du Confluent et des Coteaux de Prayssas | 200068922 | ❔ | ❌ | ❌ |
+| CC | CC Fumel Vallée du Lot | 200068930 | ❔ | ❌ | ❌ |
+| CC | CC Albret Communauté | 200068948 | ❔ | ❌ | ❌ |
+| CA | CA Agglomération d'Agen | 200096956 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Duras | 244700449 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lauzun | 244700464 | ❔ | ❌ | ❌ |
+| CC | CC des Coteaux et Landes de Gascogne | 244701355 | ❔ | ❌ | ❌ |
+| CC | CC Lot et Tolzac | 244701405 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Rives | 248200016 | ❔ | ❌ | ❌ |
+| Département | Pyrénées-Atlantiques | 64 | ❔ | ❌ | ❌ |
+| CC | CC de Lacq-Orthez | 200039204 | ❔ | ❌ | ❌ |
+| CA | CA du Pays Basque | 200067106 | ❔ | ❌ | ❌ |
+| CC | CC des Luys en Béarn | 200067239 | ❔ | ❌ | ❌ |
+| CA | CA Pau Béarn Pyrénées | 200067254 | ✅ | ✅ | ❌ |
+| CC | CC du Haut Béarn | 200067262 | ✅ | ✅ | ❌ |
+| CC | CC du Béarn des Gaves | 200067288 | ❔ | ❌ | ❌ |
+| CC | CC du Nord Est Béarn | 200067296 | ❔ | ❌ | ❌ |
+| CC | CC Adour Madiran | 200072106 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée d'Ossau | 246400337 | ✅ | ✅ | ❌ |
+| CC | CC Pays de Nay | 246401756 | ❔ | ❌ | ❌ |
+| Département | Deux-Sèvres | 79 | ❔ | ❌ | ❌ |
+| CA | CA du Bocage Bressuirais | 200040244 | ❔ | ❌ | ❌ |
+| CA | CA du Niortais | 200041317 | ❔ | ❌ | ❌ |
+| CC | CC de Parthenay-Gâtine | 200041333 | ❔ | ❌ | ❌ |
+| CC | CC Airvaudais-Val du Thouet | 200041416 | ❔ | ❌ | ❌ |
+| CC | CC Haut Val de Sèvre | 200041994 | ✅ | ✅ | ❌ |
+| CC | CC Val de Gâtine | 200069748 | ❔ | ❌ | ❌ |
+| CC | CC Mellois en Poitou | 200069755 | ❔ | ❌ | ❌ |
+| CC | CC du Thouarsais | 247900798 | ❔ | ❌ | ❌ |
+| Département | Vienne | 86 | ❔ | ❌ | ❌ |
+| CC | CC des Vallées du Clain | 200043628 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Poitou | 200069763 | ❔ | ❌ | ❌ |
+| CU | CU du Grand Poitiers | 200069854 | ✅ | ✅ | ❌ |
+| CC | CC du Civraisien en Poitou | 200070035 | ❔ | ❌ | ❌ |
+| CC | CC Vienne et Gartempe | 200070043 | ✅ | ✅ | ❌ |
+| CA | CA Grand Châtellerault | 248600413 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Loudunais | 248600447 | ❔ | ❌ | ❌ |
+| Département | Haute-Vienne | 87 | ❔ | ❌ | ❌ |
+| CC | CC Briance Sud Haute Vienne | 200040814 | ❔ | ❌ | ❌ |
+| CC | CC Porte Océane du Limousin | 200059400 | ❔ | ❌ | ❌ |
+| CC | CC Élan Limousin Avenir Nature | 200066512 | ❔ | ❌ | ❌ |
+| CC | CC Ouest Limousin | 200066520 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Nexon Monts de Chalus | 200070506 | ❔ | ❌ | ❌ |
+| CC | CC Haut Limousin en Marche | 200071942 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saint Yrieix | 248700189 | ❔ | ❌ | ❌ |
+| CC | CC Gartempe - Saint Pardoux | 248719262 | ❔ | ❌ | ❌ |
+| CC | CC du Val de Vienne | 248719288 | ❔ | ❌ | ❌ |
+| CU | CU Limoges Métropole | 248719312 | ✅ | ✅ | ❌ |
+| CC | CC Briance-Combade | 248719338 | ❔ | ❌ | ❌ |
+| CC | CC des Portes de Vassivière | 248719353 | ❔ | ❌ | ❌ |
+| CC | CC de Noblat | 248719361 | ❔ | ❌ | ❌ |

--- a/couverture/76_Occitanie.md
+++ b/couverture/76_Occitanie.md
@@ -1,0 +1,195 @@
+# Couverture des aides en Occitanie (76)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Occitanie | 76 | ✅ | ✅ | ❌ |
+| Département | Ariège | 09 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Mirepoix | 200044469 | ❔ | ❌ | ❌ |
+| CC | CC Arize Lèze | 200066223 | ❔ | ❌ | ❌ |
+| CC | CC des Portes d'Ariège Pyrénées | 200066231 | ❔ | ❌ | ❌ |
+| CC | CC de la Haute Ariège | 200066363 | ❔ | ❌ | ❌ |
+| CA | CA L'Agglo Foix-Varilhes | 200067791 | ❔ | ❌ | ❌ |
+| CC | CC Couserans-Pyrénées | 200067940 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Tarascon | 240900431 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Olmes | 240900464 | ❔ | ❌ | ❌ |
+| Département | Aude | 11 | ❔ | ❌ | ❌ |
+| CC | CC Piège Lauragais Malepère | 200035707 | ❔ | ❌ | ❌ |
+| CA | CA Carcassonne Agglo | 200035715 | ❔ | ❌ | ❌ |
+| CC | CC Castelnaudary Lauragais Audois | 200035855 | ❔ | ❌ | ❌ |
+| CC | CC Région Lézignanaise, Corbières et Minervois | 200035863 | ❔ | ❌ | ❌ |
+| CC | CC de la Montagne Noire | 200042463 | ❔ | ❌ | ❌ |
+| CC | CC Pyrénées audoises | 200043776 | ❔ | ❌ | ❌ |
+| CC | CC Corbières Salanque Méditerranée | 200070365 | ❔ | ❌ | ❌ |
+| CC | CC du Limouxin | 200071926 | ❔ | ❌ | ❌ |
+| CA | CA Le Grand Narbonne | 241100593 | ❔ | ❌ | ❌ |
+| CC | CC Aux sources du Canal du Midi | 243100567 | ❔ | ❌ | ❌ |
+| Département | Aveyron | 12 | ❔ | ❌ | ❌ |
+| CC | CC Decazeville Communauté | 200067064 | ❔ | ❌ | ❌ |
+| CC | CC Saint Affricain, Roquefort, Sept Vallons | 200067155 | ❔ | ❌ | ❌ |
+| CC | CC Monts, Rance et Rougier | 200067163 | ❔ | ❌ | ❌ |
+| CC | CC Aubrac, Carladez et Viadène | 200067171 | ❔ | ❌ | ❌ |
+| CC | CC Grand-Figeac | 200067361 | ❔ | ❌ | ❌ |
+| CC | CC Comtal Lot et Truyère | 200067478 | ❔ | ❌ | ❌ |
+| CC | CC des Causses à l'Aubrac | 200068484 | ❔ | ❌ | ❌ |
+| CC | CC Pays Ségali Communauté | 200068831 | ❔ | ❌ | ❌ |
+| CC | CC Ouest Aveyron Communauté | 200069383 | ❔ | ❌ | ❌ |
+| CA | CA Rodez Agglomération | 241200187 | ❔ | ❌ | ❌ |
+| CC | CC du Réquistanais | 241200542 | ❔ | ❌ | ❌ |
+| CC | CC de Millau Grands Causses | 241200567 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Rignacois | 241200625 | ❔ | ❌ | ❌ |
+| CC | CC Conques-Marcillac | 241200641 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Salars | 241200658 | ❔ | ❌ | ❌ |
+| CC | CC du Plateau de Montbazens | 241200674 | ❔ | ❌ | ❌ |
+| CC | CC de Lévézou Pareloup | 241200765 | ❔ | ❌ | ❌ |
+| CC | CC Aveyron Bas Ségala Viaur | 241200807 | ❔ | ❌ | ❌ |
+| CC | CC Larzac et Vallées | 241200906 | ❔ | ❌ | ❌ |
+| CC | CC de la Muse et des Raspes du Tarn | 241200914 | ❔ | ❌ | ❌ |
+| Département | Gard | 30 | ❔ | ❌ | ❌ |
+| CC | CC Pays d'Uzès | 200034379 | ❔ | ❌ | ❌ |
+| CC | CC du Piémont Cévenol | 200034411 | ❔ | ❌ | ❌ |
+| CC | CC Causses Aigoual Cévennes | 200034601 | ❔ | ❌ | ❌ |
+| CA | CA du Gard Rhodanien | 200034692 | ❔ | ❌ | ❌ |
+| CC | CC de Cèze Cévennes | 200035129 | ❔ | ❌ | ❌ |
+| CA | CA Alès Agglomération | 200066918 | ❔ | ❌ | ❌ |
+| CC | CC Mont Lozère | 200069128 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Viganais | 243000270 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Sommières | 243000296 | ❔ | ❌ | ❌ |
+| CC | CC Rhony, Vistre, Vidourle | 243000569 | ❔ | ❌ | ❌ |
+| CC | CC Beaucaire Terre d'Argence | 243000585 | ❔ | ❌ | ❌ |
+| CC | CC de Petite Camargue | 243000593 | ❔ | ❌ | ❌ |
+| CA | CA de Nîmes Métropole | 243000643 | ❔ | ❌ | ❌ |
+| CC | CC Terre de Camargue | 243000650 | ❔ | ❌ | ❌ |
+| CC | CC du Pont du Gard | 243000684 | ❔ | ❌ | ❌ |
+| CC | CC des Cévennes Gangeoises et Suménoises | 243400736 | ✅ | ✅ | ❌ |
+| CA | CA du Grand Avignon (COGA) | 248400251 | ✅ | ✅ | ❌ |
+| Département | Haute-Garonne | 31 | ❔ | ❌ | ❌ |
+| CC | CC Tarn-Agout | 200034023 | ❔ | ❌ | ❌ |
+| CC | CC du Frontonnais | 200034957 | ❔ | ❌ | ❌ |
+| CC | CC du Volvestre | 200066819 | ❔ | ❌ | ❌ |
+| CA | CA Le Muretain Agglo | 200068641 | ❔ | ❌ | ❌ |
+| CC | CC du Bassin Auterivain Haut-Garonnais | 200068807 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Garonne | 200068815 | ❔ | ❌ | ❌ |
+| CC | CC des Terres du Lauragais | 200071298 | ❔ | ❌ | ❌ |
+| CC | CC des Hauts-Tolosans | 200071314 | ❔ | ❌ | ❌ |
+| CC | CC Pyrénées Haut Garonnaises | 200072635 | ❔ | ❌ | ❌ |
+| CC | CC Coeur et Coteaux du Comminges | 200072643 | ❔ | ❌ | ❌ |
+| CC | CC Cagire Garonne Salat | 200073146 | ❔ | ❌ | ❌ |
+| METRO | Toulouse Métropole | 243100518 | ✅ | ✅ | ❌ |
+| CC | CC Aux sources du Canal du Midi | 243100567 | ❔ | ❌ | ❌ |
+| CA | CA du Sicoval | 243100633 | ❔ | ❌ | ❌ |
+| CC | CC des Coteaux du Girou | 243100732 | ❔ | ❌ | ❌ |
+| CC | CC Val'Aïgo | 243100773 | ❔ | ❌ | ❌ |
+| CC | CC Le Grand Ouest Toulousain | 243100781 | ❔ | ❌ | ❌ |
+| CC | CC des Coteaux Bellevue | 243100815 | ❔ | ❌ | ❌ |
+| Département | Gers | 32 | ❔ | ❌ | ❌ |
+| CC | CC de la Gascogne Toulousaine | 200023620 | ❔ | ❌ | ❌ |
+| CC | CC d'Aire-sur-l'Adour | 200030435 | ❔ | ❌ | ❌ |
+| CC | CC Bastides de Lomagne | 200034726 | ❔ | ❌ | ❌ |
+| CC | CC Armagnac Adour | 200035632 | ❔ | ❌ | ❌ |
+| CC | CC Astarac Arros en Gascogne | 200035756 | ❔ | ❌ | ❌ |
+| CC | CC des Coteaux Arrats Gimone | 200042372 | ❔ | ❌ | ❌ |
+| CA | CA Grand Auch Coeur de Gascogne | 200066926 | ❔ | ❌ | ❌ |
+| CC | CC Val de Gers | 200072320 | ❔ | ❌ | ❌ |
+| CC | CC de la Lomagne Gersoise | 243200391 | ❔ | ❌ | ❌ |
+| CC | CC du Bas Armagnac | 243200409 | ❔ | ❌ | ❌ |
+| CC | CC de la Tenarèze | 243200417 | ❔ | ❌ | ❌ |
+| CC | CC Coeur d'Astarac en Gascogne | 243200425 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Armagnac | 243200458 | ❔ | ❌ | ❌ |
+| CC | CC Bastides et Vallons du Gers | 243200508 | ❔ | ❌ | ❌ |
+| CC | CC du Saves | 243200599 | ❔ | ❌ | ❌ |
+| CC | CC Artagnan de Fezensac | 243200607 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Rives | 248200016 | ❔ | ❌ | ❌ |
+| Département | Hérault | 34 | ✅ | ✅ | ❌ |
+| CC | CC Lodévois et Larzac | 200017341 | ❔ | ❌ | ❌ |
+| CC | CC du Grand Pic Saint-Loup | 200022986 | ❔ | ❌ | ❌ |
+| CC | CC Grand Orb Communauté de Communes en Languedoc | 200042646 | ✅ | ✅ | ❌ |
+| CC | CC Sud-Hérault | 200042653 | ❔ | ❌ | ❌ |
+| CC | CC du Minervois au Caroux | 200066348 | ❔ | ❌ | ❌ |
+| CA | CA Sète Agglopôle Méditerranée | 200066355 | ✅ | ✅ | ❌ |
+| CC | CC du Haut-Languedoc | 200066553 | ❔ | ❌ | ❌ |
+| CC | CC Les Avant-Monts | 200071058 | ✅ | ✅ | ❌ |
+| METRO | Montpellier Méditerranée Métropole | 243400017 | ✅ | ✅ | ❌ |
+| CC | CC du Clermontais | 243400355 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de l'Or | 243400470 | ❔ | ❌ | ❌ |
+| CC | CC la Domitienne | 243400488 | ❔ | ❌ | ❌ |
+| CA | CA Lunel Agglo | 243400520 | ❔ | ❌ | ❌ |
+| CC | CC Vallée de l'Hérault | 243400694 | ❔ | ❌ | ❌ |
+| CC | CC des Cévennes Gangeoises et Suménoises | 243400736 | ✅ | ✅ | ❌ |
+| CA | CA de Béziers-Méditerranée | 243400769 | ❔ | ❌ | ❌ |
+| CA | CA Hérault-Méditerranée | 243400819 | ❔ | ❌ | ❌ |
+| Département | Lot | 46 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Cahors | 200023737 | ❔ | ❌ | ❌ |
+| CC | CC Cazals-Salviac | 200035327 | ❔ | ❌ | ❌ |
+| CC | CC du Quercy Blanc | 200039519 | ❔ | ❌ | ❌ |
+| CC | CC Causses et Vallée de la Dordogne | 200066371 | ❔ | ❌ | ❌ |
+| CC | CC Grand-Figeac | 200067361 | ❔ | ❌ | ❌ |
+| CC | CC Ouest Aveyron Communauté | 200069383 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée du Lot et du Vignoble | 244600433 | ❔ | ❌ | ❌ |
+| CC | CC Quercy - Bouriane | 244600482 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lalbenque-Limogne | 244600532 | ❔ | ❌ | ❌ |
+| CC | CC du Causse de Labastide Murat | 244600573 | ❔ | ❌ | ❌ |
+| Département | Lozère | 48 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Allier Margeride | 200006930 | ❔ | ❌ | ❌ |
+| CC | CC Randon - Margeride | 200069102 | ❔ | ❌ | ❌ |
+| CC | CC Mont Lozère | 200069128 | ❔ | ❌ | ❌ |
+| CC | CC des Cévennes au Mont Lozère | 200069136 | ❔ | ❌ | ❌ |
+| CC | CC des Hautes Terres de l'Aubrac | 200069144 | ❔ | ❌ | ❌ |
+| CC | CC Gorges Causses Cévennes | 200069151 | ❔ | ❌ | ❌ |
+| CC | CC des Terres d'Apcher-Margeride-Aubrac | 200069185 | ❔ | ❌ | ❌ |
+| CC | CC Aubrac Lot Causses Tarn | 200069268 | ❔ | ❌ | ❌ |
+| CC | CC de Millau Grands Causses | 241200567 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Lozère | 244800405 | ❔ | ❌ | ❌ |
+| CC | CC du Gévaudan | 244800470 | ❔ | ❌ | ❌ |
+| Département | Hautes-Pyrénées | 65 | ❔ | ❌ | ❌ |
+| CA | CA Tarbes-Lourdes-Pyrénées | 200069300 | ✅ | ✅ | ❌ |
+| CC | CC du Plateau de Lannemezan | 200070787 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Trie et du Magnoac | 200070795 | ❔ | ❌ | ❌ |
+| CC | CC des Coteaux du Val d'Arros | 200070803 | ❔ | ❌ | ❌ |
+| CC | CC Pyrénées Vallées des Gaves | 200070811 | ❔ | ❌ | ❌ |
+| CC | CC Neste Barousse | 200070829 | ❔ | ❌ | ❌ |
+| CC | CC Adour Madiran | 200072106 | ❔ | ❌ | ❌ |
+| CC | CC Pays de Nay | 246401756 | ❔ | ❌ | ❌ |
+| CC | CC de la Haute-Bigorre | 246500482 | ❔ | ❌ | ❌ |
+| CC | CC Aure Louron | 246500573 | ❔ | ❌ | ❌ |
+| Département | Pyrénées-Orientales | 66 | ❔ | ❌ | ❌ |
+| CU | CU Perpignan Méditerranée Métropole | 200027183 | ✅ | ✅ | ❌ |
+| CC | CC des Albères, de la Côte Vermeille et de l'Illibéris | 200043602 | ❔ | ❌ | ❌ |
+| CC | CC Conflent-Canigó | 200049211 | ❔ | ❌ | ❌ |
+| CC | CC Corbières Salanque Méditerranée | 200070365 | ❔ | ❌ | ❌ |
+| CC | CC Sud-Roussillon | 246600282 | ❔ | ❌ | ❌ |
+| CC | CC du Vallespir | 246600373 | ❔ | ❌ | ❌ |
+| CC | CC Pyrénées Cerdagne | 246600399 | ❔ | ❌ | ❌ |
+| CC | CC Roussillon-Conflent | 246600415 | ❔ | ❌ | ❌ |
+| CC | CC Agly Fenouillèdes | 246600423 | ❔ | ❌ | ❌ |
+| CC | CC des Aspres | 246600449 | ❔ | ❌ | ❌ |
+| CC | CC Pyrénées Catalanes | 246600464 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Vallespir | 246600548 | ✅ | ✅ | ❌ |
+| Département | Tarn | 81 | ❔ | ❌ | ❌ |
+| CC | CC Tarn-Agout | 200034023 | ❔ | ❌ | ❌ |
+| CC | CC des Monts d'Alban et du Villefranchois | 200034031 | ❔ | ❌ | ❌ |
+| CC | CC Centre Tarn | 200034049 | ❔ | ❌ | ❌ |
+| CC | CC du Lautrécois et du Pays d'Agout | 200034056 | ❔ | ❌ | ❌ |
+| CC | CC du Cordais et du Causse (4 C) | 200034064 | ❔ | ❌ | ❌ |
+| CC | CC Carmausin-Ségala | 200040905 | ❔ | ❌ | ❌ |
+| CA | CA Gaillac-Graulhet | 200066124 | ❔ | ❌ | ❌ |
+| CC | CC du Haut-Languedoc | 200066553 | ❔ | ❌ | ❌ |
+| CC | CC Sidobre Vals et Plateaux | 200066561 | ❔ | ❌ | ❌ |
+| CC | CC Aux sources du Canal du Midi | 243100567 | ❔ | ❌ | ❌ |
+| CC | CC du Sor et de l'Agout | 248100158 | ❔ | ❌ | ❌ |
+| CA | CA de Castres Mazamet | 248100430 | ❔ | ❌ | ❌ |
+| CC | CC Val 81 | 248100497 | ❔ | ❌ | ❌ |
+| CA | CA de l'Albigeois (C2A) | 248100737 | ✅ | ✅ | ❌ |
+| CC | CC Thoré Montagne Noire | 248100745 | ❔ | ❌ | ❌ |
+| CC | CC du Quercy Rouergue et des Gorges de l'Aveyron | 248200107 | ❔ | ❌ | ❌ |
+| Département | Tarn-et-Garonne | 82 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Serres en Quercy | 200040418 | ❔ | ❌ | ❌ |
+| CC | CC Terres des Confluences | 200066322 | ❔ | ❌ | ❌ |
+| CC | CC Grand Sud Tarn-et-Garonne | 200066652 | ❔ | ❌ | ❌ |
+| CC | CC Quercy Vert-Aveyron | 200066884 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lafrançaise | 200067122 | ❔ | ❌ | ❌ |
+| CC | CC des Deux Rives | 248200016 | ❔ | ❌ | ❌ |
+| CC | CC du Quercy Caussadais | 248200057 | ❔ | ❌ | ❌ |
+| CC | CC de la Lomagne Tarn-et-Garonnaise | 248200065 | ❔ | ❌ | ❌ |
+| CA | CA Grand Montauban | 248200099 | ✅ | ✅ | ❌ |
+| CC | CC du Quercy Rouergue et des Gorges de l'Aveyron | 248200107 | ❔ | ❌ | ❌ |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -154,30 +154,30 @@
 | CC          | CC du Pays Mornantais (COPAMO)                       | 246900740 | ✅               | ✅        | ❌    |
 | CC          | CC de la Vallée du Garon (CCVG)                      | 246900757 | ❌               | ❌        | ✅    |
 | CC          | CC du Pays de l'Ozon                                 | 246900765 | ✅               | ✅        | ✅    |
-| Département | Savoie                                               | 73        | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Tarentaise                               | 200023299 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Chartreuse                               | 200040111 | ❔               | ❌        | ❌    |
-| CC          | CC Val Vanoise                                       | 200040798 | ❔               | ❌        | ❌    |
+| Département | Savoie                                               | 73        | ❌               | ❌        | 🤖    |
+| CC          | CC Coeur de Tarentaise                               | 200023299 | ❌               | ❌        | 🤖    |
+| CC          | CC Coeur de Chartreuse                               | 200040111 | ❌               | ❌        | 🤖    |
+| CC          | CC Val Vanoise                                       | 200040798 | ❌               | ❌        | 🤖    |
 | CC          | CC Coeur de Savoie                                   | 200041010 | ✅               | ✅        | ✅    |
-| CA          | CA Grand Lac                                         | 200068674 | ❔               | ❌        | ❌    |
-| CA          | CA Arlysère                                          | 200068997 | ❔               | ❌        | ❌    |
+| CA          | CA Grand Lac                                         | 200068674 | ❌               | ❌        | 🤖    |
+| CA          | CA Arlysère                                          | 200068997 | ❌               | ❌        | 🤖    |
 | CA          | CA du Grand Chambéry                                 | 200069110 | ✅               | ✅        | ✅    |
-| CC          | CC Haute Maurienne Vanoise                           | 200070340 | ❔               | ❌        | ❌    |
+| CC          | CC Haute Maurienne Vanoise                           | 200070340 | ❌               | ❌        | 🤖    |
 | CC          | CC Coeur de Maurienne Arvan                          | 200070464 | ✅               | ✅        | ✅    |
-| CC          | CC des Vallées d'Aigueblanche                        | 247300015 | ❔               | ❌        | ❌    |
-| CC          | CC de Haute-Tarentaise                               | 247300254 | ❔               | ❌        | ❌    |
-| CC          | CC de Yenne                                          | 247300262 | ❔               | ❌        | ❌    |
-| CC          | CC du Canton de La Chambre                           | 247300361 | ❔               | ❌        | ❌    |
-| CC          | CC Maurienne Galibier                                | 247300452 | ❔               | ❌        | ❌    |
-| CC          | CC Val Guiers                                        | 247300528 | ❔               | ❌        | ❌    |
-| CC          | CC du Lac d'Aiguebelette (CCLA)                      | 247300668 | ❔               | ❌        | ❌    |
-| CC          | CC Porte de Maurienne                                | 247300676 | ❔               | ❌        | ❌    |
-| CC          | CC Les Versants d'Aime                               | 247300817 | ❔               | ❌        | ❌    |
+| CC          | CC des Vallées d'Aigueblanche                        | 247300015 | ❌               | ❌        | 🤖    |
+| CC          | CC de Haute-Tarentaise                               | 247300254 | ❌               | ❌        | 🤖    |
+| CC          | CC de Yenne                                          | 247300262 | ❌               | ❌        | 🤖    |
+| CC          | CC du Canton de La Chambre                           | 247300361 | ❌               | ❌        | 🤖    |
+| CC          | CC Maurienne Galibier                                | 247300452 | ❌               | ❌        | 🤖    |
+| CC          | CC Val Guiers                                        | 247300528 | ❌               | ❌        | 🤖    |
+| CC          | CC du Lac d'Aiguebelette (CCLA)                      | 247300668 | ❌               | ❌        | 🤖    |
+| CC          | CC Porte de Maurienne                                | 247300676 | ❌               | ❌        | 🤖    |
+| CC          | CC Les Versants d'Aime                               | 247300817 | ❌               | ❌        | 🤖    |
 | Département | Haute-Savoie                                         | 74        | ❔               | ❌        | ❌    |
 | CC          | CC Faucigny - Glières                                | 200000172 | ❔               | ❌        | ❌    |
 | CA          | CA Annemasse-Les Voirons-Agglomération               | 200011773 | ❔               | ❌        | ❌    |
 | CC          | CC de la Vallée de Chamonix-Mont-Blanc               | 200023372 | ❔               | ❌        | ❌    |
-| CC          | CC Cluses-Arve et Montagnes                          | 200033116 | ✅               | ✅        | ❌    |
+| CC          | CC Cluses-Arve et Montagnes                          | 200033116 | ✅               | ✅        | ✅    |
 | CC          | CC des Montagnes du Giffre                           | 200034098 | ❔               | ❌        | ❌    |
 | CC          | CC Pays du Mont-Blanc                                | 200034882 | ❔               | ❌        | ❌    |
 | CA          | CA du Grand Annecy                                   | 200066793 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -65,52 +65,52 @@
 | CC          | CC Cère et Goul en Carladès                          | 241501089 | ❌               | ❌        | 🤖    |
 | CC          | CC du Pays de Salers                                 | 241501139 | ❌               | ❌        | 🤖    |
 | CC          | CC du Massif du Sancy                                | 246300966 | ❌               | ❌        | 🤖    |
-| Département | Drôme                                                | 26        | ❔               | ❌        | 🤖    |
-| CC          | CC Ventoux Sud                                       | 200035723 | ❔               | ❌        | ❌    |
-| CA          | CA Montélimar Agglomération                          | 200040459 | ❔               | ❌        | ❌    |
-| CC          | CC Porte de Dromardèche                              | 200040491 | ❔               | ❌        | ❌    |
+| Département | Drôme                                                | 26        | ❌               | ❌        | ✅    |
+| CC          | CC Ventoux Sud                                       | 200035723 | ❌               | ❌        | ✅    |
+| CA          | CA Montélimar Agglomération                          | 200040459 | ❌               | ❌        | ✅    |
+| CC          | CC Porte de Dromardèche                              | 200040491 | ❌               | ❌        | ✅    |
 | CC          | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅               | ✅        | ✅    |
-| CC          | CC Enclave des Papes - Pays de Grignan               | 200040681 | ❔               | ❌        | ❌    |
-| CC          | CC Drôme Sud Provence                                | 200042901 | ❔               | ❌        | ❌    |
-| CC          | CC du Royans-Vercors                                 | 200067767 | ❔               | ❌        | ❌    |
-| CC          | CC des Baronnies en Drôme Provençale                 | 200068229 | ❔               | ❌        | ❌    |
-| CC          | CC du Sisteronais-Buëch                              | 200068765 | ❔               | ❌        | ❌    |
-| CA          | CA Valence Romans Agglo                              | 200068781 | ❔               | ❌        | ❌    |
-| CC          | CC Jabron-Lure-Vançon-Durance                        | 200071033 | ❔               | ❌        | ❌    |
+| CC          | CC Enclave des Papes - Pays de Grignan               | 200040681 | ❌               | ❌        | ✅    |
+| CC          | CC Drôme Sud Provence                                | 200042901 | ❌               | ❌        | ✅    |
+| CC          | CC du Royans-Vercors                                 | 200067767 | ❌               | ❌        | ✅    |
+| CC          | CC des Baronnies en Drôme Provençale                 | 200068229 | ✅               | 📧        | 📧    |
+| CC          | CC du Sisteronais-Buëch                              | 200068765 | ❌               | ❌        | ✅    |
+| CA          | CA Valence Romans Agglo                              | 200068781 | ❌               | ❌        | ✅    |
+| CC          | CC Jabron-Lure-Vançon-Durance                        | 200071033 | ❌               | ❌        | ✅    |
 | CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ✅    |
-| CC          | CC du Val de Drôme en Biovallée                      | 242600252 | ✅               | ✅        | ❌    |
-| CC          | CC Dieulefit-Bourdeaux                               | 242600492 | ✅               | ✅        | ❌    |
-| CC          | CC du Diois                                          | 242600534 | ❔               | ❌        | ❌    |
-| CC          | CC Vaison Ventoux                                    | 248400335 | ❔               | ❌        | ❌    |
-| Département | Isère                                                | 38        | ❔               | ❌        | ❌    |
-| CC          | CC Le Grésivaudan                                    | 200018166 | ❔               | ❌        | ❌    |
-| CC          | CC du Trièves                                        | 200030658 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Chartreuse                               | 200040111 | ❔               | ❌        | ❌    |
-| CC          | CC de la Matheysine                                  | 200040657 | ❔               | ❌        | ❌    |
-| METRO       | Grenoble-Alpes-Métropole                             | 200040715 | ✅               | ✅        | ❌    |
-| CC          | CC Bièvre Isère                                      | 200059392 | ✅               | ✅        | ❌    |
-| CC          | CC Les Balcons du Dauphiné                           | 200068542 | ❔               | ❌        | ❌    |
-| CC          | CC Les Vals du Dauphiné                              | 200068567 | ❔               | ❌        | ❌    |
-| CC          | CC Saint-Marcellin Vercors Isère Communauté          | 200070431 | ✅               | ✅        | ❌    |
-| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ❌    |
-| CC          | CC Entre Bièvre et Rhône                             | 200085751 | ❔               | ❌        | ❌    |
-| CA          | CA Porte de l'Isère (CAPI)                           | 243800604 | ❔               | ❌        | ❌    |
-| CC          | CC de l'Oisans                                       | 243800745 | ❔               | ❌        | ❌    |
-| CC          | CC Lyon-Saint-Exupéry en Dauphiné                    | 243800935 | ✅               | ✅        | ❌    |
-| CA          | CA du Pays Voironnais                                | 243800984 | ❔               | ❌        | ❌    |
-| CC          | CC du Massif du Vercors                              | 243801024 | ✅               | ✅        | ❌    |
-| CC          | CC de Bièvre Est                                     | 243801073 | ❔               | ❌        | ❌    |
-| CC          | CC Collines Isère Nord Communauté                    | 243801255 | ❔               | ❌        | ❌    |
-| Département | Loire                                                | 42        | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Drôme en Biovallée                      | 242600252 | ✅               | ✅        | ✅    |
+| CC          | CC Dieulefit-Bourdeaux                               | 242600492 | ✅               | ✅        | ✅    |
+| CC          | CC du Diois                                          | 242600534 | ❌               | ❌        | ✅    |
+| CC          | CC Vaison Ventoux                                    | 248400335 | ❌               | ❌        | ✅    |
+| Département | Isère                                                | 38        | ❌               | ❌        | 🤖    |
+| CC          | CC Le Grésivaudan                                    | 200018166 | ❌               | ❌        | 🤖    |
+| CC          | CC du Trièves                                        | 200030658 | ❌               | ❌        | 🤖    |
+| CC          | CC Coeur de Chartreuse                               | 200040111 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Matheysine                                  | 200040657 | ❌               | ❌        | 🤖    |
+| METRO       | Grenoble-Alpes-Métropole                             | 200040715 | ✅               | ✅        | ✅    |
+| CC          | CC Bièvre Isère                                      | 200059392 | ✅               | ✅        | ✅    |
+| CC          | CC Les Balcons du Dauphiné                           | 200068542 | ❌               | ❌        | 🤖    |
+| CC          | CC Les Vals du Dauphiné                              | 200068567 | ❌               | ❌        | 🤖    |
+| CC          | CC Saint-Marcellin Vercors Isère Communauté          | 200070431 | ✅               | 📧        | 📧    |
+| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ✅    |
+| CC          | CC Entre Bièvre et Rhône                             | 200085751 | ❌               | ❌        | 🤖    |
+| CA          | CA Porte de l'Isère (CAPI)                           | 243800604 | ❌               | ❌        | 🤖    |
+| CC          | CC de l'Oisans                                       | 243800745 | ❌               | ❌        | 🤖    |
+| CC          | CC Lyon-Saint-Exupéry en Dauphiné                    | 243800935 | ✅               | ✅        | ✅    |
+| CA          | CA du Pays Voironnais                                | 243800984 | ❌               | ❌        | 🤖    |
+| CC          | CC du Massif du Vercors                              | 243801024 | ✅               | ✅        | ✅    |
+| CC          | CC de Bièvre Est                                     | 243801073 | ❌               | ❌        | 🤖    |
+| CC          | CC Collines Isère Nord Communauté                    | 243801255 | ❌               | ❌        | 🤖    |
+| Département | Loire                                                | 42        | ❌               | ❌        | 🤖    |
 | CC          | CC Charlieu-Belmont                                  | 200035202 | ✅               | ✅        | ❌    |
 | CA          | CA Roannais Agglomération                            | 200035731 | ❔               | ❌        | ❌    |
 | CA          | CA Loire Forez Agglomération (LFA)                   | 200065886 | ❔               | ❌        | ❌    |
 | CC          | CC de Forez-Est                                      | 200065894 | ❔               | ❌        | ❌    |
 | CC          | CC des Monts du Lyonnais                             | 200066587 | ❔               | ❌        | ❌    |
 | CC          | CC des Vals d'Aix et Isable                          | 244200614 | ❔               | ❌        | ❌    |
-| CC          | CC des Monts du Pilat                                | 244200622 | ❔               | ❌        | ❌    |
+| CC          | CC des Monts du Pilat                                | 244200622 | ✅               | ✅        | ✅    |
 | CC          | CC du Pays Entre Loire et Rhône                      | 244200630 | ❔               | ❌        | ❌    |
-| METRO       | Saint-Étienne Métropole                              | 244200770 | ✅               | ✅        | ❌    |
+| METRO       | Saint-Étienne Métropole                              | 244200770 | ✅               | ✅        | ✅    |
 | CC          | CC du Pays d'Urfé                                    | 244200820 | ❔               | ❌        | ❌    |
 | CC          | CC du Pilat Rhodanien                                | 244200895 | ❔               | ❌        | ❌    |
 | Département | Haute-Loire                                          | 43        | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -133,7 +133,7 @@
 | CC          | CC Thiers Dore et Montagne                           | 200070712 | ❔               | ❌        | ❌    |
 | CA          | CA Riom Limagne et Volcans                           | 200070753 | ❔               | ❌        | ❌    |
 | CC          | CC Ambert Livradois Forez                            | 200070761 | ❔               | ❌        | ❌    |
-| CC          | CC Plaine Limagne                                    | 200071199 | ❔               | ❌        | ❌    |
+| CC          | CC Plaine Limagne                                    | 200071199 | ✅               | ✅        | ✅    |
 | CC          | CC Chavanon Combrailles et Volcans                   | 200071215 | ❔               | ❌        | ❌    |
 | CC          | CC du Pays de Saint-Eloy                             | 200072080 | ❔               | ❌        | ❌    |
 | CC          | CC Combrailles Sioule et Morge                       | 200072098 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -1,0 +1,198 @@
+# Couverture des aides en Auvergne-Rhône-Alpes (84)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Auvergne-Rhône-Alpes | 84 | ❔ | ❌ | ❌ |
+| Département | Ain | 01 | ❔ | ❌ | ❌ |
+| CC | CC Rives de l'Ain - Pays du Cerdon | 200029999 | ❔ | ❌ | ❌ |
+| CC | CC Bugey Sud | 200040350 | ❔ | ❌ | ❌ |
+| CA | CA Villefranche Beaujolais Saône | 200040590 | ✅ | ✅ | ❌ |
+| CC | CC Dombes Saône Vallée | 200042497 | ❔ | ❌ | ❌ |
+| CA | CA Haut-Bugey Agglomération | 200042935 | ❔ | ❌ | ❌ |
+| CC | CC de la Dombes | 200069193 | ❔ | ❌ | ❌ |
+| CC | CC Val de Saône Centre | 200070118 | ❔ | ❌ | ❌ |
+| CA | CA Mâconnais Beaujolais Agglomération | 200070308 | ❔ | ❌ | ❌ |
+| CC | CC de la Veyle | 200070555 | ❔ | ❌ | ❌ |
+| CC | CC Usses et Rhône | 200070852 | ❔ | ❌ | ❌ |
+| CC | CC Bresse et Saône | 200071371 | ❔ | ❌ | ❌ |
+| CA | CA du Bassin de Bourg-en-Bresse | 200071751 | ❔ | ❌ | ❌ |
+| CC | CC de la Côtière à Montluel | 240100610 | ✅ | ✅ | ❌ |
+| CA | CA du Pays de Gex | 240100750 | ❔ | ❌ | ❌ |
+| CC | CC de Miribel et du Plateau | 240100800 | ❔ | ❌ | ❌ |
+| CC | CC de la Plaine de l'Ain | 240100883 | ✅ | ✅ | ❌ |
+| CC | CC Terre Valserhône (CCTV) | 240100891 | ❔ | ❌ | ❌ |
+| Département | Allier | 03 | ❔ | ❌ | ❌ |
+| CA | CA Montluçon Communauté | 200071082 | ✅ | ✅ | ❌ |
+| CA | CA Moulins Communauté | 200071140 | ❔ | ❌ | ❌ |
+| CA | CA Vichy Communauté | 200071363 | ❔ | ❌ | ❌ |
+| CC | CC Saint-Pourçain Sioule Limagne | 200071389 | ❔ | ❌ | ❌ |
+| CC | CC Entr'Allier Besbre et Loire | 200071470 | ❔ | ❌ | ❌ |
+| CC | CC du Bocage Bourbonnais | 200071496 | ❔ | ❌ | ❌ |
+| CC | CC Commentry Montmarault Néris Communauté | 200071512 | ❔ | ❌ | ❌ |
+| CC | CC Le Grand Charolais | 200071884 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Lapalisse | 240300491 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Tronçais | 240300558 | ❔ | ❌ | ❌ |
+| CC | CC du Val de Cher | 240300566 | ❔ | ❌ | ❌ |
+| CC | CC du Pays d'Huriel | 240300657 | ❔ | ❌ | ❌ |
+| Département | Ardèche | 07 | ✅ | ✅ | ❌ |
+| CC | CC du Pays de Lamastre | 200016905 | ❔ | ❌ | ❌ |
+| CC | CC de Cèze Cévennes | 200035129 | ❔ | ❌ | ❌ |
+| CC | CC des Gorges de l'Ardèche | 200039808 | ❔ | ❌ | ❌ |
+| CC | CC Ardèche des Sources et Volcans | 200039824 | ❔ | ❌ | ❌ |
+| CC | CC Pays des Vans en Cévennes | 200039832 | ❔ | ❌ | ❌ |
+| CC | CC Porte de Dromardèche | 200040491 | ❔ | ❌ | ❌ |
+| CC | CC Rhône Crussol | 200041366 | ❔ | ❌ | ❌ |
+| CC | CC Val Eyrieux | 200041465 | ❔ | ❌ | ❌ |
+| CC | CC Ardèche Rhône Coiron | 200071405 | ❔ | ❌ | ❌ |
+| CA | CA Privas Centre Ardèche | 200071413 | ❔ | ❌ | ❌ |
+| CC | CC Montagne d'Ardèche | 200072007 | ❔ | ❌ | ❌ |
+| CA | CA Annonay Rhône Agglo | 200072015 | ✅ | ✅ | ❌ |
+| CA | CA Arche Agglo | 200073096 | ✅ | ✅ | ❌ |
+| CC | CC du Bassin d'Aubenas | 200073245 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Beaume-Drobie | 240700302 | ❔ | ❌ | ❌ |
+| CC | CC Val de Ligne | 240700617 | ❔ | ❌ | ❌ |
+| CC | CC du Val d'Ay | 240700716 | ❔ | ❌ | ❌ |
+| CC | CC Berg et Coiron | 240700815 | ❔ | ❌ | ❌ |
+| CC | CC du Rhône aux Gorges de l'Ardèche | 240700864 | ❔ | ❌ | ❌ |
+| Département | Cantal | 15 | ❔ | ❌ | ❌ |
+| CC | CC Hautes Terres | 200066637 | ❔ | ❌ | ❌ |
+| CC | CC de Saint-Flour | 200066660 | ❔ | ❌ | ❌ |
+| CC | CC de la Châtaigneraie Cantalienne | 200066678 | ❔ | ❌ | ❌ |
+| CA | CA du Bassin d'Aurillac | 241500230 | ✅ | ✅ | ❌ |
+| CC | CC du Pays Gentiane | 241500255 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Mauriac | 241500271 | ❔ | ❌ | ❌ |
+| CC | CC Sumène - Artense | 241501055 | ❔ | ❌ | ❌ |
+| CC | CC Cère et Goul en Carladès | 241501089 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Salers | 241501139 | ❔ | ❌ | ❌ |
+| CC | CC du Massif du Sancy | 246300966 | ❔ | ❌ | ❌ |
+| Département | Drôme | 26 | ❔ | ❌ | ❌ |
+| CC | CC Ventoux Sud | 200035723 | ❔ | ❌ | ❌ |
+| CA | CA Montélimar Agglomération | 200040459 | ❔ | ❌ | ❌ |
+| CC | CC Porte de Dromardèche | 200040491 | ❔ | ❌ | ❌ |
+| CC | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅ | ✅ | ❌ |
+| CC | CC Enclave des Papes - Pays de Grignan | 200040681 | ❔ | ❌ | ❌ |
+| CC | CC Drôme Sud Provence | 200042901 | ❔ | ❌ | ❌ |
+| CC | CC du Royans-Vercors | 200067767 | ❔ | ❌ | ❌ |
+| CC | CC des Baronnies en Drôme Provençale | 200068229 | ❔ | ❌ | ❌ |
+| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
+| CA | CA Valence Romans Agglo | 200068781 | ❔ | ❌ | ❌ |
+| CC | CC Jabron-Lure-Vançon-Durance | 200071033 | ❔ | ❌ | ❌ |
+| CA | CA Arche Agglo | 200073096 | ✅ | ✅ | ❌ |
+| CC | CC du Val de Drôme en Biovallée | 242600252 | ✅ | ✅ | ❌ |
+| CC | CC Dieulefit-Bourdeaux | 242600492 | ✅ | ✅ | ❌ |
+| CC | CC du Diois | 242600534 | ❔ | ❌ | ❌ |
+| CC | CC Vaison Ventoux | 248400335 | ❔ | ❌ | ❌ |
+| Département | Isère | 38 | ❔ | ❌ | ❌ |
+| CC | CC Le Grésivaudan | 200018166 | ❔ | ❌ | ❌ |
+| CC | CC du Trièves | 200030658 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Chartreuse | 200040111 | ❔ | ❌ | ❌ |
+| CC | CC de la Matheysine | 200040657 | ❔ | ❌ | ❌ |
+| METRO | Grenoble-Alpes-Métropole | 200040715 | ✅ | ✅ | ❌ |
+| CC | CC Bièvre Isère | 200059392 | ✅ | ✅ | ❌ |
+| CC | CC Les Balcons du Dauphiné | 200068542 | ❔ | ❌ | ❌ |
+| CC | CC Les Vals du Dauphiné | 200068567 | ❔ | ❌ | ❌ |
+| CC | CC Saint-Marcellin Vercors Isère Communauté | 200070431 | ✅ | ✅ | ❌ |
+| CA | CA Vienne Condrieu | 200077014 | ✅ | ✅ | ❌ |
+| CC | CC Entre Bièvre et Rhône | 200085751 | ❔ | ❌ | ❌ |
+| CA | CA Porte de l'Isère (CAPI) | 243800604 | ❔ | ❌ | ❌ |
+| CC | CC de l'Oisans | 243800745 | ❔ | ❌ | ❌ |
+| CC | CC Lyon-Saint-Exupéry en Dauphiné | 243800935 | ✅ | ✅ | ❌ |
+| CA | CA du Pays Voironnais | 243800984 | ❔ | ❌ | ❌ |
+| CC | CC du Massif du Vercors | 243801024 | ✅ | ✅ | ❌ |
+| CC | CC de Bièvre Est | 243801073 | ❔ | ❌ | ❌ |
+| CC | CC Collines Isère Nord Communauté | 243801255 | ❔ | ❌ | ❌ |
+| Département | Loire | 42 | ❔ | ❌ | ❌ |
+| CC | CC Charlieu-Belmont | 200035202 | ✅ | ✅ | ❌ |
+| CA | CA Roannais Agglomération | 200035731 | ❔ | ❌ | ❌ |
+| CA | CA Loire Forez Agglomération (LFA) | 200065886 | ❔ | ❌ | ❌ |
+| CC | CC de Forez-Est | 200065894 | ❔ | ❌ | ❌ |
+| CC | CC des Monts du Lyonnais | 200066587 | ❔ | ❌ | ❌ |
+| CC | CC des Vals d'Aix et Isable | 244200614 | ❔ | ❌ | ❌ |
+| CC | CC des Monts du Pilat | 244200622 | ❔ | ❌ | ❌ |
+| CC | CC du Pays Entre Loire et Rhône | 244200630 | ❔ | ❌ | ❌ |
+| METRO | Saint-Étienne Métropole | 244200770 | ✅ | ✅ | ❌ |
+| CC | CC du Pays d'Urfé | 244200820 | ❔ | ❌ | ❌ |
+| CC | CC du Pilat Rhodanien | 244200895 | ❔ | ❌ | ❌ |
+| Département | Haute-Loire | 43 | ❔ | ❌ | ❌ |
+| CC | CC des Rives du Haut Allier | 200073393 | ❔ | ❌ | ❌ |
+| CC | CC Mézenc-Loire-Meygal | 200073401 | ❔ | ❌ | ❌ |
+| CA | CA du Puy-en-Velay | 200073419 | ❔ | ❌ | ❌ |
+| CC | CC Marches du Velay-Rochebaron | 200073427 | ❔ | ❌ | ❌ |
+| CC | CC Brioude Sud Auvergne | 200085728 | ❔ | ❌ | ❌ |
+| CC | CC Haut Pays du Velay | 244300307 | ❔ | ❌ | ❌ |
+| CC | CC des Sucs | 244301016 | ❔ | ❌ | ❌ |
+| CC | CC Auzon Communauté | 244301099 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Lignon | 244301107 | ❔ | ❌ | ❌ |
+| CC | CC des Pays de Cayres et de Pradelles | 244301123 | ❔ | ❌ | ❌ |
+| CC | CC Loire et Semène | 244301131 | ❔ | ❌ | ❌ |
+| Département | Puy-de-Dôme | 63 | ❔ | ❌ | ❌ |
+| CC | CC Billom Communauté | 200067627 | ❔ | ❌ | ❌ |
+| CC | CC Dômes Sancy Artense | 200069169 | ❔ | ❌ | ❌ |
+| CC | CC Mond'Arverne Communauté | 200069177 | ❔ | ❌ | ❌ |
+| CA | CA Agglo Pays d'Issoire | 200070407 | ❔ | ❌ | ❌ |
+| CC | CC Thiers Dore et Montagne | 200070712 | ❔ | ❌ | ❌ |
+| CA | CA Riom Limagne et Volcans | 200070753 | ❔ | ❌ | ❌ |
+| CC | CC Ambert Livradois Forez | 200070761 | ❔ | ❌ | ❌ |
+| CC | CC Plaine Limagne | 200071199 | ❔ | ❌ | ❌ |
+| CC | CC Chavanon Combrailles et Volcans | 200071215 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Saint-Eloy | 200072080 | ❔ | ❌ | ❌ |
+| CC | CC Combrailles Sioule et Morge | 200072098 | ❔ | ❌ | ❌ |
+| METRO | Clermont Auvergne Métropole | 246300701 | ❔ | ❌ | ❌ |
+| CC | CC du Massif du Sancy | 246300966 | ❔ | ❌ | ❌ |
+| CC | CC Entre Dore et Allier | 246301097 | ❔ | ❌ | ❌ |
+| Département | Rhône | 69 | ❔ | ❌ | ❌ |
+| CA | CA de l'Ouest Rhodanien | 200040566 | ❔ | ❌ | ❌ |
+| CC | CC Beaujolais Pierres Dorées | 200040574 | ❔ | ❌ | ❌ |
+| CA | CA Villefranche Beaujolais Saône | 200040590 | ✅ | ✅ | ❌ |
+| MET69 | Métropole de Lyon | 200046977 | ✅ | ✅ | ❌ |
+| CC | CC des Monts du Lyonnais | 200066587 | ❔ | ❌ | ❌ |
+| CC | CC Saône-Beaujolais | 200067817 | ✅ | ✅ | ❌ |
+| CA | CA Vienne Condrieu | 200077014 | ✅ | ✅ | ❌ |
+| CC | CC de l'Est Lyonnais (CCEL) | 246900575 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de l'Arbresle (CCPA) | 246900625 | ❔ | ❌ | ❌ |
+| CC | CC des Vallons du Lyonnais (CCVL) | 246900724 | ✅ | ✅ | ❌ |
+| CC | CC du Pays Mornantais (COPAMO) | 246900740 | ✅ | ✅ | ❌ |
+| CC | CC de la Vallée du Garon (CCVG) | 246900757 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de l'Ozon | 246900765 | ✅ | ✅ | ❌ |
+| Département | Savoie | 73 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Tarentaise | 200023299 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Chartreuse | 200040111 | ❔ | ❌ | ❌ |
+| CC | CC Val Vanoise | 200040798 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Savoie | 200041010 | ✅ | ✅ | ❌ |
+| CA | CA Grand Lac | 200068674 | ❔ | ❌ | ❌ |
+| CA | CA Arlysère | 200068997 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Chambéry | 200069110 | ❔ | ❌ | ❌ |
+| CC | CC Haute Maurienne Vanoise | 200070340 | ❔ | ❌ | ❌ |
+| CC | CC Coeur de Maurienne Arvan | 200070464 | ✅ | ✅ | ❌ |
+| CC | CC des Vallées d'Aigueblanche | 247300015 | ❔ | ❌ | ❌ |
+| CC | CC de Haute-Tarentaise | 247300254 | ❔ | ❌ | ❌ |
+| CC | CC de Yenne | 247300262 | ❔ | ❌ | ❌ |
+| CC | CC du Canton de La Chambre | 247300361 | ❔ | ❌ | ❌ |
+| CC | CC Maurienne Galibier | 247300452 | ❔ | ❌ | ❌ |
+| CC | CC Val Guiers | 247300528 | ❔ | ❌ | ❌ |
+| CC | CC du Lac d'Aiguebelette (CCLA) | 247300668 | ❔ | ❌ | ❌ |
+| CC | CC Porte de Maurienne | 247300676 | ❔ | ❌ | ❌ |
+| CC | CC Les Versants d'Aime | 247300817 | ❔ | ❌ | ❌ |
+| Département | Haute-Savoie | 74 | ❔ | ❌ | ❌ |
+| CC | CC Faucigny - Glières | 200000172 | ❔ | ❌ | ❌ |
+| CA | CA Annemasse-Les Voirons-Agglomération | 200011773 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée de Chamonix-Mont-Blanc | 200023372 | ❔ | ❌ | ❌ |
+| CC | CC Cluses-Arve et Montagnes | 200033116 | ✅ | ✅ | ❌ |
+| CC | CC des Montagnes du Giffre | 200034098 | ❔ | ❌ | ❌ |
+| CC | CC Pays du Mont-Blanc | 200034882 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Annecy | 200066793 | ❔ | ❌ | ❌ |
+| CA | CA Thonon Agglomération | 200067551 | ❔ | ❌ | ❌ |
+| CC | CC Usses et Rhône | 200070852 | ❔ | ❌ | ❌ |
+| CC | CC Pays d'Evian Vallée d'Abondance | 200071967 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée Verte | 247400047 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Cruseilles | 247400112 | ✅ | ✅ | ❌ |
+| CC | CC Fier et Usses | 247400567 | ✅ | ✅ | ❌ |
+| CC | CC Arve et Salève | 247400583 | ❔ | ❌ | ❌ |
+| CC | CC des Vallées de Thônes | 247400617 | ❔ | ❌ | ❌ |
+| CC | CC des Quatre Rivières | 247400666 | ❔ | ❌ | ❌ |
+| CC | CC du Haut Chablais | 247400682 | ❔ | ❌ | ❌ |
+| CC | CC du Genevois | 247400690 | ✅ | ✅ | ❌ |
+| CC | CC du Pays Rochois | 247400724 | ❔ | ❌ | ❌ |
+| CC | CC Rumilly Terre de Savoie | 247400740 | ❔ | ❌ | ❌ |
+| CC | CC des Sources du Lac d'Annecy | 247400773 | ❔ | ❌ | ❌ |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -125,30 +125,30 @@
 | CC          | CC du Haut Lignon                                    | 244301107 | ❌               | ❌        | 🤖    |
 | CC          | CC des Pays de Cayres et de Pradelles                | 244301123 | ❌               | ❌        | 🤖    |
 | CC          | CC Loire et Semène                                   | 244301131 | ❌               | ❌        | 🤖    |
-| Département | Puy-de-Dôme                                          | 63        | ❔               | ❌        | ❌    |
-| CC          | CC Billom Communauté                                 | 200067627 | ❔               | ❌        | ❌    |
-| CC          | CC Dômes Sancy Artense                               | 200069169 | ❔               | ❌        | ❌    |
-| CC          | CC Mond'Arverne Communauté                           | 200069177 | ❔               | ❌        | ❌    |
-| CA          | CA Agglo Pays d'Issoire                              | 200070407 | ❔               | ❌        | ❌    |
-| CC          | CC Thiers Dore et Montagne                           | 200070712 | ❔               | ❌        | ❌    |
-| CA          | CA Riom Limagne et Volcans                           | 200070753 | ❔               | ❌        | ❌    |
-| CC          | CC Ambert Livradois Forez                            | 200070761 | ❔               | ❌        | ❌    |
+| Département | Puy-de-Dôme                                          | 63        | ❌               | ❌        | 🤖    |
+| CC          | CC Billom Communauté                                 | 200067627 | ❌               | ❌        | 🤖    |
+| CC          | CC Dômes Sancy Artense                               | 200069169 | ❌               | ❌        | 🤖    |
+| CC          | CC Mond'Arverne Communauté                           | 200069177 | ❌               | ❌        | 🤖    |
+| CA          | CA Agglo Pays d'Issoire                              | 200070407 | ❌               | ❌        | 🤖    |
+| CC          | CC Thiers Dore et Montagne                           | 200070712 | ❌               | ❌        | 🤖    |
+| CA          | CA Riom Limagne et Volcans                           | 200070753 | ❌               | ❌        | 🤖    |
+| CC          | CC Ambert Livradois Forez                            | 200070761 | ❌               | ❌        | 🤖    |
 | CC          | CC Plaine Limagne                                    | 200071199 | ✅               | ✅        | ✅    |
-| CC          | CC Chavanon Combrailles et Volcans                   | 200071215 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Saint-Eloy                             | 200072080 | ❔               | ❌        | ❌    |
-| CC          | CC Combrailles Sioule et Morge                       | 200072098 | ❔               | ❌        | ❌    |
+| CC          | CC Chavanon Combrailles et Volcans                   | 200071215 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Saint-Eloy                             | 200072080 | ❌               | ❌        | 🤖    |
+| CC          | CC Combrailles Sioule et Morge                       | 200072098 | ❌               | ❌        | 🤖    |
 | METRO       | Clermont Auvergne Métropole                          | 246300701 | ❌               | ❌        | ✅    |
-| CC          | CC du Massif du Sancy                                | 246300966 | ❔               | ❌        | ❌    |
-| CC          | CC Entre Dore et Allier                              | 246301097 | ❔               | ❌        | ❌    |
+| CC          | CC du Massif du Sancy                                | 246300966 | ❌               | ❌        | 🤖    |
+| CC          | CC Entre Dore et Allier                              | 246301097 | ❌               | ❌        | 🤖    |
 | Département | Rhône                                                | 69        | ❔               | ❌        | ❌    |
 | CA          | CA de l'Ouest Rhodanien                              | 200040566 | ❔               | ❌        | ❌    |
 | CC          | CC Beaujolais Pierres Dorées                         | 200040574 | ❔               | ❌        | ❌    |
-| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ❌    |
-| MET69       | Métropole de Lyon                                    | 200046977 | ✅               | ✅        | ❌    |
-| CC          | CC des Monts du Lyonnais                             | 200066587 | ❔               | ❌        | ❌    |
-| CC          | CC Saône-Beaujolais                                  | 200067817 | ✅               | ✅        | ❌    |
-| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ❌    |
-| CC          | CC de l'Est Lyonnais (CCEL)                          | 246900575 | ❔               | ❌        | ❌    |
+| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ✅    |
+| MET69       | Métropole de Lyon                                    | 200046977 | ✅               | ✅        | ✅    |
+| CC          | CC des Monts du Lyonnais                             | 200066587 | ❌               | ❌        | ✅    |
+| CC          | CC Saône-Beaujolais                                  | 200067817 | ✅               | ✅        | ✅    |
+| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ✅    |
+| CC          | CC de l'Est Lyonnais (CCEL)                          | 246900575 | ❌               | ❌        | ✅    |
 | CC          | CC du Pays de l'Arbresle (CCPA)                      | 246900625 | ❔               | ❌        | ❌    |
 | CC          | CC des Vallons du Lyonnais (CCVL)                    | 246900724 | ✅               | ✅        | ❌    |
 | CC          | CC du Pays Mornantais (COPAMO)                       | 246900740 | ✅               | ✅        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -185,8 +185,8 @@
 | CC          | CC Usses et Rhône                                    | 200070852 | ❔               | ❌        | ❌    |
 | CC          | CC Pays d'Evian Vallée d'Abondance                   | 200071967 | ❔               | ❌        | ❌    |
 | CC          | CC de la Vallée Verte                                | 247400047 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Cruseilles                             | 247400112 | ✅               | ✅        | ❌    |
-| CC          | CC Fier et Usses                                     | 247400567 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Cruseilles                             | 247400112 | ✅               | ✅        | ✅    |
+| CC          | CC Fier et Usses                                     | 247400567 | ✅               | ✅        | ✅    |
 | CC          | CC Arve et Salève                                    | 247400583 | ❔               | ❌        | ❌    |
 | CC          | CC des Vallées de Thônes                             | 247400617 | ❔               | ❌        | ❌    |
 | CC          | CC des Quatre Rivières                               | 247400666 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -2,74 +2,74 @@
 
 | Echelle     | Nom                                                  | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ---------------------------------------------------- | --------- | ---------------- | --------- | ----- |
-| Région      | Auvergne-Rhône-Alpes                                 | 84        | ❔               | ❌        | ❌    |
-| Département | Ain                                                  | 01        | ❔               | ❌        | ❌    |
-| CC          | CC Rives de l'Ain - Pays du Cerdon                   | 200029999 | ❔               | ❌        | ❌    |
-| CC          | CC Bugey Sud                                         | 200040350 | ❔               | ❌        | ❌    |
-| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ❌    |
-| CC          | CC Dombes Saône Vallée                               | 200042497 | ❔               | ❌        | ❌    |
-| CA          | CA Haut-Bugey Agglomération                          | 200042935 | ❔               | ❌        | ❌    |
-| CC          | CC de la Dombes                                      | 200069193 | ❔               | ❌        | ❌    |
+| Région      | Auvergne-Rhône-Alpes                                 | 84        | ❌               | ❌        | 🤖    |
+| Département | Ain                                                  | 01        | ❌               | ❌        | 🤖    |
+| CC          | CC Rives de l'Ain - Pays du Cerdon                   | 200029999 | ❌               | ❌        | 🤖    |
+| CC          | CC Bugey Sud                                         | 200040350 | ❌               | ❌        | 🤖    |
+| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ✅    |
+| CC          | CC Dombes Saône Vallée                               | 200042497 | ❌               | ❌        | 🤖    |
+| CA          | CA Haut-Bugey Agglomération                          | 200042935 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Dombes                                      | 200069193 | ❌               | ❌        | 🤖    |
 | CC          | CC Val de Saône Centre                               | 200070118 | ✅               | ✅        | ✅    |
-| CA          | CA Mâconnais Beaujolais Agglomération                | 200070308 | ❔               | ❌        | ❌    |
-| CC          | CC de la Veyle                                       | 200070555 | ❔               | ❌        | ❌    |
-| CC          | CC Usses et Rhône                                    | 200070852 | ❔               | ❌        | ❌    |
-| CC          | CC Bresse et Saône                                   | 200071371 | ❔               | ❌        | ❌    |
-| CA          | CA du Bassin de Bourg-en-Bresse                      | 200071751 | ❔               | ❌        | ❌    |
-| CC          | CC de la Côtière à Montluel                          | 240100610 | ✅               | ✅        | ❌    |
-| CA          | CA du Pays de Gex                                    | 240100750 | ❔               | ❌        | ❌    |
-| CC          | CC de Miribel et du Plateau                          | 240100800 | ❔               | ❌        | ❌    |
-| CC          | CC de la Plaine de l'Ain                             | 240100883 | ✅               | ✅        | ❌    |
-| CC          | CC Terre Valserhône (CCTV)                           | 240100891 | ❔               | ❌        | ❌    |
-| Département | Allier                                               | 03        | ❔               | ❌        | ❌    |
-| CA          | CA Montluçon Communauté                              | 200071082 | ✅               | ✅        | ❌    |
-| CA          | CA Moulins Communauté                                | 200071140 | ❔               | ❌        | ❌    |
-| CA          | CA Vichy Communauté                                  | 200071363 | ❔               | ❌        | ❌    |
-| CC          | CC Saint-Pourçain Sioule Limagne                     | 200071389 | ❔               | ❌        | ❌    |
-| CC          | CC Entr'Allier Besbre et Loire                       | 200071470 | ❔               | ❌        | ❌    |
-| CC          | CC du Bocage Bourbonnais                             | 200071496 | ❔               | ❌        | ❌    |
-| CC          | CC Commentry Montmarault Néris Communauté            | 200071512 | ❔               | ❌        | ❌    |
-| CC          | CC Le Grand Charolais                                | 200071884 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Lapalisse                              | 240300491 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Tronçais                               | 240300558 | ❔               | ❌        | ❌    |
-| CC          | CC du Val de Cher                                    | 240300566 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays d'Huriel                                  | 240300657 | ❔               | ❌        | ❌    |
-| Département | Ardèche                                              | 07        | ✅               | ✅        | ❌    |
-| CC          | CC du Pays de Lamastre                               | 200016905 | ❔               | ❌        | ❌    |
-| CC          | CC de Cèze Cévennes                                  | 200035129 | ❔               | ❌        | ❌    |
-| CC          | CC des Gorges de l'Ardèche                           | 200039808 | ❔               | ❌        | ❌    |
-| CC          | CC Ardèche des Sources et Volcans                    | 200039824 | ❔               | ❌        | ❌    |
-| CC          | CC Pays des Vans en Cévennes                         | 200039832 | ❔               | ❌        | ❌    |
-| CC          | CC Porte de Dromardèche                              | 200040491 | ❔               | ❌        | ❌    |
-| CC          | CC Rhône Crussol                                     | 200041366 | ❔               | ❌        | ❌    |
-| CC          | CC Val Eyrieux                                       | 200041465 | ❔               | ❌        | ❌    |
-| CC          | CC Ardèche Rhône Coiron                              | 200071405 | ❔               | ❌        | ❌    |
-| CA          | CA Privas Centre Ardèche                             | 200071413 | ❔               | ❌        | ❌    |
-| CC          | CC Montagne d'Ardèche                                | 200072007 | ❔               | ❌        | ❌    |
-| CA          | CA Annonay Rhône Agglo                               | 200072015 | ✅               | ✅        | ❌    |
-| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ❌    |
-| CC          | CC du Bassin d'Aubenas                               | 200073245 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays Beaume-Drobie                             | 240700302 | ❔               | ❌        | ❌    |
-| CC          | CC Val de Ligne                                      | 240700617 | ❔               | ❌        | ❌    |
-| CC          | CC du Val d'Ay                                       | 240700716 | ❔               | ❌        | ❌    |
-| CC          | CC Berg et Coiron                                    | 240700815 | ❔               | ❌        | ❌    |
-| CC          | CC du Rhône aux Gorges de l'Ardèche                  | 240700864 | ❔               | ❌        | ❌    |
-| Département | Cantal                                               | 15        | ❔               | ❌        | ❌    |
-| CC          | CC Hautes Terres                                     | 200066637 | ❔               | ❌        | ❌    |
-| CC          | CC de Saint-Flour                                    | 200066660 | ❔               | ❌        | ❌    |
-| CC          | CC de la Châtaigneraie Cantalienne                   | 200066678 | ❔               | ❌        | ❌    |
-| CA          | CA du Bassin d'Aurillac                              | 241500230 | ✅               | ✅        | ❌    |
-| CC          | CC du Pays Gentiane                                  | 241500255 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Mauriac                                | 241500271 | ❔               | ❌        | ❌    |
-| CC          | CC Sumène - Artense                                  | 241501055 | ❔               | ❌        | ❌    |
-| CC          | CC Cère et Goul en Carladès                          | 241501089 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Salers                                 | 241501139 | ❔               | ❌        | ❌    |
-| CC          | CC du Massif du Sancy                                | 246300966 | ❔               | ❌        | ❌    |
-| Département | Drôme                                                | 26        | ❔               | ❌        | ❌    |
+| CA          | CA Mâconnais Beaujolais Agglomération                | 200070308 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Veyle                                       | 200070555 | ❌               | ❌        | 🤖    |
+| CC          | CC Usses et Rhône                                    | 200070852 | ❌               | ❌        | 🤖    |
+| CC          | CC Bresse et Saône                                   | 200071371 | ❌               | ❌        | 🤖    |
+| CA          | CA du Bassin de Bourg-en-Bresse                      | 200071751 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Côtière à Montluel                          | 240100610 | ✅               | ✅        | ✅    |
+| CA          | CA du Pays de Gex                                    | 240100750 | ❌               | ❌        | 🤖    |
+| CC          | CC de Miribel et du Plateau                          | 240100800 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Plaine de l'Ain                             | 240100883 | ✅               | ✅        | ✅    |
+| CC          | CC Terre Valserhône (CCTV)                           | 240100891 | ❌               | ❌        | 🤖    |
+| Département | Allier                                               | 03        | ❌               | ❌        | 🤖    |
+| CA          | CA Montluçon Communauté                              | 200071082 | ✅               | ✅        | ✅    |
+| CA          | CA Moulins Communauté                                | 200071140 | ❌               | ❌        | 🤖    |
+| CA          | CA Vichy Communauté                                  | 200071363 | ❌               | ❌        | 🤖    |
+| CC          | CC Saint-Pourçain Sioule Limagne                     | 200071389 | ❌               | ❌        | 🤖    |
+| CC          | CC Entr'Allier Besbre et Loire                       | 200071470 | ❌               | ❌        | 🤖    |
+| CC          | CC du Bocage Bourbonnais                             | 200071496 | ❌               | ❌        | 🤖    |
+| CC          | CC Commentry Montmarault Néris Communauté            | 200071512 | ❌               | ❌        | 🤖    |
+| CC          | CC Le Grand Charolais                                | 200071884 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Lapalisse                              | 240300491 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Tronçais                               | 240300558 | ❌               | ❌        | 🤖    |
+| CC          | CC du Val de Cher                                    | 240300566 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays d'Huriel                                  | 240300657 | ❌               | ❌        | 🤖    |
+| Département | Ardèche                                              | 07        | ✅               | ✅        | ✅    |
+| CC          | CC du Pays de Lamastre                               | 200016905 | ❌               | ❌        | ✅    |
+| CC          | CC de Cèze Cévennes                                  | 200035129 | ❌               | ❌        | ✅    |
+| CC          | CC des Gorges de l'Ardèche                           | 200039808 | ❌               | ❌        | ✅    |
+| CC          | CC Ardèche des Sources et Volcans                    | 200039824 | ❌               | ❌        | ✅    |
+| CC          | CC Pays des Vans en Cévennes                         | 200039832 | ❌               | ❌        | 🤖    |
+| CC          | CC Porte de Dromardèche                              | 200040491 | ❌               | ❌        | 🤖    |
+| CC          | CC Rhône Crussol                                     | 200041366 | ❌               | ❌        | 🤖    |
+| CC          | CC Val Eyrieux                                       | 200041465 | ❌               | ❌        | 🤖    |
+| CC          | CC Ardèche Rhône Coiron                              | 200071405 | ❌               | ❌        | 🤖    |
+| CA          | CA Privas Centre Ardèche                             | 200071413 | ❌               | ❌        | ✅    |
+| CC          | CC Montagne d'Ardèche                                | 200072007 | ❌               | ❌        | 🤖    |
+| CA          | CA Annonay Rhône Agglo                               | 200072015 | ✅               | ✅        | ✅    |
+| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ✅    |
+| CC          | CC du Bassin d'Aubenas                               | 200073245 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays Beaume-Drobie                             | 240700302 | ❌               | ❌        | 🤖    |
+| CC          | CC Val de Ligne                                      | 240700617 | ❌               | ❌        | 🤖    |
+| CC          | CC du Val d'Ay                                       | 240700716 | ❌               | ❌        | 🤖    |
+| CC          | CC Berg et Coiron                                    | 240700815 | ❌               | ❌        | 🤖    |
+| CC          | CC du Rhône aux Gorges de l'Ardèche                  | 240700864 | ❌               | ❌        | 🤖    |
+| Département | Cantal                                               | 15        | ❌               | ❌        | ✅    |
+| CC          | CC Hautes Terres                                     | 200066637 | ❌               | ❌        | 🤖    |
+| CC          | CC de Saint-Flour                                    | 200066660 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Châtaigneraie Cantalienne                   | 200066678 | ❌               | ❌        | 🤖    |
+| CA          | CA du Bassin d'Aurillac                              | 241500230 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays Gentiane                                  | 241500255 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Mauriac                                | 241500271 | ❌               | ❌        | 🤖    |
+| CC          | CC Sumène - Artense                                  | 241501055 | ❌               | ❌        | 🤖    |
+| CC          | CC Cère et Goul en Carladès                          | 241501089 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Salers                                 | 241501139 | ❌               | ❌        | 🤖    |
+| CC          | CC du Massif du Sancy                                | 246300966 | ❌               | ❌        | 🤖    |
+| Département | Drôme                                                | 26        | ❔               | ❌        | 🤖    |
 | CC          | CC Ventoux Sud                                       | 200035723 | ❔               | ❌        | ❌    |
 | CA          | CA Montélimar Agglomération                          | 200040459 | ❔               | ❌        | ❌    |
 | CC          | CC Porte de Dromardèche                              | 200040491 | ❔               | ❌        | ❌    |
-| CC          | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅               | ✅        | ❌    |
+| CC          | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅               | ✅        | ✅    |
 | CC          | CC Enclave des Papes - Pays de Grignan               | 200040681 | ❔               | ❌        | ❌    |
 | CC          | CC Drôme Sud Provence                                | 200042901 | ❔               | ❌        | ❌    |
 | CC          | CC du Royans-Vercors                                 | 200067767 | ❔               | ❌        | ❌    |
@@ -77,7 +77,7 @@
 | CC          | CC du Sisteronais-Buëch                              | 200068765 | ❔               | ❌        | ❌    |
 | CA          | CA Valence Romans Agglo                              | 200068781 | ❔               | ❌        | ❌    |
 | CC          | CC Jabron-Lure-Vançon-Durance                        | 200071033 | ❔               | ❌        | ❌    |
-| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ❌    |
+| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ✅    |
 | CC          | CC du Val de Drôme en Biovallée                      | 242600252 | ✅               | ✅        | ❌    |
 | CC          | CC Dieulefit-Bourdeaux                               | 242600492 | ✅               | ✅        | ❌    |
 | CC          | CC du Diois                                          | 242600534 | ❔               | ❌        | ❌    |
@@ -161,7 +161,7 @@
 | CC          | CC Coeur de Savoie                                   | 200041010 | ✅               | ✅        | ❌    |
 | CA          | CA Grand Lac                                         | 200068674 | ❔               | ❌        | ❌    |
 | CA          | CA Arlysère                                          | 200068997 | ❔               | ❌        | ❌    |
-| CA          | CA du Grand Chambéry                                 | 200069110 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Chambéry                                 | 200069110 | ✅               | ✅        | ✅    |
 | CC          | CC Haute Maurienne Vanoise                           | 200070340 | ❔               | ❌        | ❌    |
 | CC          | CC Coeur de Maurienne Arvan                          | 200070464 | ✅               | ✅        | ❌    |
 | CC          | CC des Vallées d'Aigueblanche                        | 247300015 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -1,5 +1,7 @@
 # Couverture des aides en Auvergne-Rhône-Alpes (84)
 
+- 2025 : ✅
+
 | Echelle     | Nom                                                  | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ---------------------------------------------------- | --------- | ---------------- | --------- | ----- |
 | Région      | Auvergne-Rhône-Alpes                                 | 84        | ❌               | ❌        | 🤖    |
@@ -173,25 +175,25 @@
 | CC          | CC du Lac d'Aiguebelette (CCLA)                      | 247300668 | ❌               | ❌        | 🤖    |
 | CC          | CC Porte de Maurienne                                | 247300676 | ❌               | ❌        | 🤖    |
 | CC          | CC Les Versants d'Aime                               | 247300817 | ❌               | ❌        | 🤖    |
-| Département | Haute-Savoie                                         | 74        | ❔               | ❌        | ❌    |
-| CC          | CC Faucigny - Glières                                | 200000172 | ❔               | ❌        | ❌    |
-| CA          | CA Annemasse-Les Voirons-Agglomération               | 200011773 | ❔               | ❌        | ❌    |
-| CC          | CC de la Vallée de Chamonix-Mont-Blanc               | 200023372 | ❔               | ❌        | ❌    |
+| Département | Haute-Savoie                                         | 74        | ❌               | ❌        | 🤖    |
+| CC          | CC Faucigny - Glières                                | 200000172 | ❌               | ❌        | 🤖    |
+| CA          | CA Annemasse-Les Voirons-Agglomération               | 200011773 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Vallée de Chamonix-Mont-Blanc               | 200023372 | ❌               | ❌        | 🤖    |
 | CC          | CC Cluses-Arve et Montagnes                          | 200033116 | ✅               | ✅        | ✅    |
-| CC          | CC des Montagnes du Giffre                           | 200034098 | ❔               | ❌        | ❌    |
-| CC          | CC Pays du Mont-Blanc                                | 200034882 | ❔               | ❌        | ❌    |
-| CA          | CA du Grand Annecy                                   | 200066793 | ❔               | ❌        | ❌    |
-| CA          | CA Thonon Agglomération                              | 200067551 | ❔               | ❌        | ❌    |
-| CC          | CC Usses et Rhône                                    | 200070852 | ❔               | ❌        | ❌    |
-| CC          | CC Pays d'Evian Vallée d'Abondance                   | 200071967 | ❔               | ❌        | ❌    |
-| CC          | CC de la Vallée Verte                                | 247400047 | ❔               | ❌        | ❌    |
+| CC          | CC des Montagnes du Giffre                           | 200034098 | ❌               | ❌        | 🤖    |
+| CC          | CC Pays du Mont-Blanc                                | 200034882 | ❌               | ❌        | 🤖    |
+| CA          | CA du Grand Annecy                                   | 200066793 | ❌               | ❌        | 🤖    |
+| CA          | CA Thonon Agglomération                              | 200067551 | ❌               | ❌        | 🤖    |
+| CC          | CC Usses et Rhône                                    | 200070852 | ❌               | ❌        | 🤖    |
+| CC          | CC Pays d'Evian Vallée d'Abondance                   | 200071967 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Vallée Verte                                | 247400047 | ❌               | ❌        | 🤖    |
 | CC          | CC du Pays de Cruseilles                             | 247400112 | ✅               | ✅        | ✅    |
 | CC          | CC Fier et Usses                                     | 247400567 | ✅               | ✅        | ✅    |
-| CC          | CC Arve et Salève                                    | 247400583 | ❔               | ❌        | ❌    |
-| CC          | CC des Vallées de Thônes                             | 247400617 | ❔               | ❌        | ❌    |
-| CC          | CC des Quatre Rivières                               | 247400666 | ❔               | ❌        | ❌    |
-| CC          | CC du Haut Chablais                                  | 247400682 | ❔               | ❌        | ❌    |
+| CC          | CC Arve et Salève                                    | 247400583 | ❌               | ❌        | 🤖    |
+| CC          | CC des Vallées de Thônes                             | 247400617 | ❌               | ❌        | 🤖    |
+| CC          | CC des Quatre Rivières                               | 247400666 | ❌               | ❌        | 🤖    |
+| CC          | CC du Haut Chablais                                  | 247400682 | ❌               | ❌        | 🤖    |
 | CC          | CC du Genevois                                       | 247400690 | ✅               | ✅        | ✅    |
-| CC          | CC du Pays Rochois                                   | 247400724 | ❔               | ❌        | ❌    |
-| CC          | CC Rumilly Terre de Savoie                           | 247400740 | ❔               | ❌        | ❌    |
-| CC          | CC des Sources du Lac d'Annecy                       | 247400773 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Rochois                                   | 247400724 | ❌               | ❌        | 🤖    |
+| CC          | CC Rumilly Terre de Savoie                           | 247400740 | ❌               | ❌        | 🤖    |
+| CC          | CC des Sources du Lac d'Annecy                       | 247400773 | ❌               | ❌        | 🤖    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -1,198 +1,197 @@
 # Couverture des aides en Auvergne-Rhône-Alpes (84)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Auvergne-Rhône-Alpes | 84 | ❔ | ❌ | ❌ |
-| Département | Ain | 01 | ❔ | ❌ | ❌ |
-| CC | CC Rives de l'Ain - Pays du Cerdon | 200029999 | ❔ | ❌ | ❌ |
-| CC | CC Bugey Sud | 200040350 | ❔ | ❌ | ❌ |
-| CA | CA Villefranche Beaujolais Saône | 200040590 | ✅ | ✅ | ❌ |
-| CC | CC Dombes Saône Vallée | 200042497 | ❔ | ❌ | ❌ |
-| CA | CA Haut-Bugey Agglomération | 200042935 | ❔ | ❌ | ❌ |
-| CC | CC de la Dombes | 200069193 | ❔ | ❌ | ❌ |
-| CC | CC Val de Saône Centre | 200070118 | ❔ | ❌ | ❌ |
-| CA | CA Mâconnais Beaujolais Agglomération | 200070308 | ❔ | ❌ | ❌ |
-| CC | CC de la Veyle | 200070555 | ❔ | ❌ | ❌ |
-| CC | CC Usses et Rhône | 200070852 | ❔ | ❌ | ❌ |
-| CC | CC Bresse et Saône | 200071371 | ❔ | ❌ | ❌ |
-| CA | CA du Bassin de Bourg-en-Bresse | 200071751 | ❔ | ❌ | ❌ |
-| CC | CC de la Côtière à Montluel | 240100610 | ✅ | ✅ | ❌ |
-| CA | CA du Pays de Gex | 240100750 | ❔ | ❌ | ❌ |
-| CC | CC de Miribel et du Plateau | 240100800 | ❔ | ❌ | ❌ |
-| CC | CC de la Plaine de l'Ain | 240100883 | ✅ | ✅ | ❌ |
-| CC | CC Terre Valserhône (CCTV) | 240100891 | ❔ | ❌ | ❌ |
-| Département | Allier | 03 | ❔ | ❌ | ❌ |
-| CA | CA Montluçon Communauté | 200071082 | ✅ | ✅ | ❌ |
-| CA | CA Moulins Communauté | 200071140 | ❔ | ❌ | ❌ |
-| CA | CA Vichy Communauté | 200071363 | ❔ | ❌ | ❌ |
-| CC | CC Saint-Pourçain Sioule Limagne | 200071389 | ❔ | ❌ | ❌ |
-| CC | CC Entr'Allier Besbre et Loire | 200071470 | ❔ | ❌ | ❌ |
-| CC | CC du Bocage Bourbonnais | 200071496 | ❔ | ❌ | ❌ |
-| CC | CC Commentry Montmarault Néris Communauté | 200071512 | ❔ | ❌ | ❌ |
-| CC | CC Le Grand Charolais | 200071884 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Lapalisse | 240300491 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Tronçais | 240300558 | ❔ | ❌ | ❌ |
-| CC | CC du Val de Cher | 240300566 | ❔ | ❌ | ❌ |
-| CC | CC du Pays d'Huriel | 240300657 | ❔ | ❌ | ❌ |
-| Département | Ardèche | 07 | ✅ | ✅ | ❌ |
-| CC | CC du Pays de Lamastre | 200016905 | ❔ | ❌ | ❌ |
-| CC | CC de Cèze Cévennes | 200035129 | ❔ | ❌ | ❌ |
-| CC | CC des Gorges de l'Ardèche | 200039808 | ❔ | ❌ | ❌ |
-| CC | CC Ardèche des Sources et Volcans | 200039824 | ❔ | ❌ | ❌ |
-| CC | CC Pays des Vans en Cévennes | 200039832 | ❔ | ❌ | ❌ |
-| CC | CC Porte de Dromardèche | 200040491 | ❔ | ❌ | ❌ |
-| CC | CC Rhône Crussol | 200041366 | ❔ | ❌ | ❌ |
-| CC | CC Val Eyrieux | 200041465 | ❔ | ❌ | ❌ |
-| CC | CC Ardèche Rhône Coiron | 200071405 | ❔ | ❌ | ❌ |
-| CA | CA Privas Centre Ardèche | 200071413 | ❔ | ❌ | ❌ |
-| CC | CC Montagne d'Ardèche | 200072007 | ❔ | ❌ | ❌ |
-| CA | CA Annonay Rhône Agglo | 200072015 | ✅ | ✅ | ❌ |
-| CA | CA Arche Agglo | 200073096 | ✅ | ✅ | ❌ |
-| CC | CC du Bassin d'Aubenas | 200073245 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Beaume-Drobie | 240700302 | ❔ | ❌ | ❌ |
-| CC | CC Val de Ligne | 240700617 | ❔ | ❌ | ❌ |
-| CC | CC du Val d'Ay | 240700716 | ❔ | ❌ | ❌ |
-| CC | CC Berg et Coiron | 240700815 | ❔ | ❌ | ❌ |
-| CC | CC du Rhône aux Gorges de l'Ardèche | 240700864 | ❔ | ❌ | ❌ |
-| Département | Cantal | 15 | ❔ | ❌ | ❌ |
-| CC | CC Hautes Terres | 200066637 | ❔ | ❌ | ❌ |
-| CC | CC de Saint-Flour | 200066660 | ❔ | ❌ | ❌ |
-| CC | CC de la Châtaigneraie Cantalienne | 200066678 | ❔ | ❌ | ❌ |
-| CA | CA du Bassin d'Aurillac | 241500230 | ✅ | ✅ | ❌ |
-| CC | CC du Pays Gentiane | 241500255 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Mauriac | 241500271 | ❔ | ❌ | ❌ |
-| CC | CC Sumène - Artense | 241501055 | ❔ | ❌ | ❌ |
-| CC | CC Cère et Goul en Carladès | 241501089 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Salers | 241501139 | ❔ | ❌ | ❌ |
-| CC | CC du Massif du Sancy | 246300966 | ❔ | ❌ | ❌ |
-| Département | Drôme | 26 | ❔ | ❌ | ❌ |
-| CC | CC Ventoux Sud | 200035723 | ❔ | ❌ | ❌ |
-| CA | CA Montélimar Agglomération | 200040459 | ❔ | ❌ | ❌ |
-| CC | CC Porte de Dromardèche | 200040491 | ❔ | ❌ | ❌ |
-| CC | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅ | ✅ | ❌ |
-| CC | CC Enclave des Papes - Pays de Grignan | 200040681 | ❔ | ❌ | ❌ |
-| CC | CC Drôme Sud Provence | 200042901 | ❔ | ❌ | ❌ |
-| CC | CC du Royans-Vercors | 200067767 | ❔ | ❌ | ❌ |
-| CC | CC des Baronnies en Drôme Provençale | 200068229 | ❔ | ❌ | ❌ |
-| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
-| CA | CA Valence Romans Agglo | 200068781 | ❔ | ❌ | ❌ |
-| CC | CC Jabron-Lure-Vançon-Durance | 200071033 | ❔ | ❌ | ❌ |
-| CA | CA Arche Agglo | 200073096 | ✅ | ✅ | ❌ |
-| CC | CC du Val de Drôme en Biovallée | 242600252 | ✅ | ✅ | ❌ |
-| CC | CC Dieulefit-Bourdeaux | 242600492 | ✅ | ✅ | ❌ |
-| CC | CC du Diois | 242600534 | ❔ | ❌ | ❌ |
-| CC | CC Vaison Ventoux | 248400335 | ❔ | ❌ | ❌ |
-| Département | Isère | 38 | ❔ | ❌ | ❌ |
-| CC | CC Le Grésivaudan | 200018166 | ❔ | ❌ | ❌ |
-| CC | CC du Trièves | 200030658 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Chartreuse | 200040111 | ❔ | ❌ | ❌ |
-| CC | CC de la Matheysine | 200040657 | ❔ | ❌ | ❌ |
-| METRO | Grenoble-Alpes-Métropole | 200040715 | ✅ | ✅ | ❌ |
-| CC | CC Bièvre Isère | 200059392 | ✅ | ✅ | ❌ |
-| CC | CC Les Balcons du Dauphiné | 200068542 | ❔ | ❌ | ❌ |
-| CC | CC Les Vals du Dauphiné | 200068567 | ❔ | ❌ | ❌ |
-| CC | CC Saint-Marcellin Vercors Isère Communauté | 200070431 | ✅ | ✅ | ❌ |
-| CA | CA Vienne Condrieu | 200077014 | ✅ | ✅ | ❌ |
-| CC | CC Entre Bièvre et Rhône | 200085751 | ❔ | ❌ | ❌ |
-| CA | CA Porte de l'Isère (CAPI) | 243800604 | ❔ | ❌ | ❌ |
-| CC | CC de l'Oisans | 243800745 | ❔ | ❌ | ❌ |
-| CC | CC Lyon-Saint-Exupéry en Dauphiné | 243800935 | ✅ | ✅ | ❌ |
-| CA | CA du Pays Voironnais | 243800984 | ❔ | ❌ | ❌ |
-| CC | CC du Massif du Vercors | 243801024 | ✅ | ✅ | ❌ |
-| CC | CC de Bièvre Est | 243801073 | ❔ | ❌ | ❌ |
-| CC | CC Collines Isère Nord Communauté | 243801255 | ❔ | ❌ | ❌ |
-| Département | Loire | 42 | ❔ | ❌ | ❌ |
-| CC | CC Charlieu-Belmont | 200035202 | ✅ | ✅ | ❌ |
-| CA | CA Roannais Agglomération | 200035731 | ❔ | ❌ | ❌ |
-| CA | CA Loire Forez Agglomération (LFA) | 200065886 | ❔ | ❌ | ❌ |
-| CC | CC de Forez-Est | 200065894 | ❔ | ❌ | ❌ |
-| CC | CC des Monts du Lyonnais | 200066587 | ❔ | ❌ | ❌ |
-| CC | CC des Vals d'Aix et Isable | 244200614 | ❔ | ❌ | ❌ |
-| CC | CC des Monts du Pilat | 244200622 | ❔ | ❌ | ❌ |
-| CC | CC du Pays Entre Loire et Rhône | 244200630 | ❔ | ❌ | ❌ |
-| METRO | Saint-Étienne Métropole | 244200770 | ✅ | ✅ | ❌ |
-| CC | CC du Pays d'Urfé | 244200820 | ❔ | ❌ | ❌ |
-| CC | CC du Pilat Rhodanien | 244200895 | ❔ | ❌ | ❌ |
-| Département | Haute-Loire | 43 | ❔ | ❌ | ❌ |
-| CC | CC des Rives du Haut Allier | 200073393 | ❔ | ❌ | ❌ |
-| CC | CC Mézenc-Loire-Meygal | 200073401 | ❔ | ❌ | ❌ |
-| CA | CA du Puy-en-Velay | 200073419 | ❔ | ❌ | ❌ |
-| CC | CC Marches du Velay-Rochebaron | 200073427 | ❔ | ❌ | ❌ |
-| CC | CC Brioude Sud Auvergne | 200085728 | ❔ | ❌ | ❌ |
-| CC | CC Haut Pays du Velay | 244300307 | ❔ | ❌ | ❌ |
-| CC | CC des Sucs | 244301016 | ❔ | ❌ | ❌ |
-| CC | CC Auzon Communauté | 244301099 | ❔ | ❌ | ❌ |
-| CC | CC du Haut Lignon | 244301107 | ❔ | ❌ | ❌ |
-| CC | CC des Pays de Cayres et de Pradelles | 244301123 | ❔ | ❌ | ❌ |
-| CC | CC Loire et Semène | 244301131 | ❔ | ❌ | ❌ |
-| Département | Puy-de-Dôme | 63 | ❔ | ❌ | ❌ |
-| CC | CC Billom Communauté | 200067627 | ❔ | ❌ | ❌ |
-| CC | CC Dômes Sancy Artense | 200069169 | ❔ | ❌ | ❌ |
-| CC | CC Mond'Arverne Communauté | 200069177 | ❔ | ❌ | ❌ |
-| CA | CA Agglo Pays d'Issoire | 200070407 | ❔ | ❌ | ❌ |
-| CC | CC Thiers Dore et Montagne | 200070712 | ❔ | ❌ | ❌ |
-| CA | CA Riom Limagne et Volcans | 200070753 | ❔ | ❌ | ❌ |
-| CC | CC Ambert Livradois Forez | 200070761 | ❔ | ❌ | ❌ |
-| CC | CC Plaine Limagne | 200071199 | ❔ | ❌ | ❌ |
-| CC | CC Chavanon Combrailles et Volcans | 200071215 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Saint-Eloy | 200072080 | ❔ | ❌ | ❌ |
-| CC | CC Combrailles Sioule et Morge | 200072098 | ❔ | ❌ | ❌ |
-| METRO | Clermont Auvergne Métropole | 246300701 | ❔ | ❌ | ❌ |
-| CC | CC du Massif du Sancy | 246300966 | ❔ | ❌ | ❌ |
-| CC | CC Entre Dore et Allier | 246301097 | ❔ | ❌ | ❌ |
-| Département | Rhône | 69 | ❔ | ❌ | ❌ |
-| CA | CA de l'Ouest Rhodanien | 200040566 | ❔ | ❌ | ❌ |
-| CC | CC Beaujolais Pierres Dorées | 200040574 | ❔ | ❌ | ❌ |
-| CA | CA Villefranche Beaujolais Saône | 200040590 | ✅ | ✅ | ❌ |
-| MET69 | Métropole de Lyon | 200046977 | ✅ | ✅ | ❌ |
-| CC | CC des Monts du Lyonnais | 200066587 | ❔ | ❌ | ❌ |
-| CC | CC Saône-Beaujolais | 200067817 | ✅ | ✅ | ❌ |
-| CA | CA Vienne Condrieu | 200077014 | ✅ | ✅ | ❌ |
-| CC | CC de l'Est Lyonnais (CCEL) | 246900575 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de l'Arbresle (CCPA) | 246900625 | ❔ | ❌ | ❌ |
-| CC | CC des Vallons du Lyonnais (CCVL) | 246900724 | ✅ | ✅ | ❌ |
-| CC | CC du Pays Mornantais (COPAMO) | 246900740 | ✅ | ✅ | ❌ |
-| CC | CC de la Vallée du Garon (CCVG) | 246900757 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de l'Ozon | 246900765 | ✅ | ✅ | ❌ |
-| Département | Savoie | 73 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Tarentaise | 200023299 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Chartreuse | 200040111 | ❔ | ❌ | ❌ |
-| CC | CC Val Vanoise | 200040798 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Savoie | 200041010 | ✅ | ✅ | ❌ |
-| CA | CA Grand Lac | 200068674 | ❔ | ❌ | ❌ |
-| CA | CA Arlysère | 200068997 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Chambéry | 200069110 | ❔ | ❌ | ❌ |
-| CC | CC Haute Maurienne Vanoise | 200070340 | ❔ | ❌ | ❌ |
-| CC | CC Coeur de Maurienne Arvan | 200070464 | ✅ | ✅ | ❌ |
-| CC | CC des Vallées d'Aigueblanche | 247300015 | ❔ | ❌ | ❌ |
-| CC | CC de Haute-Tarentaise | 247300254 | ❔ | ❌ | ❌ |
-| CC | CC de Yenne | 247300262 | ❔ | ❌ | ❌ |
-| CC | CC du Canton de La Chambre | 247300361 | ❔ | ❌ | ❌ |
-| CC | CC Maurienne Galibier | 247300452 | ❔ | ❌ | ❌ |
-| CC | CC Val Guiers | 247300528 | ❔ | ❌ | ❌ |
-| CC | CC du Lac d'Aiguebelette (CCLA) | 247300668 | ❔ | ❌ | ❌ |
-| CC | CC Porte de Maurienne | 247300676 | ❔ | ❌ | ❌ |
-| CC | CC Les Versants d'Aime | 247300817 | ❔ | ❌ | ❌ |
-| Département | Haute-Savoie | 74 | ❔ | ❌ | ❌ |
-| CC | CC Faucigny - Glières | 200000172 | ❔ | ❌ | ❌ |
-| CA | CA Annemasse-Les Voirons-Agglomération | 200011773 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée de Chamonix-Mont-Blanc | 200023372 | ❔ | ❌ | ❌ |
-| CC | CC Cluses-Arve et Montagnes | 200033116 | ✅ | ✅ | ❌ |
-| CC | CC des Montagnes du Giffre | 200034098 | ❔ | ❌ | ❌ |
-| CC | CC Pays du Mont-Blanc | 200034882 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Annecy | 200066793 | ❔ | ❌ | ❌ |
-| CA | CA Thonon Agglomération | 200067551 | ❔ | ❌ | ❌ |
-| CC | CC Usses et Rhône | 200070852 | ❔ | ❌ | ❌ |
-| CC | CC Pays d'Evian Vallée d'Abondance | 200071967 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée Verte | 247400047 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Cruseilles | 247400112 | ✅ | ✅ | ❌ |
-| CC | CC Fier et Usses | 247400567 | ✅ | ✅ | ❌ |
-| CC | CC Arve et Salève | 247400583 | ❔ | ❌ | ❌ |
-| CC | CC des Vallées de Thônes | 247400617 | ❔ | ❌ | ❌ |
-| CC | CC des Quatre Rivières | 247400666 | ❔ | ❌ | ❌ |
-| CC | CC du Haut Chablais | 247400682 | ❔ | ❌ | ❌ |
-| CC | CC du Genevois | 247400690 | ✅ | ✅ | ❌ |
-| CC | CC du Pays Rochois | 247400724 | ❔ | ❌ | ❌ |
-| CC | CC Rumilly Terre de Savoie | 247400740 | ❔ | ❌ | ❌ |
-| CC | CC des Sources du Lac d'Annecy | 247400773 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                                  | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ---------------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Auvergne-Rhône-Alpes                                 | 84        | ❔               | ❌        | ❌    |
+| Département | Ain                                                  | 01        | ❔               | ❌        | ❌    |
+| CC          | CC Rives de l'Ain - Pays du Cerdon                   | 200029999 | ❔               | ❌        | ❌    |
+| CC          | CC Bugey Sud                                         | 200040350 | ❔               | ❌        | ❌    |
+| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ❌    |
+| CC          | CC Dombes Saône Vallée                               | 200042497 | ❔               | ❌        | ❌    |
+| CA          | CA Haut-Bugey Agglomération                          | 200042935 | ❔               | ❌        | ❌    |
+| CC          | CC de la Dombes                                      | 200069193 | ❔               | ❌        | ❌    |
+| CC          | CC Val de Saône Centre                               | 200070118 | ✅               | ✅        | ✅    |
+| CA          | CA Mâconnais Beaujolais Agglomération                | 200070308 | ❔               | ❌        | ❌    |
+| CC          | CC de la Veyle                                       | 200070555 | ❔               | ❌        | ❌    |
+| CC          | CC Usses et Rhône                                    | 200070852 | ❔               | ❌        | ❌    |
+| CC          | CC Bresse et Saône                                   | 200071371 | ❔               | ❌        | ❌    |
+| CA          | CA du Bassin de Bourg-en-Bresse                      | 200071751 | ❔               | ❌        | ❌    |
+| CC          | CC de la Côtière à Montluel                          | 240100610 | ✅               | ✅        | ❌    |
+| CA          | CA du Pays de Gex                                    | 240100750 | ❔               | ❌        | ❌    |
+| CC          | CC de Miribel et du Plateau                          | 240100800 | ❔               | ❌        | ❌    |
+| CC          | CC de la Plaine de l'Ain                             | 240100883 | ✅               | ✅        | ❌    |
+| CC          | CC Terre Valserhône (CCTV)                           | 240100891 | ❔               | ❌        | ❌    |
+| Département | Allier                                               | 03        | ❔               | ❌        | ❌    |
+| CA          | CA Montluçon Communauté                              | 200071082 | ✅               | ✅        | ❌    |
+| CA          | CA Moulins Communauté                                | 200071140 | ❔               | ❌        | ❌    |
+| CA          | CA Vichy Communauté                                  | 200071363 | ❔               | ❌        | ❌    |
+| CC          | CC Saint-Pourçain Sioule Limagne                     | 200071389 | ❔               | ❌        | ❌    |
+| CC          | CC Entr'Allier Besbre et Loire                       | 200071470 | ❔               | ❌        | ❌    |
+| CC          | CC du Bocage Bourbonnais                             | 200071496 | ❔               | ❌        | ❌    |
+| CC          | CC Commentry Montmarault Néris Communauté            | 200071512 | ❔               | ❌        | ❌    |
+| CC          | CC Le Grand Charolais                                | 200071884 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Lapalisse                              | 240300491 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Tronçais                               | 240300558 | ❔               | ❌        | ❌    |
+| CC          | CC du Val de Cher                                    | 240300566 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Huriel                                  | 240300657 | ❔               | ❌        | ❌    |
+| Département | Ardèche                                              | 07        | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de Lamastre                               | 200016905 | ❔               | ❌        | ❌    |
+| CC          | CC de Cèze Cévennes                                  | 200035129 | ❔               | ❌        | ❌    |
+| CC          | CC des Gorges de l'Ardèche                           | 200039808 | ❔               | ❌        | ❌    |
+| CC          | CC Ardèche des Sources et Volcans                    | 200039824 | ❔               | ❌        | ❌    |
+| CC          | CC Pays des Vans en Cévennes                         | 200039832 | ❔               | ❌        | ❌    |
+| CC          | CC Porte de Dromardèche                              | 200040491 | ❔               | ❌        | ❌    |
+| CC          | CC Rhône Crussol                                     | 200041366 | ❔               | ❌        | ❌    |
+| CC          | CC Val Eyrieux                                       | 200041465 | ❔               | ❌        | ❌    |
+| CC          | CC Ardèche Rhône Coiron                              | 200071405 | ❔               | ❌        | ❌    |
+| CA          | CA Privas Centre Ardèche                             | 200071413 | ❔               | ❌        | ❌    |
+| CC          | CC Montagne d'Ardèche                                | 200072007 | ❔               | ❌        | ❌    |
+| CA          | CA Annonay Rhône Agglo                               | 200072015 | ✅               | ✅        | ❌    |
+| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ❌    |
+| CC          | CC du Bassin d'Aubenas                               | 200073245 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Beaume-Drobie                             | 240700302 | ❔               | ❌        | ❌    |
+| CC          | CC Val de Ligne                                      | 240700617 | ❔               | ❌        | ❌    |
+| CC          | CC du Val d'Ay                                       | 240700716 | ❔               | ❌        | ❌    |
+| CC          | CC Berg et Coiron                                    | 240700815 | ❔               | ❌        | ❌    |
+| CC          | CC du Rhône aux Gorges de l'Ardèche                  | 240700864 | ❔               | ❌        | ❌    |
+| Département | Cantal                                               | 15        | ❔               | ❌        | ❌    |
+| CC          | CC Hautes Terres                                     | 200066637 | ❔               | ❌        | ❌    |
+| CC          | CC de Saint-Flour                                    | 200066660 | ❔               | ❌        | ❌    |
+| CC          | CC de la Châtaigneraie Cantalienne                   | 200066678 | ❔               | ❌        | ❌    |
+| CA          | CA du Bassin d'Aurillac                              | 241500230 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays Gentiane                                  | 241500255 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Mauriac                                | 241500271 | ❔               | ❌        | ❌    |
+| CC          | CC Sumène - Artense                                  | 241501055 | ❔               | ❌        | ❌    |
+| CC          | CC Cère et Goul en Carladès                          | 241501089 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Salers                                 | 241501139 | ❔               | ❌        | ❌    |
+| CC          | CC du Massif du Sancy                                | 246300966 | ❔               | ❌        | ❌    |
+| Département | Drôme                                                | 26        | ❔               | ❌        | ❌    |
+| CC          | CC Ventoux Sud                                       | 200035723 | ❔               | ❌        | ❌    |
+| CA          | CA Montélimar Agglomération                          | 200040459 | ❔               | ❌        | ❌    |
+| CC          | CC Porte de Dromardèche                              | 200040491 | ❔               | ❌        | ❌    |
+| CC          | CC du Crestois et de Pays de Saillans Coeur de Drôme | 200040509 | ✅               | ✅        | ❌    |
+| CC          | CC Enclave des Papes - Pays de Grignan               | 200040681 | ❔               | ❌        | ❌    |
+| CC          | CC Drôme Sud Provence                                | 200042901 | ❔               | ❌        | ❌    |
+| CC          | CC du Royans-Vercors                                 | 200067767 | ❔               | ❌        | ❌    |
+| CC          | CC des Baronnies en Drôme Provençale                 | 200068229 | ❔               | ❌        | ❌    |
+| CC          | CC du Sisteronais-Buëch                              | 200068765 | ❔               | ❌        | ❌    |
+| CA          | CA Valence Romans Agglo                              | 200068781 | ❔               | ❌        | ❌    |
+| CC          | CC Jabron-Lure-Vançon-Durance                        | 200071033 | ❔               | ❌        | ❌    |
+| CA          | CA Arche Agglo                                       | 200073096 | ✅               | ✅        | ❌    |
+| CC          | CC du Val de Drôme en Biovallée                      | 242600252 | ✅               | ✅        | ❌    |
+| CC          | CC Dieulefit-Bourdeaux                               | 242600492 | ✅               | ✅        | ❌    |
+| CC          | CC du Diois                                          | 242600534 | ❔               | ❌        | ❌    |
+| CC          | CC Vaison Ventoux                                    | 248400335 | ❔               | ❌        | ❌    |
+| Département | Isère                                                | 38        | ❔               | ❌        | ❌    |
+| CC          | CC Le Grésivaudan                                    | 200018166 | ❔               | ❌        | ❌    |
+| CC          | CC du Trièves                                        | 200030658 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Chartreuse                               | 200040111 | ❔               | ❌        | ❌    |
+| CC          | CC de la Matheysine                                  | 200040657 | ❔               | ❌        | ❌    |
+| METRO       | Grenoble-Alpes-Métropole                             | 200040715 | ✅               | ✅        | ❌    |
+| CC          | CC Bièvre Isère                                      | 200059392 | ✅               | ✅        | ❌    |
+| CC          | CC Les Balcons du Dauphiné                           | 200068542 | ❔               | ❌        | ❌    |
+| CC          | CC Les Vals du Dauphiné                              | 200068567 | ❔               | ❌        | ❌    |
+| CC          | CC Saint-Marcellin Vercors Isère Communauté          | 200070431 | ✅               | ✅        | ❌    |
+| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ❌    |
+| CC          | CC Entre Bièvre et Rhône                             | 200085751 | ❔               | ❌        | ❌    |
+| CA          | CA Porte de l'Isère (CAPI)                           | 243800604 | ❔               | ❌        | ❌    |
+| CC          | CC de l'Oisans                                       | 243800745 | ❔               | ❌        | ❌    |
+| CC          | CC Lyon-Saint-Exupéry en Dauphiné                    | 243800935 | ✅               | ✅        | ❌    |
+| CA          | CA du Pays Voironnais                                | 243800984 | ❔               | ❌        | ❌    |
+| CC          | CC du Massif du Vercors                              | 243801024 | ✅               | ✅        | ❌    |
+| CC          | CC de Bièvre Est                                     | 243801073 | ❔               | ❌        | ❌    |
+| CC          | CC Collines Isère Nord Communauté                    | 243801255 | ❔               | ❌        | ❌    |
+| Département | Loire                                                | 42        | ❔               | ❌        | ❌    |
+| CC          | CC Charlieu-Belmont                                  | 200035202 | ✅               | ✅        | ❌    |
+| CA          | CA Roannais Agglomération                            | 200035731 | ❔               | ❌        | ❌    |
+| CA          | CA Loire Forez Agglomération (LFA)                   | 200065886 | ❔               | ❌        | ❌    |
+| CC          | CC de Forez-Est                                      | 200065894 | ❔               | ❌        | ❌    |
+| CC          | CC des Monts du Lyonnais                             | 200066587 | ❔               | ❌        | ❌    |
+| CC          | CC des Vals d'Aix et Isable                          | 244200614 | ❔               | ❌        | ❌    |
+| CC          | CC des Monts du Pilat                                | 244200622 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Entre Loire et Rhône                      | 244200630 | ❔               | ❌        | ❌    |
+| METRO       | Saint-Étienne Métropole                              | 244200770 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays d'Urfé                                    | 244200820 | ❔               | ❌        | ❌    |
+| CC          | CC du Pilat Rhodanien                                | 244200895 | ❔               | ❌        | ❌    |
+| Département | Haute-Loire                                          | 43        | ❔               | ❌        | ❌    |
+| CC          | CC des Rives du Haut Allier                          | 200073393 | ❔               | ❌        | ❌    |
+| CC          | CC Mézenc-Loire-Meygal                               | 200073401 | ❔               | ❌        | ❌    |
+| CA          | CA du Puy-en-Velay                                   | 200073419 | ❔               | ❌        | ❌    |
+| CC          | CC Marches du Velay-Rochebaron                       | 200073427 | ❔               | ❌        | ❌    |
+| CC          | CC Brioude Sud Auvergne                              | 200085728 | ❔               | ❌        | ❌    |
+| CC          | CC Haut Pays du Velay                                | 244300307 | ❔               | ❌        | ❌    |
+| CC          | CC des Sucs                                          | 244301016 | ❔               | ❌        | ❌    |
+| CC          | CC Auzon Communauté                                  | 244301099 | ❔               | ❌        | ❌    |
+| CC          | CC du Haut Lignon                                    | 244301107 | ❔               | ❌        | ❌    |
+| CC          | CC des Pays de Cayres et de Pradelles                | 244301123 | ❔               | ❌        | ❌    |
+| CC          | CC Loire et Semène                                   | 244301131 | ❔               | ❌        | ❌    |
+| Département | Puy-de-Dôme                                          | 63        | ❔               | ❌        | ❌    |
+| CC          | CC Billom Communauté                                 | 200067627 | ❔               | ❌        | ❌    |
+| CC          | CC Dômes Sancy Artense                               | 200069169 | ❔               | ❌        | ❌    |
+| CC          | CC Mond'Arverne Communauté                           | 200069177 | ❔               | ❌        | ❌    |
+| CA          | CA Agglo Pays d'Issoire                              | 200070407 | ❔               | ❌        | ❌    |
+| CC          | CC Thiers Dore et Montagne                           | 200070712 | ❔               | ❌        | ❌    |
+| CA          | CA Riom Limagne et Volcans                           | 200070753 | ❔               | ❌        | ❌    |
+| CC          | CC Ambert Livradois Forez                            | 200070761 | ❔               | ❌        | ❌    |
+| CC          | CC Plaine Limagne                                    | 200071199 | ❔               | ❌        | ❌    |
+| CC          | CC Chavanon Combrailles et Volcans                   | 200071215 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Saint-Eloy                             | 200072080 | ❔               | ❌        | ❌    |
+| CC          | CC Combrailles Sioule et Morge                       | 200072098 | ❔               | ❌        | ❌    |
+| METRO       | Clermont Auvergne Métropole                          | 246300701 | ❔               | ❌        | ❌    |
+| CC          | CC du Massif du Sancy                                | 246300966 | ❔               | ❌        | ❌    |
+| CC          | CC Entre Dore et Allier                              | 246301097 | ❔               | ❌        | ❌    |
+| Département | Rhône                                                | 69        | ❔               | ❌        | ❌    |
+| CA          | CA de l'Ouest Rhodanien                              | 200040566 | ❔               | ❌        | ❌    |
+| CC          | CC Beaujolais Pierres Dorées                         | 200040574 | ❔               | ❌        | ❌    |
+| CA          | CA Villefranche Beaujolais Saône                     | 200040590 | ✅               | ✅        | ❌    |
+| MET69       | Métropole de Lyon                                    | 200046977 | ✅               | ✅        | ❌    |
+| CC          | CC des Monts du Lyonnais                             | 200066587 | ❔               | ❌        | ❌    |
+| CC          | CC Saône-Beaujolais                                  | 200067817 | ✅               | ✅        | ❌    |
+| CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ❌    |
+| CC          | CC de l'Est Lyonnais (CCEL)                          | 246900575 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de l'Arbresle (CCPA)                      | 246900625 | ❔               | ❌        | ❌    |
+| CC          | CC des Vallons du Lyonnais (CCVL)                    | 246900724 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays Mornantais (COPAMO)                       | 246900740 | ✅               | ✅        | ❌    |
+| CC          | CC de la Vallée du Garon (CCVG)                      | 246900757 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de l'Ozon                                 | 246900765 | ✅               | ✅        | ❌    |
+| Département | Savoie                                               | 73        | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Tarentaise                               | 200023299 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Chartreuse                               | 200040111 | ❔               | ❌        | ❌    |
+| CC          | CC Val Vanoise                                       | 200040798 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Savoie                                   | 200041010 | ✅               | ✅        | ❌    |
+| CA          | CA Grand Lac                                         | 200068674 | ❔               | ❌        | ❌    |
+| CA          | CA Arlysère                                          | 200068997 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Chambéry                                 | 200069110 | ❔               | ❌        | ❌    |
+| CC          | CC Haute Maurienne Vanoise                           | 200070340 | ❔               | ❌        | ❌    |
+| CC          | CC Coeur de Maurienne Arvan                          | 200070464 | ✅               | ✅        | ❌    |
+| CC          | CC des Vallées d'Aigueblanche                        | 247300015 | ❔               | ❌        | ❌    |
+| CC          | CC de Haute-Tarentaise                               | 247300254 | ❔               | ❌        | ❌    |
+| CC          | CC de Yenne                                          | 247300262 | ❔               | ❌        | ❌    |
+| CC          | CC du Canton de La Chambre                           | 247300361 | ❔               | ❌        | ❌    |
+| CC          | CC Maurienne Galibier                                | 247300452 | ❔               | ❌        | ❌    |
+| CC          | CC Val Guiers                                        | 247300528 | ❔               | ❌        | ❌    |
+| CC          | CC du Lac d'Aiguebelette (CCLA)                      | 247300668 | ❔               | ❌        | ❌    |
+| CC          | CC Porte de Maurienne                                | 247300676 | ❔               | ❌        | ❌    |
+| CC          | CC Les Versants d'Aime                               | 247300817 | ❔               | ❌        | ❌    |
+| Département | Haute-Savoie                                         | 74        | ❔               | ❌        | ❌    |
+| CC          | CC Faucigny - Glières                                | 200000172 | ❔               | ❌        | ❌    |
+| CA          | CA Annemasse-Les Voirons-Agglomération               | 200011773 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée de Chamonix-Mont-Blanc               | 200023372 | ❔               | ❌        | ❌    |
+| CC          | CC Cluses-Arve et Montagnes                          | 200033116 | ✅               | ✅        | ❌    |
+| CC          | CC des Montagnes du Giffre                           | 200034098 | ❔               | ❌        | ❌    |
+| CC          | CC Pays du Mont-Blanc                                | 200034882 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Annecy                                   | 200066793 | ❔               | ❌        | ❌    |
+| CA          | CA Thonon Agglomération                              | 200067551 | ❔               | ❌        | ❌    |
+| CC          | CC Usses et Rhône                                    | 200070852 | ❔               | ❌        | ❌    |
+| CC          | CC Pays d'Evian Vallée d'Abondance                   | 200071967 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée Verte                                | 247400047 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Cruseilles                             | 247400112 | ✅               | ✅        | ❌    |
+| CC          | CC Fier et Usses                                     | 247400567 | ✅               | ✅        | ❌    |
+| CC          | CC Arve et Salève                                    | 247400583 | ❔               | ❌        | ❌    |
+| CC          | CC des Vallées de Thônes                             | 247400617 | ❔               | ❌        | ❌    |
+| CC          | CC des Quatre Rivières                               | 247400666 | ❔               | ❌        | ❌    |
+| CC          | CC du Haut Chablais                                  | 247400682 | ❔               | ❌        | ❌    |
+| CC          | CC du Genevois                                       | 247400690 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays Rochois                                   | 247400724 | ❔               | ❌        | ❌    |
+| CC          | CC Rumilly Terre de Savoie                           | 247400740 | ❔               | ❌        | ❌    |
+| CC          | CC des Sources du Lac d'Annecy                       | 247400773 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -149,21 +149,21 @@
 | CC          | CC Saône-Beaujolais                                  | 200067817 | ✅               | ✅        | ✅    |
 | CA          | CA Vienne Condrieu                                   | 200077014 | ✅               | ✅        | ✅    |
 | CC          | CC de l'Est Lyonnais (CCEL)                          | 246900575 | ❌               | ❌        | ✅    |
-| CC          | CC du Pays de l'Arbresle (CCPA)                      | 246900625 | ❔               | ❌        | ❌    |
-| CC          | CC des Vallons du Lyonnais (CCVL)                    | 246900724 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays de l'Arbresle (CCPA)                      | 246900625 | ✅               | ✅        | ✅    |
+| CC          | CC des Vallons du Lyonnais (CCVL)                    | 246900724 | ✅               | ✅        | ✅    |
 | CC          | CC du Pays Mornantais (COPAMO)                       | 246900740 | ✅               | ✅        | ❌    |
-| CC          | CC de la Vallée du Garon (CCVG)                      | 246900757 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de l'Ozon                                 | 246900765 | ✅               | ✅        | ❌    |
+| CC          | CC de la Vallée du Garon (CCVG)                      | 246900757 | ❌               | ❌        | ✅    |
+| CC          | CC du Pays de l'Ozon                                 | 246900765 | ✅               | ✅        | ✅    |
 | Département | Savoie                                               | 73        | ❔               | ❌        | ❌    |
 | CC          | CC Coeur de Tarentaise                               | 200023299 | ❔               | ❌        | ❌    |
 | CC          | CC Coeur de Chartreuse                               | 200040111 | ❔               | ❌        | ❌    |
 | CC          | CC Val Vanoise                                       | 200040798 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Savoie                                   | 200041010 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur de Savoie                                   | 200041010 | ✅               | ✅        | ✅    |
 | CA          | CA Grand Lac                                         | 200068674 | ❔               | ❌        | ❌    |
 | CA          | CA Arlysère                                          | 200068997 | ❔               | ❌        | ❌    |
 | CA          | CA du Grand Chambéry                                 | 200069110 | ✅               | ✅        | ✅    |
 | CC          | CC Haute Maurienne Vanoise                           | 200070340 | ❔               | ❌        | ❌    |
-| CC          | CC Coeur de Maurienne Arvan                          | 200070464 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur de Maurienne Arvan                          | 200070464 | ✅               | ✅        | ✅    |
 | CC          | CC des Vallées d'Aigueblanche                        | 247300015 | ❔               | ❌        | ❌    |
 | CC          | CC de Haute-Tarentaise                               | 247300254 | ❔               | ❌        | ❌    |
 | CC          | CC de Yenne                                          | 247300262 | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -101,30 +101,30 @@
 | CC          | CC du Massif du Vercors                              | 243801024 | ✅               | ✅        | ✅    |
 | CC          | CC de Bièvre Est                                     | 243801073 | ❌               | ❌        | 🤖    |
 | CC          | CC Collines Isère Nord Communauté                    | 243801255 | ❌               | ❌        | 🤖    |
-| Département | Loire                                                | 42        | ❌               | ❌        | 🤖    |
-| CC          | CC Charlieu-Belmont                                  | 200035202 | ✅               | ✅        | ❌    |
-| CA          | CA Roannais Agglomération                            | 200035731 | ❔               | ❌        | ❌    |
-| CA          | CA Loire Forez Agglomération (LFA)                   | 200065886 | ❔               | ❌        | ❌    |
-| CC          | CC de Forez-Est                                      | 200065894 | ❔               | ❌        | ❌    |
-| CC          | CC des Monts du Lyonnais                             | 200066587 | ❔               | ❌        | ❌    |
-| CC          | CC des Vals d'Aix et Isable                          | 244200614 | ❔               | ❌        | ❌    |
+| Département | Loire                                                | 42        | ✅               | ❌        | 🤖    |
+| CC          | CC Charlieu-Belmont                                  | 200035202 | ✅               | ✅        | ✅    |
+| CA          | CA Roannais Agglomération                            | 200035731 | ❌               | ❌        | ✅    |
+| CA          | CA Loire Forez Agglomération (LFA)                   | 200065886 | ❌               | ❌        | ✅    |
+| CC          | CC de Forez-Est                                      | 200065894 | ❌               | ❌        | ✅    |
+| CC          | CC des Monts du Lyonnais                             | 200066587 | ❌               | ❌        | ✅    |
+| CC          | CC des Vals d'Aix et Isable                          | 244200614 | ❌               | ❌        | ✅    |
 | CC          | CC des Monts du Pilat                                | 244200622 | ✅               | ✅        | ✅    |
-| CC          | CC du Pays Entre Loire et Rhône                      | 244200630 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays Entre Loire et Rhône                      | 244200630 | ❌               | ❌        | ✅    |
 | METRO       | Saint-Étienne Métropole                              | 244200770 | ✅               | ✅        | ✅    |
-| CC          | CC du Pays d'Urfé                                    | 244200820 | ❔               | ❌        | ❌    |
-| CC          | CC du Pilat Rhodanien                                | 244200895 | ❔               | ❌        | ❌    |
-| Département | Haute-Loire                                          | 43        | ❔               | ❌        | ❌    |
-| CC          | CC des Rives du Haut Allier                          | 200073393 | ❔               | ❌        | ❌    |
-| CC          | CC Mézenc-Loire-Meygal                               | 200073401 | ❔               | ❌        | ❌    |
-| CA          | CA du Puy-en-Velay                                   | 200073419 | ❔               | ❌        | ❌    |
-| CC          | CC Marches du Velay-Rochebaron                       | 200073427 | ❔               | ❌        | ❌    |
-| CC          | CC Brioude Sud Auvergne                              | 200085728 | ❔               | ❌        | ❌    |
-| CC          | CC Haut Pays du Velay                                | 244300307 | ❔               | ❌        | ❌    |
-| CC          | CC des Sucs                                          | 244301016 | ❔               | ❌        | ❌    |
-| CC          | CC Auzon Communauté                                  | 244301099 | ❔               | ❌        | ❌    |
-| CC          | CC du Haut Lignon                                    | 244301107 | ❔               | ❌        | ❌    |
-| CC          | CC des Pays de Cayres et de Pradelles                | 244301123 | ❔               | ❌        | ❌    |
-| CC          | CC Loire et Semène                                   | 244301131 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays d'Urfé                                    | 244200820 | ❌               | ❌        | ✅    |
+| CC          | CC du Pilat Rhodanien                                | 244200895 | ❌               | ❌        | ✅    |
+| Département | Haute-Loire                                          | 43        | ❌               | ❌        | 🤖    |
+| CC          | CC des Rives du Haut Allier                          | 200073393 | ❌               | ❌        | 🤖    |
+| CC          | CC Mézenc-Loire-Meygal                               | 200073401 | ❌               | ❌        | 🤖    |
+| CA          | CA du Puy-en-Velay                                   | 200073419 | ❌               | ❌        | 🤖    |
+| CC          | CC Marches du Velay-Rochebaron                       | 200073427 | ❌               | ❌        | 🤖    |
+| CC          | CC Brioude Sud Auvergne                              | 200085728 | ❌               | ❌        | 🤖    |
+| CC          | CC Haut Pays du Velay                                | 244300307 | ❌               | ❌        | 🤖    |
+| CC          | CC des Sucs                                          | 244301016 | ❌               | ❌        | 🤖    |
+| CC          | CC Auzon Communauté                                  | 244301099 | ❌               | ❌        | 🤖    |
+| CC          | CC du Haut Lignon                                    | 244301107 | ❌               | ❌        | 🤖    |
+| CC          | CC des Pays de Cayres et de Pradelles                | 244301123 | ❌               | ❌        | 🤖    |
+| CC          | CC Loire et Semène                                   | 244301131 | ❌               | ❌        | 🤖    |
 | Département | Puy-de-Dôme                                          | 63        | ❔               | ❌        | ❌    |
 | CC          | CC Billom Communauté                                 | 200067627 | ❔               | ❌        | ❌    |
 | CC          | CC Dômes Sancy Artense                               | 200069169 | ❔               | ❌        | ❌    |
@@ -137,7 +137,7 @@
 | CC          | CC Chavanon Combrailles et Volcans                   | 200071215 | ❔               | ❌        | ❌    |
 | CC          | CC du Pays de Saint-Eloy                             | 200072080 | ❔               | ❌        | ❌    |
 | CC          | CC Combrailles Sioule et Morge                       | 200072098 | ❔               | ❌        | ❌    |
-| METRO       | Clermont Auvergne Métropole                          | 246300701 | ❔               | ❌        | ❌    |
+| METRO       | Clermont Auvergne Métropole                          | 246300701 | ❌               | ❌        | ✅    |
 | CC          | CC du Massif du Sancy                                | 246300966 | ❔               | ❌        | ❌    |
 | CC          | CC Entre Dore et Allier                              | 246301097 | ❔               | ❌        | ❌    |
 | Département | Rhône                                                | 69        | ❔               | ❌        | ❌    |

--- a/couverture/84_Auvergne-Rhône-Alpes.md
+++ b/couverture/84_Auvergne-Rhône-Alpes.md
@@ -191,7 +191,7 @@
 | CC          | CC des Vallées de Thônes                             | 247400617 | ❔               | ❌        | ❌    |
 | CC          | CC des Quatre Rivières                               | 247400666 | ❔               | ❌        | ❌    |
 | CC          | CC du Haut Chablais                                  | 247400682 | ❔               | ❌        | ❌    |
-| CC          | CC du Genevois                                       | 247400690 | ✅               | ✅        | ❌    |
+| CC          | CC du Genevois                                       | 247400690 | ✅               | ✅        | ✅    |
 | CC          | CC du Pays Rochois                                   | 247400724 | ❔               | ❌        | ❌    |
 | CC          | CC Rumilly Terre de Savoie                           | 247400740 | ❔               | ❌        | ❌    |
 | CC          | CC des Sources du Lac d'Annecy                       | 247400773 | ❔               | ❌        | ❌    |

--- a/couverture/93_Provence-Alpes-Côte_d-Azur.md
+++ b/couverture/93_Provence-Alpes-Côte_d-Azur.md
@@ -1,5 +1,7 @@
 # Couverture des aides en Provence-Alpes-Côte d'Azur (93)
 
+- 2025 : ✅
+
 | Echelle     | Nom                                             | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ----------------------------------------------- | --------- | ---------------- | --------- | ----- |
 | Région      | Provence-Alpes-Côte d'Azur                      | 93        | ❌               | ❌        | ✅    |

--- a/couverture/93_Provence-Alpes-Côte_d-Azur.md
+++ b/couverture/93_Provence-Alpes-Côte_d-Azur.md
@@ -1,0 +1,72 @@
+# Couverture des aides en Provence-Alpes-Côte d'Azur (93)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Provence-Alpes-Côte d'Azur | 93 | ❔ | ❌ | ❌ |
+| Département | Alpes-de-Haute-Provence | 04 | ❔ | ❌ | ❌ |
+| CA | CA Durance-Lubéron-Verdon Agglomération | 200034700 | ✅ | ✅ | ❌ |
+| CC | CC Pays d'Apt-Luberon | 200040624 | ❔ | ❌ | ❌ |
+| CC | CC Serre-Ponçon Val d'Avance | 200067320 | ❔ | ❌ | ❌ |
+| CA | CA Provence-Alpes-Agglomération | 200067437 | ❔ | ❌ | ❌ |
+| CC | CC Serre-Ponçon | 200067742 | ❔ | ❌ | ❌ |
+| CA | CA Gap-Tallard-Durance | 200067825 | ❔ | ❌ | ❌ |
+| CC | CC Alpes-Provence-Verdon "Sources de lumière" | 200068625 | ❔ | ❌ | ❌ |
+| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
+| CC | CC Haute-Provence - Pays de Banon | 200071025 | ❔ | ❌ | ❌ |
+| CC | CC Jabron-Lure-Vançon-Durance | 200071033 | ❔ | ❌ | ❌ |
+| CC | CC Vallée de l'Ubaye - Serre-Ponçon | 200072304 | ❔ | ❌ | ❌ |
+| CC | CC Pays Forcalquier et Montagne de Lure | 240400440 | ❔ | ❌ | ❌ |
+| Département | Hautes-Alpes | 05 | ❔ | ❌ | ❌ |
+| CC | CC Serre-Ponçon Val d'Avance | 200067320 | ❔ | ❌ | ❌ |
+| CC | CC Buëch-Dévoluy | 200067445 | ❔ | ❌ | ❌ |
+| CC | CC du Guillestrois et du Queyras | 200067452 | ❔ | ❌ | ❌ |
+| CC | CC Serre-Ponçon | 200067742 | ❔ | ❌ | ❌ |
+| CA | CA Gap-Tallard-Durance | 200067825 | ❔ | ❌ | ❌ |
+| CC | CC Champsaur-Valgaudemar | 200068096 | ❔ | ❌ | ❌ |
+| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
+| CC | CC du Briançonnais | 240500439 | ❔ | ❌ | ❌ |
+| CC | CC du Pays des Ecrins | 240500462 | ❔ | ❌ | ❌ |
+| Département | Alpes-Maritimes | 06 | ❔ | ❌ | ❌ |
+| METRO | Métropole Nice Côte d'Azur | 200030195 | ❔ | ❌ | ❌ |
+| CA | CA du Pays de Grasse | 200039857 | ❔ | ❌ | ❌ |
+| CA | CA Cannes Pays de Lérins | 200039915 | ❔ | ❌ | ❌ |
+| CC | CC Alpes d'Azur | 200039931 | ❔ | ❌ | ❌ |
+| CA | CA de la Riviera Française | 240600551 | ✅ | ✅ | ❌ |
+| CA | CA de Sophia Antipolis | 240600585 | ✅ | ✅ | ❌ |
+| CC | CC du Pays des Paillons | 240600593 | ❔ | ❌ | ❌ |
+| Département | Bouches-du-Rhône | 13 | ❔ | ❌ | ❌ |
+| CA | CA Terre de Provence | 200035087 | ❔ | ❌ | ❌ |
+| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
+| CC | CC Vallée des Baux-Alpilles (CC VBA) | 241300375 | ❔ | ❌ | ❌ |
+| CA | CA d'Arles-Crau-Camargue-Montagnette | 241300417 | ❔ | ❌ | ❌ |
+| Département | Var | 83 | ❔ | ❌ | ❌ |
+| CC | CC du Pays de Fayence | 200004802 | ❔ | ❌ | ❌ |
+| CC | CC Méditerranée Porte des Maures | 200027100 | ❔ | ❌ | ❌ |
+| CA | CA Durance-Lubéron-Verdon Agglomération | 200034700 | ✅ | ✅ | ❌ |
+| CA | CA Estérel Côte d'Azur Agglomération | 200035319 | ❔ | ❌ | ❌ |
+| CC | CC du Golfe de Saint-Tropez | 200036077 | ✅ | ✅ | ❌ |
+| CC | CC Provence Verdon | 200040202 | ❔ | ❌ | ❌ |
+| CC | CC Lacs et Gorges du Verdon | 200040210 | ❔ | ❌ | ❌ |
+| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
+| CA | CA de la Provence Verte | 200068104 | ✅ | ✅ | ❌ |
+| CA | CA Sud Sainte Baume | 248300394 | ❔ | ❌ | ❌ |
+| CC | CC de la Vallée du Gapeau | 248300410 | ❔ | ❌ | ❌ |
+| CA | CA Dracénie Provence Verdon Agglomération | 248300493 | ❔ | ❌ | ❌ |
+| METRO | Métropole Toulon-Provence-Méditerranée | 248300543 | ✅ | ✅ | ❌ |
+| CC | CC Coeur du Var | 248300550 | ❔ | ❌ | ❌ |
+| Département | Vaucluse | 84 | ❔ | ❌ | ❌ |
+| CC | CC Rhône Lez Provence | 200000628 | ❔ | ❌ | ❌ |
+| CC | CC Ventoux Sud | 200035723 | ❔ | ❌ | ❌ |
+| CA | CA Luberon Monts de Vaucluse | 200040442 | ✅ | ✅ | ❌ |
+| CC | CC Pays d'Apt-Luberon | 200040624 | ❔ | ❌ | ❌ |
+| CC | CC Enclave des Papes - Pays de Grignan | 200040681 | ❔ | ❌ | ❌ |
+| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
+| CA | CA Ventoux-Comtat-Venaissin (COVE) | 248400053 | ❔ | ❌ | ❌ |
+| CC | CC Aygues-Ouvèze en Provence (CCAOP) | 248400160 | ❔ | ❌ | ❌ |
+| CC | CC Pays d'Orange en Provence | 248400236 | ❔ | ❌ | ❌ |
+| CA | CA du Grand Avignon (COGA) | 248400251 | ✅ | ✅ | ❌ |
+| CC | CC Territoriale Sud-Luberon | 248400285 | ❔ | ❌ | ❌ |
+| CA | CA des Sorgues du Comtat | 248400293 | ✅ | ✅ | ❌ |
+| CC | CC du Pays des Sorgues et des Monts de Vaucluse | 248400319 | ✅ | ✅ | ❌ |
+| CC | CC Vaison Ventoux | 248400335 | ❔ | ❌ | ❌ |

--- a/couverture/93_Provence-Alpes-Côte_d-Azur.md
+++ b/couverture/93_Provence-Alpes-Côte_d-Azur.md
@@ -1,72 +1,71 @@
 # Couverture des aides en Provence-Alpes-Côte d'Azur (93)
 
-
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Provence-Alpes-Côte d'Azur | 93 | ❔ | ❌ | ❌ |
-| Département | Alpes-de-Haute-Provence | 04 | ❔ | ❌ | ❌ |
-| CA | CA Durance-Lubéron-Verdon Agglomération | 200034700 | ✅ | ✅ | ❌ |
-| CC | CC Pays d'Apt-Luberon | 200040624 | ❔ | ❌ | ❌ |
-| CC | CC Serre-Ponçon Val d'Avance | 200067320 | ❔ | ❌ | ❌ |
-| CA | CA Provence-Alpes-Agglomération | 200067437 | ❔ | ❌ | ❌ |
-| CC | CC Serre-Ponçon | 200067742 | ❔ | ❌ | ❌ |
-| CA | CA Gap-Tallard-Durance | 200067825 | ❔ | ❌ | ❌ |
-| CC | CC Alpes-Provence-Verdon "Sources de lumière" | 200068625 | ❔ | ❌ | ❌ |
-| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
-| CC | CC Haute-Provence - Pays de Banon | 200071025 | ❔ | ❌ | ❌ |
-| CC | CC Jabron-Lure-Vançon-Durance | 200071033 | ❔ | ❌ | ❌ |
-| CC | CC Vallée de l'Ubaye - Serre-Ponçon | 200072304 | ❔ | ❌ | ❌ |
-| CC | CC Pays Forcalquier et Montagne de Lure | 240400440 | ❔ | ❌ | ❌ |
-| Département | Hautes-Alpes | 05 | ❔ | ❌ | ❌ |
-| CC | CC Serre-Ponçon Val d'Avance | 200067320 | ❔ | ❌ | ❌ |
-| CC | CC Buëch-Dévoluy | 200067445 | ❔ | ❌ | ❌ |
-| CC | CC du Guillestrois et du Queyras | 200067452 | ❔ | ❌ | ❌ |
-| CC | CC Serre-Ponçon | 200067742 | ❔ | ❌ | ❌ |
-| CA | CA Gap-Tallard-Durance | 200067825 | ❔ | ❌ | ❌ |
-| CC | CC Champsaur-Valgaudemar | 200068096 | ❔ | ❌ | ❌ |
-| CC | CC du Sisteronais-Buëch | 200068765 | ❔ | ❌ | ❌ |
-| CC | CC du Briançonnais | 240500439 | ❔ | ❌ | ❌ |
-| CC | CC du Pays des Ecrins | 240500462 | ❔ | ❌ | ❌ |
-| Département | Alpes-Maritimes | 06 | ❔ | ❌ | ❌ |
-| METRO | Métropole Nice Côte d'Azur | 200030195 | ❔ | ❌ | ❌ |
-| CA | CA du Pays de Grasse | 200039857 | ❔ | ❌ | ❌ |
-| CA | CA Cannes Pays de Lérins | 200039915 | ❔ | ❌ | ❌ |
-| CC | CC Alpes d'Azur | 200039931 | ❔ | ❌ | ❌ |
-| CA | CA de la Riviera Française | 240600551 | ✅ | ✅ | ❌ |
-| CA | CA de Sophia Antipolis | 240600585 | ✅ | ✅ | ❌ |
-| CC | CC du Pays des Paillons | 240600593 | ❔ | ❌ | ❌ |
-| Département | Bouches-du-Rhône | 13 | ❔ | ❌ | ❌ |
-| CA | CA Terre de Provence | 200035087 | ❔ | ❌ | ❌ |
-| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
-| CC | CC Vallée des Baux-Alpilles (CC VBA) | 241300375 | ❔ | ❌ | ❌ |
-| CA | CA d'Arles-Crau-Camargue-Montagnette | 241300417 | ❔ | ❌ | ❌ |
-| Département | Var | 83 | ❔ | ❌ | ❌ |
-| CC | CC du Pays de Fayence | 200004802 | ❔ | ❌ | ❌ |
-| CC | CC Méditerranée Porte des Maures | 200027100 | ❔ | ❌ | ❌ |
-| CA | CA Durance-Lubéron-Verdon Agglomération | 200034700 | ✅ | ✅ | ❌ |
-| CA | CA Estérel Côte d'Azur Agglomération | 200035319 | ❔ | ❌ | ❌ |
-| CC | CC du Golfe de Saint-Tropez | 200036077 | ✅ | ✅ | ❌ |
-| CC | CC Provence Verdon | 200040202 | ❔ | ❌ | ❌ |
-| CC | CC Lacs et Gorges du Verdon | 200040210 | ❔ | ❌ | ❌ |
-| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
-| CA | CA de la Provence Verte | 200068104 | ✅ | ✅ | ❌ |
-| CA | CA Sud Sainte Baume | 248300394 | ❔ | ❌ | ❌ |
-| CC | CC de la Vallée du Gapeau | 248300410 | ❔ | ❌ | ❌ |
-| CA | CA Dracénie Provence Verdon Agglomération | 248300493 | ❔ | ❌ | ❌ |
-| METRO | Métropole Toulon-Provence-Méditerranée | 248300543 | ✅ | ✅ | ❌ |
-| CC | CC Coeur du Var | 248300550 | ❔ | ❌ | ❌ |
-| Département | Vaucluse | 84 | ❔ | ❌ | ❌ |
-| CC | CC Rhône Lez Provence | 200000628 | ❔ | ❌ | ❌ |
-| CC | CC Ventoux Sud | 200035723 | ❔ | ❌ | ❌ |
-| CA | CA Luberon Monts de Vaucluse | 200040442 | ✅ | ✅ | ❌ |
-| CC | CC Pays d'Apt-Luberon | 200040624 | ❔ | ❌ | ❌ |
-| CC | CC Enclave des Papes - Pays de Grignan | 200040681 | ❔ | ❌ | ❌ |
-| METRO | Métropole d'Aix-Marseille-Provence | 200054807 | ❔ | ❌ | ❌ |
-| CA | CA Ventoux-Comtat-Venaissin (COVE) | 248400053 | ❔ | ❌ | ❌ |
-| CC | CC Aygues-Ouvèze en Provence (CCAOP) | 248400160 | ❔ | ❌ | ❌ |
-| CC | CC Pays d'Orange en Provence | 248400236 | ❔ | ❌ | ❌ |
-| CA | CA du Grand Avignon (COGA) | 248400251 | ✅ | ✅ | ❌ |
-| CC | CC Territoriale Sud-Luberon | 248400285 | ❔ | ❌ | ❌ |
-| CA | CA des Sorgues du Comtat | 248400293 | ✅ | ✅ | ❌ |
-| CC | CC du Pays des Sorgues et des Monts de Vaucluse | 248400319 | ✅ | ✅ | ❌ |
-| CC | CC Vaison Ventoux | 248400335 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                             | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | ----------------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Provence-Alpes-Côte d'Azur                      | 93        | ❔               | ❌        | ❌    |
+| Département | Alpes-de-Haute-Provence                         | 04        | ❔               | ❌        | ❌    |
+| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ❌    |
+| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❔               | ❌        | ❌    |
+| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❔               | ❌        | ❌    |
+| CA          | CA Provence-Alpes-Agglomération                 | 200067437 | ❔               | ❌        | ❌    |
+| CC          | CC Serre-Ponçon                                 | 200067742 | ❔               | ❌        | ❌    |
+| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❔               | ❌        | ❌    |
+| CC          | CC Alpes-Provence-Verdon "Sources de lumière"   | 200068625 | ❔               | ❌        | ❌    |
+| CC          | CC du Sisteronais-Buëch                         | 200068765 | ❔               | ❌        | ❌    |
+| CC          | CC Haute-Provence - Pays de Banon               | 200071025 | ❔               | ❌        | ❌    |
+| CC          | CC Jabron-Lure-Vançon-Durance                   | 200071033 | ❔               | ❌        | ❌    |
+| CC          | CC Vallée de l'Ubaye - Serre-Ponçon             | 200072304 | ❔               | ❌        | ❌    |
+| CC          | CC Pays Forcalquier et Montagne de Lure         | 240400440 | ❔               | ❌        | ❌    |
+| Département | Hautes-Alpes                                    | 05        | ❔               | ❌        | ❌    |
+| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❔               | ❌        | ❌    |
+| CC          | CC Buëch-Dévoluy                                | 200067445 | ❔               | ❌        | ❌    |
+| CC          | CC du Guillestrois et du Queyras                | 200067452 | ❔               | ❌        | ❌    |
+| CC          | CC Serre-Ponçon                                 | 200067742 | ❔               | ❌        | ❌    |
+| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❔               | ❌        | ❌    |
+| CC          | CC Champsaur-Valgaudemar                        | 200068096 | ❔               | ❌        | ❌    |
+| CC          | CC du Sisteronais-Buëch                         | 200068765 | ❔               | ❌        | ❌    |
+| CC          | CC du Briançonnais                              | 240500439 | ❔               | ❌        | ❌    |
+| CC          | CC du Pays des Ecrins                           | 240500462 | ❔               | ❌        | ❌    |
+| Département | Alpes-Maritimes                                 | 06        | ❔               | ❌        | ❌    |
+| METRO       | Métropole Nice Côte d'Azur                      | 200030195 | ❔               | ❌        | ❌    |
+| CA          | CA du Pays de Grasse                            | 200039857 | ❔               | ❌        | ❌    |
+| CA          | CA Cannes Pays de Lérins                        | 200039915 | ❔               | ❌        | ❌    |
+| CC          | CC Alpes d'Azur                                 | 200039931 | ❔               | ❌        | ❌    |
+| CA          | CA de la Riviera Française                      | 240600551 | ✅               | ✅        | ❌    |
+| CA          | CA de Sophia Antipolis                          | 240600585 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays des Paillons                         | 240600593 | ❔               | ❌        | ❌    |
+| Département | Bouches-du-Rhône                                | 13        | ❔               | ❌        | ❌    |
+| CA          | CA Terre de Provence                            | 200035087 | ❔               | ❌        | ❌    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
+| CC          | CC Vallée des Baux-Alpilles (CC VBA)            | 241300375 | ❔               | ❌        | ❌    |
+| CA          | CA d'Arles-Crau-Camargue-Montagnette            | 241300417 | ❔               | ❌        | ❌    |
+| Département | Var                                             | 83        | ❔               | ❌        | ❌    |
+| CC          | CC du Pays de Fayence                           | 200004802 | ❔               | ❌        | ❌    |
+| CC          | CC Méditerranée Porte des Maures                | 200027100 | ❔               | ❌        | ❌    |
+| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ❌    |
+| CA          | CA Estérel Côte d'Azur Agglomération            | 200035319 | ❔               | ❌        | ❌    |
+| CC          | CC du Golfe de Saint-Tropez                     | 200036077 | ✅               | ✅        | ❌    |
+| CC          | CC Provence Verdon                              | 200040202 | ❔               | ❌        | ❌    |
+| CC          | CC Lacs et Gorges du Verdon                     | 200040210 | ❔               | ❌        | ❌    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
+| CA          | CA de la Provence Verte                         | 200068104 | ✅               | ✅        | ❌    |
+| CA          | CA Sud Sainte Baume                             | 248300394 | ❔               | ❌        | ❌    |
+| CC          | CC de la Vallée du Gapeau                       | 248300410 | ❔               | ❌        | ❌    |
+| CA          | CA Dracénie Provence Verdon Agglomération       | 248300493 | ❔               | ❌        | ❌    |
+| METRO       | Métropole Toulon-Provence-Méditerranée          | 248300543 | ✅               | ✅        | ❌    |
+| CC          | CC Coeur du Var                                 | 248300550 | ❔               | ❌        | ❌    |
+| Département | Vaucluse                                        | 84        | ❔               | ❌        | ❌    |
+| CC          | CC Rhône Lez Provence                           | 200000628 | ❔               | ❌        | ❌    |
+| CC          | CC Ventoux Sud                                  | 200035723 | ❔               | ❌        | ❌    |
+| CA          | CA Luberon Monts de Vaucluse                    | 200040442 | ✅               | ✅        | ❌    |
+| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❔               | ❌        | ❌    |
+| CC          | CC Enclave des Papes - Pays de Grignan          | 200040681 | ❔               | ❌        | ❌    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
+| CA          | CA Ventoux-Comtat-Venaissin (COVE)              | 248400053 | ❔               | ❌        | ❌    |
+| CC          | CC Aygues-Ouvèze en Provence (CCAOP)            | 248400160 | ❔               | ❌        | ❌    |
+| CC          | CC Pays d'Orange en Provence                    | 248400236 | ❔               | ❌        | ❌    |
+| CA          | CA du Grand Avignon (COGA)                      | 248400251 | ✅               | ✅        | ❌    |
+| CC          | CC Territoriale Sud-Luberon                     | 248400285 | ❔               | ❌        | ❌    |
+| CA          | CA des Sorgues du Comtat                        | 248400293 | ✅               | ✅        | ❌    |
+| CC          | CC du Pays des Sorgues et des Monts de Vaucluse | 248400319 | ✅               | ✅        | ❌    |
+| CC          | CC Vaison Ventoux                               | 248400335 | ❔               | ❌        | ❌    |

--- a/couverture/93_Provence-Alpes-Côte_d-Azur.md
+++ b/couverture/93_Provence-Alpes-Côte_d-Azur.md
@@ -2,70 +2,70 @@
 
 | Echelle     | Nom                                             | Code      | Possède une aide | Modélisée | Relue |
 | ----------- | ----------------------------------------------- | --------- | ---------------- | --------- | ----- |
-| Région      | Provence-Alpes-Côte d'Azur                      | 93        | ❔               | ❌        | ❌    |
-| Département | Alpes-de-Haute-Provence                         | 04        | ❔               | ❌        | ❌    |
-| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ❌    |
-| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❔               | ❌        | ❌    |
-| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❔               | ❌        | ❌    |
-| CA          | CA Provence-Alpes-Agglomération                 | 200067437 | ❔               | ❌        | ❌    |
-| CC          | CC Serre-Ponçon                                 | 200067742 | ❔               | ❌        | ❌    |
-| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❔               | ❌        | ❌    |
-| CC          | CC Alpes-Provence-Verdon "Sources de lumière"   | 200068625 | ❔               | ❌        | ❌    |
-| CC          | CC du Sisteronais-Buëch                         | 200068765 | ❔               | ❌        | ❌    |
-| CC          | CC Haute-Provence - Pays de Banon               | 200071025 | ❔               | ❌        | ❌    |
-| CC          | CC Jabron-Lure-Vançon-Durance                   | 200071033 | ❔               | ❌        | ❌    |
-| CC          | CC Vallée de l'Ubaye - Serre-Ponçon             | 200072304 | ❔               | ❌        | ❌    |
-| CC          | CC Pays Forcalquier et Montagne de Lure         | 240400440 | ❔               | ❌        | ❌    |
-| Département | Hautes-Alpes                                    | 05        | ❔               | ❌        | ❌    |
-| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❔               | ❌        | ❌    |
-| CC          | CC Buëch-Dévoluy                                | 200067445 | ❔               | ❌        | ❌    |
-| CC          | CC du Guillestrois et du Queyras                | 200067452 | ❔               | ❌        | ❌    |
-| CC          | CC Serre-Ponçon                                 | 200067742 | ❔               | ❌        | ❌    |
-| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❔               | ❌        | ❌    |
-| CC          | CC Champsaur-Valgaudemar                        | 200068096 | ❔               | ❌        | ❌    |
-| CC          | CC du Sisteronais-Buëch                         | 200068765 | ❔               | ❌        | ❌    |
-| CC          | CC du Briançonnais                              | 240500439 | ❔               | ❌        | ❌    |
-| CC          | CC du Pays des Ecrins                           | 240500462 | ❔               | ❌        | ❌    |
-| Département | Alpes-Maritimes                                 | 06        | ❔               | ❌        | ❌    |
-| METRO       | Métropole Nice Côte d'Azur                      | 200030195 | ❔               | ❌        | ❌    |
-| CA          | CA du Pays de Grasse                            | 200039857 | ❔               | ❌        | ❌    |
-| CA          | CA Cannes Pays de Lérins                        | 200039915 | ❔               | ❌        | ❌    |
-| CC          | CC Alpes d'Azur                                 | 200039931 | ❔               | ❌        | ❌    |
-| CA          | CA de la Riviera Française                      | 240600551 | ✅               | ✅        | ❌    |
-| CA          | CA de Sophia Antipolis                          | 240600585 | ✅               | ✅        | ❌    |
-| CC          | CC du Pays des Paillons                         | 240600593 | ❔               | ❌        | ❌    |
-| Département | Bouches-du-Rhône                                | 13        | ❔               | ❌        | ❌    |
-| CA          | CA Terre de Provence                            | 200035087 | ❔               | ❌        | ❌    |
-| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
-| CC          | CC Vallée des Baux-Alpilles (CC VBA)            | 241300375 | ❔               | ❌        | ❌    |
-| CA          | CA d'Arles-Crau-Camargue-Montagnette            | 241300417 | ❔               | ❌        | ❌    |
-| Département | Var                                             | 83        | ❔               | ❌        | ❌    |
-| CC          | CC du Pays de Fayence                           | 200004802 | ❔               | ❌        | ❌    |
-| CC          | CC Méditerranée Porte des Maures                | 200027100 | ❔               | ❌        | ❌    |
-| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ❌    |
-| CA          | CA Estérel Côte d'Azur Agglomération            | 200035319 | ❔               | ❌        | ❌    |
-| CC          | CC du Golfe de Saint-Tropez                     | 200036077 | ✅               | ✅        | ❌    |
-| CC          | CC Provence Verdon                              | 200040202 | ❔               | ❌        | ❌    |
-| CC          | CC Lacs et Gorges du Verdon                     | 200040210 | ❔               | ❌        | ❌    |
-| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
-| CA          | CA de la Provence Verte                         | 200068104 | ✅               | ✅        | ❌    |
-| CA          | CA Sud Sainte Baume                             | 248300394 | ❔               | ❌        | ❌    |
-| CC          | CC de la Vallée du Gapeau                       | 248300410 | ❔               | ❌        | ❌    |
-| CA          | CA Dracénie Provence Verdon Agglomération       | 248300493 | ❔               | ❌        | ❌    |
-| METRO       | Métropole Toulon-Provence-Méditerranée          | 248300543 | ✅               | ✅        | ❌    |
-| CC          | CC Coeur du Var                                 | 248300550 | ❔               | ❌        | ❌    |
-| Département | Vaucluse                                        | 84        | ❔               | ❌        | ❌    |
-| CC          | CC Rhône Lez Provence                           | 200000628 | ❔               | ❌        | ❌    |
-| CC          | CC Ventoux Sud                                  | 200035723 | ❔               | ❌        | ❌    |
-| CA          | CA Luberon Monts de Vaucluse                    | 200040442 | ✅               | ✅        | ❌    |
-| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❔               | ❌        | ❌    |
-| CC          | CC Enclave des Papes - Pays de Grignan          | 200040681 | ❔               | ❌        | ❌    |
-| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❔               | ❌        | ❌    |
-| CA          | CA Ventoux-Comtat-Venaissin (COVE)              | 248400053 | ❔               | ❌        | ❌    |
-| CC          | CC Aygues-Ouvèze en Provence (CCAOP)            | 248400160 | ❔               | ❌        | ❌    |
-| CC          | CC Pays d'Orange en Provence                    | 248400236 | ❔               | ❌        | ❌    |
-| CA          | CA du Grand Avignon (COGA)                      | 248400251 | ✅               | ✅        | ❌    |
-| CC          | CC Territoriale Sud-Luberon                     | 248400285 | ❔               | ❌        | ❌    |
-| CA          | CA des Sorgues du Comtat                        | 248400293 | ✅               | ✅        | ❌    |
-| CC          | CC du Pays des Sorgues et des Monts de Vaucluse | 248400319 | ✅               | ✅        | ❌    |
-| CC          | CC Vaison Ventoux                               | 248400335 | ❔               | ❌        | ❌    |
+| Région      | Provence-Alpes-Côte d'Azur                      | 93        | ❌               | ❌        | ✅    |
+| Département | Alpes-de-Haute-Provence                         | 04        | ❌               | ❌        | ✅    |
+| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ✅    |
+| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❌               | ❌        | ✅    |
+| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❌               | ❌        | ✅    |
+| CA          | CA Provence-Alpes-Agglomération                 | 200067437 | ❌               | ❌        | ✅    |
+| CC          | CC Serre-Ponçon                                 | 200067742 | ❌               | ❌        | ✅    |
+| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❌               | ❌        | ✅    |
+| CC          | CC Alpes-Provence-Verdon "Sources de lumière"   | 200068625 | ❌               | ❌        | ✅    |
+| CC          | CC du Sisteronais-Buëch                         | 200068765 | ✅               | ✅        | ✅    |
+| CC          | CC Haute-Provence - Pays de Banon               | 200071025 | ❌               | ❌        | ✅    |
+| CC          | CC Jabron-Lure-Vançon-Durance                   | 200071033 | ❌               | ❌        | ✅    |
+| CC          | CC Vallée de l'Ubaye - Serre-Ponçon             | 200072304 | ❌               | ❌        | ✅    |
+| CC          | CC Pays Forcalquier et Montagne de Lure         | 240400440 | 🕒               | ❌        | ✅    |
+| Département | Hautes-Alpes                                    | 05        | ❌               | ❌        | 🤖    |
+| CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❌               | ❌        | 🤖    |
+| CC          | CC Buëch-Dévoluy                                | 200067445 | ❌               | ❌        | 🤖    |
+| CC          | CC du Guillestrois et du Queyras                | 200067452 | ❌               | ❌        | 🤖    |
+| CC          | CC Serre-Ponçon                                 | 200067742 | ❌               | ❌        | 🤖    |
+| CA          | CA Gap-Tallard-Durance                          | 200067825 | ❌               | ❌        | 🤖    |
+| CC          | CC Champsaur-Valgaudemar                        | 200068096 | ❌               | ❌        | 🤖    |
+| CC          | CC du Sisteronais-Buëch                         | 200068765 | ❌               | ❌        | 🤖    |
+| CC          | CC du Briançonnais                              | 240500439 | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays des Ecrins                           | 240500462 | ❌               | ❌        | 🤖    |
+| Département | Alpes-Maritimes                                 | 06        | ❌               | ❌        | ✅    |
+| METRO       | Métropole Nice Côte d'Azur                      | 200030195 | ❌               | ❌        | 🤖    |
+| CA          | CA du Pays de Grasse                            | 200039857 | ❌               | ❌        | 🤖    |
+| CA          | CA Cannes Pays de Lérins                        | 200039915 | ❌               | ❌        | 🤖    |
+| CC          | CC Alpes d'Azur                                 | 200039931 | ❌               | ❌        | 🤖    |
+| CA          | CA de la Riviera Française                      | 240600551 | ❌               | ❌        | ✅    |
+| CA          | CA de Sophia Antipolis                          | 240600585 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays des Paillons                         | 240600593 | ❌               | ❌        | ✅    |
+| Département | Bouches-du-Rhône                                | 13        | ❌               | ❌        | ✅    |
+| CA          | CA Terre de Provence                            | 200035087 | ❌               | ❌        | 🤖    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❌               | ❌        | 🤖    |
+| CC          | CC Vallée des Baux-Alpilles (CC VBA)            | 241300375 | ❌               | ❌        | 🤖    |
+| CA          | CA d'Arles-Crau-Camargue-Montagnette            | 241300417 | ❌               | ❌        | 🤖    |
+| Département | Var                                             | 83        | ❌               | ❌        | 🤖    |
+| CC          | CC du Pays de Fayence                           | 200004802 | ❌               | ❌        | 🤖    |
+| CC          | CC Méditerranée Porte des Maures                | 200027100 | ❌               | ❌        | 🤖    |
+| CA          | CA Durance-Lubéron-Verdon Agglomération         | 200034700 | ✅               | ✅        | ✅    |
+| CA          | CA Estérel Côte d'Azur Agglomération            | 200035319 | ❌               | ❌        | 🤖    |
+| CC          | CC du Golfe de Saint-Tropez                     | 200036077 | ✅               | ✅        | ✅    |
+| CC          | CC Provence Verdon                              | 200040202 | ❌               | ❌        | 🤖    |
+| CC          | CC Lacs et Gorges du Verdon                     | 200040210 | ❌               | ❌        | 🤖    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❌               | ❌        | 🤖    |
+| CA          | CA de la Provence Verte                         | 200068104 | ✅               | ✅        | ✅    |
+| CA          | CA Sud Sainte Baume                             | 248300394 | ❌               | ❌        | 🤖    |
+| CC          | CC de la Vallée du Gapeau                       | 248300410 | ❌               | ❌        | 🤖    |
+| CA          | CA Dracénie Provence Verdon Agglomération       | 248300493 | ❌               | ❌        | 🤖    |
+| METRO       | Métropole Toulon-Provence-Méditerranée          | 248300543 | ✅               | ✅        | ✅    |
+| CC          | CC Coeur du Var                                 | 248300550 | ❌               | ❌        | 🤖    |
+| Département | Vaucluse                                        | 84        | ❌               | ❌        | 🤖    |
+| CC          | CC Rhône Lez Provence                           | 200000628 | ❌               | ❌        | 🤖    |
+| CC          | CC Ventoux Sud                                  | 200035723 | ❌               | ❌        | 🤖    |
+| CA          | CA Luberon Monts de Vaucluse                    | 200040442 | ❌               | ✅        | ✅    |
+| CC          | CC Pays d'Apt-Luberon                           | 200040624 | ❌               | ❌        | 🤖    |
+| CC          | CC Enclave des Papes - Pays de Grignan          | 200040681 | ❌               | ❌        | 🤖    |
+| METRO       | Métropole d'Aix-Marseille-Provence              | 200054807 | ❌               | ❌        | 🤖    |
+| CA          | CA Ventoux-Comtat-Venaissin (COVE)              | 248400053 | ❌               | ❌        | 🤖    |
+| CC          | CC Aygues-Ouvèze en Provence (CCAOP)            | 248400160 | ❌               | ❌        | 🤖    |
+| CC          | CC Pays d'Orange en Provence                    | 248400236 | ❌               | ❌        | 🤖    |
+| CA          | CA du Grand Avignon (COGA)                      | 248400251 | ✅               | ✅        | ✅    |
+| CC          | CC Territoriale Sud-Luberon                     | 248400285 | ❌               | ❌        | 🤖    |
+| CA          | CA des Sorgues du Comtat                        | 248400293 | ✅               | ✅        | ✅    |
+| CC          | CC du Pays des Sorgues et des Monts de Vaucluse | 248400319 | ✅               | ✅        | ✅    |
+| CC          | CC Vaison Ventoux                               | 248400335 | ❌               | ❌        | 🤖    |

--- a/couverture/93_Provence-Alpes-Côte_d-Azur.md
+++ b/couverture/93_Provence-Alpes-Côte_d-Azur.md
@@ -15,7 +15,7 @@
 | CC          | CC Haute-Provence - Pays de Banon               | 200071025 | ❌               | ❌        | ✅    |
 | CC          | CC Jabron-Lure-Vançon-Durance                   | 200071033 | ❌               | ❌        | ✅    |
 | CC          | CC Vallée de l'Ubaye - Serre-Ponçon             | 200072304 | ❌               | ❌        | ✅    |
-| CC          | CC Pays Forcalquier et Montagne de Lure         | 240400440 | 🕒               | ❌        | ✅    |
+| CC          | CC Pays Forcalquier et Montagne de Lure         | 240400440 | ✅               | ✅        | ✅    |
 | Département | Hautes-Alpes                                    | 05        | ❌               | ❌        | 🤖    |
 | CC          | CC Serre-Ponçon Val d'Avance                    | 200067320 | ❌               | ❌        | 🤖    |
 | CC          | CC Buëch-Dévoluy                                | 200067445 | ❌               | ❌        | 🤖    |

--- a/couverture/94_Corse.md
+++ b/couverture/94_Corse.md
@@ -1,27 +1,28 @@
 # Couverture des aides en Corse (94)
 
+- 2025 : ✅
 
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Corse | 94 | ✅ | ✅ | ❌ |
-| Département | Corse-du-Sud | 2A | ❔ | ❌ | ❌ |
-| CC | CC de la Pieve de l'Ornano et du Taravo | 200038958 | ❔ | ❌ | ❌ |
-| CC | CC du Sud Corse | 200040764 | ❔ | ❌ | ❌ |
-| CC | CC Spelunca-Liamone | 200067049 | ❔ | ❌ | ❌ |
-| CC | CC de l'Alta Rocca | 242000495 | ❔ | ❌ | ❌ |
-| CC | CC Celavu-Prunelli | 242000503 | ❔ | ❌ | ❌ |
-| CA | CA du Pays Ajaccien | 242010056 | ❔ | ❌ | ❌ |
-| CC | CC du Sartenais Valinco Taravo | 242010130 | ❔ | ❌ | ❌ |
-| Département | Haute-Corse | 2B | ❔ | ❌ | ❌ |
-| CC | CC de l'Oriente | 200015162 | ❔ | ❌ | ❌ |
-| CC | CC de Fium'Orbu Castellu | 200033827 | ❔ | ❌ | ❌ |
-| CC | CC de la Costa Verde | 200034205 | ❔ | ❌ | ❌ |
-| CC | CC de Marana-Golo | 200036499 | ❔ | ❌ | ❌ |
-| CC | CC du Cap Corse | 200042943 | ❔ | ❌ | ❌ |
-| CC | CC de l'Ile-Rousse - Balagne | 200073104 | ❔ | ❌ | ❌ |
-| CC | CC Nebbiu - Conca d'Oro | 200073120 | ❔ | ❌ | ❌ |
-| CC | CC Pasquale Paoli | 200073138 | ❔ | ❌ | ❌ |
-| CC | CC de la Castagniccia-Casinca | 200073252 | ❔ | ❌ | ❌ |
-| CA | CA de Bastia | 242000354 | ❔ | ❌ | ❌ |
-| CC | CC du Centre Corse | 242020071 | ❔ | ❌ | ❌ |
-| CC | CC de Calvi Balagne | 242020105 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                                     | Code      | Possède une aide | Modélisée | Relue |
+| ----------- | --------------------------------------- | --------- | ---------------- | --------- | ----- |
+| Région      | Corse                                   | 94        | ✅               | ✅        | ✅    |
+| Département | Corse-du-Sud                            | 2A        | ❌               | ❌        | ✅    |
+| CC          | CC de la Pieve de l'Ornano et du Taravo | 200038958 | ❌               | ❌        | ✅    |
+| CC          | CC du Sud Corse                         | 200040764 | ❌               | ❌        | ✅    |
+| CC          | CC Spelunca-Liamone                     | 200067049 | ❌               | ❌        | ✅    |
+| CC          | CC de l'Alta Rocca                      | 242000495 | ❌               | ❌        | ✅    |
+| CC          | CC Celavu-Prunelli                      | 242000503 | ❌               | ❌        | ✅    |
+| CA          | CA du Pays Ajaccien                     | 242010056 | ❌               | ❌        | ✅    |
+| CC          | CC du Sartenais Valinco Taravo          | 242010130 | ❌               | ❌        | ✅    |
+| Département | Haute-Corse                             | 2B        | ❌               | ❌        | ✅    |
+| CC          | CC de l'Oriente                         | 200015162 | ❌               | ❌        | ✅    |
+| CC          | CC de Fium'Orbu Castellu                | 200033827 | ❌               | ❌        | ✅    |
+| CC          | CC de la Costa Verde                    | 200034205 | ❌               | ❌        | ✅    |
+| CC          | CC de Marana-Golo                       | 200036499 | ❌               | ❌        | ✅    |
+| CC          | CC du Cap Corse                         | 200042943 | ❌               | ❌        | ✅    |
+| CC          | CC de l'Ile-Rousse - Balagne            | 200073104 | ❌               | ❌        | ✅    |
+| CC          | CC Nebbiu - Conca d'Oro                 | 200073120 | ❌               | ❌        | ✅    |
+| CC          | CC Pasquale Paoli                       | 200073138 | ❌               | ❌        | ✅    |
+| CC          | CC de la Castagniccia-Casinca           | 200073252 | ❌               | ❌        | ✅    |
+| CA          | CA de Bastia                            | 242000354 | ❌               | ❌        | ✅    |
+| CC          | CC du Centre Corse                      | 242020071 | ❌               | ❌        | ✅    |
+| CC          | CC de Calvi Balagne                     | 242020105 | ❌               | ❌        | ✅    |

--- a/couverture/94_Corse.md
+++ b/couverture/94_Corse.md
@@ -1,0 +1,27 @@
+# Couverture des aides en Corse (94)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Corse | 94 | ✅ | ✅ | ❌ |
+| Département | Corse-du-Sud | 2A | ❔ | ❌ | ❌ |
+| CC | CC de la Pieve de l'Ornano et du Taravo | 200038958 | ❔ | ❌ | ❌ |
+| CC | CC du Sud Corse | 200040764 | ❔ | ❌ | ❌ |
+| CC | CC Spelunca-Liamone | 200067049 | ❔ | ❌ | ❌ |
+| CC | CC de l'Alta Rocca | 242000495 | ❔ | ❌ | ❌ |
+| CC | CC Celavu-Prunelli | 242000503 | ❔ | ❌ | ❌ |
+| CA | CA du Pays Ajaccien | 242010056 | ❔ | ❌ | ❌ |
+| CC | CC du Sartenais Valinco Taravo | 242010130 | ❔ | ❌ | ❌ |
+| Département | Haute-Corse | 2B | ❔ | ❌ | ❌ |
+| CC | CC de l'Oriente | 200015162 | ❔ | ❌ | ❌ |
+| CC | CC de Fium'Orbu Castellu | 200033827 | ❔ | ❌ | ❌ |
+| CC | CC de la Costa Verde | 200034205 | ❔ | ❌ | ❌ |
+| CC | CC de Marana-Golo | 200036499 | ❔ | ❌ | ❌ |
+| CC | CC du Cap Corse | 200042943 | ❔ | ❌ | ❌ |
+| CC | CC de l'Ile-Rousse - Balagne | 200073104 | ❔ | ❌ | ❌ |
+| CC | CC Nebbiu - Conca d'Oro | 200073120 | ❔ | ❌ | ❌ |
+| CC | CC Pasquale Paoli | 200073138 | ❔ | ❌ | ❌ |
+| CC | CC de la Castagniccia-Casinca | 200073252 | ❔ | ❌ | ❌ |
+| CA | CA de Bastia | 242000354 | ❔ | ❌ | ❌ |
+| CC | CC du Centre Corse | 242020071 | ❔ | ❌ | ❌ |
+| CC | CC de Calvi Balagne | 242020105 | ❔ | ❌ | ❌ |

--- a/couverture/975_Saint-Pierre-et-Miquelon.md
+++ b/couverture/975_Saint-Pierre-et-Miquelon.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Saint-Pierre-et-Miquelon (975)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Saint-Pierre-et-Miquelon | 975 | ❔ | ❌ | ❌ |
+| Département | Saint-Pierre-et-Miquelon | 975 | ❔ | ❌ | ❌ |

--- a/couverture/975_Saint-Pierre-et-Miquelon.md
+++ b/couverture/975_Saint-Pierre-et-Miquelon.md
@@ -1,7 +1,8 @@
 # Couverture des aides en Saint-Pierre-et-Miquelon (975)
 
+- 2025 : ✅
 
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Saint-Pierre-et-Miquelon | 975 | ❔ | ❌ | ❌ |
-| Département | Saint-Pierre-et-Miquelon | 975 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                      | Code | Possède une aide | Modélisée | Relue |
+| ----------- | ------------------------ | ---- | ---------------- | --------- | ----- |
+| Région      | Saint-Pierre-et-Miquelon | 975  | ❌               | ❌        | ✅    |
+| Département | Saint-Pierre-et-Miquelon | 975  | ❌               | ❌        | ✅    |

--- a/couverture/977_Saint-Barthélemy.md
+++ b/couverture/977_Saint-Barthélemy.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Saint-Barthélemy (977)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Saint-Barthélemy | 977 | ❔ | ❌ | ❌ |
+| Département | Saint-Barthélemy | 977 | ❔ | ❌ | ❌ |

--- a/couverture/978_Saint-Martin.md
+++ b/couverture/978_Saint-Martin.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Saint-Martin (978)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Saint-Martin | 978 | ❔ | ❌ | ❌ |
+| Département | Saint-Martin | 978 | ❔ | ❌ | ❌ |

--- a/couverture/984_Terres_australes_et_antarctiques_françaises.md
+++ b/couverture/984_Terres_australes_et_antarctiques_françaises.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Terres australes et antarctiques françaises (984)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Terres australes et antarctiques françaises | 984 | ❔ | ❌ | ❌ |
+| Département | Terres australes et antarctiques françaises | 984 | ❔ | ❌ | ❌ |

--- a/couverture/986_Wallis_et_Futuna.md
+++ b/couverture/986_Wallis_et_Futuna.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Wallis et Futuna (986)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Wallis et Futuna | 986 | ❔ | ❌ | ❌ |
+| Département | Wallis et Futuna | 986 | ❔ | ❌ | ❌ |

--- a/couverture/987_Polynésie_française.md
+++ b/couverture/987_Polynésie_française.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Polynésie française (987)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Polynésie française | 987 | ❔ | ❌ | ❌ |
+| Département | Polynésie française | 987 | ❔ | ❌ | ❌ |

--- a/couverture/987_Polynésie_française.md
+++ b/couverture/987_Polynésie_française.md
@@ -1,7 +1,8 @@
 # Couverture des aides en Polynésie française (987)
 
+- 2025 : ✅
 
-| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
-| ------- | --- | ---- | ---------------- | --------- | ----- |
-| Région | Polynésie française | 987 | ❔ | ❌ | ❌ |
-| Département | Polynésie française | 987 | ❔ | ❌ | ❌ |
+| Echelle     | Nom                 | Code | Possède une aide | Modélisée | Relue |
+| ----------- | ------------------- | ---- | ---------------- | --------- | ----- |
+| Région      | Polynésie française | 987  | ❌               | ❌        | ✅    |
+| Département | Polynésie française | 987  | ❌               | ❌        | ✅    |

--- a/couverture/988_Nouvelle-Calédonie.md
+++ b/couverture/988_Nouvelle-Calédonie.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Nouvelle-Calédonie (988)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Nouvelle-Calédonie | 988 | ❔ | ❌ | ❌ |
+| Département | Nouvelle-Calédonie | 988 | ❔ | ❌ | ❌ |

--- a/couverture/989_Île_de_Clipperton.md
+++ b/couverture/989_Île_de_Clipperton.md
@@ -1,0 +1,7 @@
+# Couverture des aides en Île de Clipperton (989)
+
+
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+| Région | Île de Clipperton | 989 | ❔ | ❌ | ❌ |
+| Département | Île de Clipperton | 989 | ❔ | ❌ | ❌ |

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,26 @@
+{
+  "typescript": {
+  },
+  "json": {
+  },
+  "markdown": {
+  },
+  "malva": {
+  },
+  "markup": {
+  },
+  "yaml": {
+  },
+  "excludes": [
+    "**/node_modules",
+    "**/*-lock.json"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/typescript-0.95.9.wasm",
+    "https://plugins.dprint.dev/json-0.20.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.19.0.wasm",
+    "https://plugins.dprint.dev/g-plane/malva-v0.14.1.wasm",
+    "https://plugins.dprint.dev/g-plane/markup_fmt-v0.23.1.wasm",
+    "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.1.wasm"
+  ]
+}

--- a/scripts/check-outdated-aids.ts
+++ b/scripts/check-outdated-aids.ts
@@ -6,8 +6,10 @@ let outdated = 0;
 
 engine.getAllAidesIn().forEach(({ title, id, endDate }) => {
   if (endDate && endDate <= now) {
-    console.log(
-      `L'aide "${title}" (${id}) n'est plus en vigueur, elle a pris fin le ${endDate.toLocaleDateString()}.`
+    console.error(
+      `L'aide "${title}" (${id}) n'est plus en vigueur, elle a pris fin le ${endDate.toLocaleDateString(
+        "FR-fr"
+      )}.`
     );
     outdated++;
   }
@@ -21,5 +23,5 @@ if (outdated === 0) {
       outdated > 1 ? "s" : ""
     }. Veuillez les déplacer dans le fichier "./src/rules/historique/aides-desactivees.publicodes".`
   );
-  process.exit(1);
+  // process.exit(1);
 }

--- a/scripts/couverture.ts
+++ b/scripts/couverture.ts
@@ -1,0 +1,109 @@
+import communes from "@etalab/decoupage-administratif/data/communes.json";
+import departements from "@etalab/decoupage-administratif/data/departements.json";
+import epci from "@etalab/decoupage-administratif/data/epci.json";
+import regions from "@etalab/decoupage-administratif/data/regions.json";
+import * as fs from "fs";
+import { Aide, AidesVeloEngine } from "../src";
+import path from "path";
+
+/**
+ * Ce script génère un fichier permettant de suivre la couverture des aides
+ * pour chaque région, département, EPCI et commune.
+ *
+ * Pour chaque région, département, EPCI et commune, il faut pouvoir indiquer
+ * trois choses :
+ * - Est-ce que l'entité a été déjà relue ?
+ * - Existe-t-il une aide pour cette entité ?
+ * - Si oui, est-elle déjà listée dans ce modèle ?
+ */
+
+const OUTPUT_FILE = "couverture";
+const engine = new AidesVeloEngine();
+const aides = engine.getAllAidesIn();
+
+
+const writeFileSync = (file: string, content: string) => {
+  fs.writeFileSync(file, content, { encoding: "utf-8", flag: "a" });
+};
+
+const encode = (str: string) => str.replaceAll(" ", "_").replaceAll("'", "-")
+
+for (const region of regions) {
+  const file_path = path.join(OUTPUT_FILE, `${region.code}_${encode(region.nom)}.md`)
+  console.log("Processing:", file_path)
+  fs.writeFileSync(file_path,`# Couverture des aides en ${region.nom} (${region.code})\n\n`)
+  const exist = aides.some(
+    (aide: Omit<Aide, "amount">) =>
+      aide.collectivity.kind === "région" &&
+      (aide.collectivity.code === region.code || aide.collectivity.value === region.code)
+  );
+
+  writeFileSync(file_path,
+    `
+| Echelle | Nom | Code | Possède une aide | Modélisée | Relue |
+| ------- | --- | ---- | ---------------- | --------- | ----- |
+`
+  );
+
+  writeFileSync(file_path,
+    `| Région | ${region.nom} | ${region.code} | ${exist ? "✅" : "❔"} | ${
+      exist ? "✅" : "❌"
+    } | ❌ |\n`
+  );
+
+  const departementsInRegion = departements.filter(
+    (d) => d.region === region.code
+  );
+
+  for (const departement of departementsInRegion) {
+    const exist = aides.some(
+      (aide: Omit<Aide, "amount">) =>
+        aide.collectivity.kind === "département" &&
+        (aide.collectivity.code === departement.code ||
+          aide.collectivity.value === departement.code)
+    );
+
+    writeFileSync(file_path,
+      `| Département | ${departement.nom} | ${departement.code} | ${
+        exist ? "✅" : "❔"
+      } | ${exist ? "✅" : "❌"} | ❌ |\n`
+    );
+
+    const communesInDepartement =
+      //@ts-ignore
+      communes.filter((c) => c.departement === departement.code);
+
+    for (const epciItem of epci.filter((e) => {
+      return e.membres.find((m) =>
+        communesInDepartement.some((c) => c.code === m.code)
+      );
+    })) {
+      const exist = aides.some(
+        (aide: Omit<Aide, "amount">) =>
+          aide.collectivity.kind === "epci" &&
+          (aide.collectivity.code === epciItem.code
+            || aide.collectivity.value === epciItem.code)
+      );
+
+      writeFileSync(file_path,
+        `| ${epciItem.type} | ${epciItem.nom} | ${epciItem.code} | ${
+          exist ? "✅" : "❔"
+        } | ${exist ? "✅" : "❌"} | ❌ |\n`
+      );
+
+      // for (const commune of communesInDepartement) {
+      //   const exist = aides.some(
+      //     (aide: Omit<Aide, "amount">) =>
+      //       aide.collectivity.kind === "code insee" &&
+      //       aide.collectivity.code === commune.code
+      //   );
+      //
+      //   writeFileSync(file_path,
+      //     `| Commune | ${commune.nom} | ${commune.code} | ${
+      //       exist ? "✅" : "❌"
+      //     } | ${exist ? "✅" : "❌"} | ❌ |\n`
+      //   );
+      // }
+    }
+  }
+}

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -1,5 +1,6 @@
 {
   "code insee - 04019": "https://www.ville-barcelonnette.fr/images/ville-barcelonnette-logo.svg",
+  "code insee - 05061": "https://upload.wikimedia.org/wikipedia/fr/thumb/a/a7/Logo_ville_de_Gap.svg/2880px-Logo_ville_de_Gap.svg.png",
   "code insee - 34142": "https://upload.wikimedia.org/wikipedia/fr/7/7f/Logo_lod%C3%A8ve.jpg",
   "code insee - 76498": "https://upload.wikimedia.org/wikipedia/fr/8/8c/Petit-quevilly-municipalite.jpg",
   "epci - 200023414": "https://upload.wikimedia.org/wikipedia/fr/d/db/Logo_M%C3%A9tropole_Rouen_Normandie_-_2015.svg",

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -1,4 +1,5 @@
 {
+  "code insee - 04019": "https://www.ville-barcelonnette.fr/images/ville-barcelonnette-logo.svg",
   "code insee - 34142": "https://upload.wikimedia.org/wikipedia/fr/7/7f/Logo_lod%C3%A8ve.jpg",
   "code insee - 76498": "https://upload.wikimedia.org/wikipedia/fr/8/8c/Petit-quevilly-municipalite.jpg",
   "epci - 200023414": "https://upload.wikimedia.org/wikipedia/fr/d/db/Logo_M%C3%A9tropole_Rouen_Normandie_-_2015.svg",

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -10,5 +10,6 @@
   "epci - 245400601": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Bassin_de_Pompey.png",
   "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png",
   "epci - 200071223": "https://upload.wikimedia.org/wikipedia/fr/1/18/Logo-ccns-territoire.jpg",
-  "epci - 200070118": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/70/Logo_CC_Val_Sa%C3%B4ne_Centre.svg/560px-Logo_CC_Val_Sa%C3%B4ne_Centre.svg.png"
+  "epci - 200070118": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/70/Logo_CC_Val_Sa%C3%B4ne_Centre.svg/560px-Logo_CC_Val_Sa%C3%B4ne_Centre.svg.png",
+  "epci - 240400440": "https://upload.wikimedia.org/wikipedia/commons/2/2f/Logo_de_la_CCPFML_%282010_%C3%A0_aujourd%27hui%29.jpg"
 }

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -11,5 +11,6 @@
   "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png",
   "epci - 200071223": "https://upload.wikimedia.org/wikipedia/fr/1/18/Logo-ccns-territoire.jpg",
   "epci - 200070118": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/70/Logo_CC_Val_Sa%C3%B4ne_Centre.svg/560px-Logo_CC_Val_Sa%C3%B4ne_Centre.svg.png",
-  "epci - 240400440": "https://upload.wikimedia.org/wikipedia/commons/2/2f/Logo_de_la_CCPFML_%282010_%C3%A0_aujourd%27hui%29.jpg"
+  "epci - 240400440": "https://upload.wikimedia.org/wikipedia/commons/2/2f/Logo_de_la_CCPFML_%282010_%C3%A0_aujourd%27hui%29.jpg",
+  "epci - 200071199": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Logo_Plaine_Limagne_2023.png/960px-Logo_Plaine_Limagne_2023.png"
 }

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -7,5 +7,6 @@
   "epci - 243800935": "https://upload.wikimedia.org/wikipedia/fr/0/04/Lysed_logo.png",
   "epci - 245400601": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Bassin_de_Pompey.png",
   "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png",
-  "epci - 200071223": "https://upload.wikimedia.org/wikipedia/fr/1/18/Logo-ccns-territoire.jpg"
+  "epci - 200071223": "https://upload.wikimedia.org/wikipedia/fr/1/18/Logo-ccns-territoire.jpg",
+  "epci - 200070118": "https://upload.wikimedia.org/wikipedia/fr/thumb/7/70/Logo_CC_Val_Sa%C3%B4ne_Centre.svg/560px-Logo_CC_Val_Sa%C3%B4ne_Centre.svg.png"
 }

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -6,5 +6,6 @@
   "epci - 242200715": "https://upload.wikimedia.org/wikipedia/fr/5/58/Cc-kreiz-breizh.jpg",
   "epci - 243800935": "https://upload.wikimedia.org/wikipedia/fr/0/04/Lysed_logo.png",
   "epci - 245400601": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Bassin_de_Pompey.png",
-  "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png"
+  "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png",
+  "epci - 200071223": "https://upload.wikimedia.org/wikipedia/fr/1/18/Logo-ccns-territoire.jpg"
 }

--- a/scripts/data-fetch/miniatures/fallback-miniatures.json
+++ b/scripts/data-fetch/miniatures/fallback-miniatures.json
@@ -5,5 +5,6 @@
   "epci - 200068682": "https://www.cc-terredeau.fr/UserFiles/1/File/cc-terre-deau-logo-blanchd.png",
   "epci - 242200715": "https://upload.wikimedia.org/wikipedia/fr/5/58/Cc-kreiz-breizh.jpg",
   "epci - 243800935": "https://upload.wikimedia.org/wikipedia/fr/0/04/Lysed_logo.png",
-  "epci - 245400601": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Bassin_de_Pompey.png"
+  "epci - 245400601": "https://upload.wikimedia.org/wikipedia/commons/3/3c/Logo_Bassin_de_Pompey.png",
+  "epci - 200069953": "https://upload.wikimedia.org/wikipedia/commons/5/5d/CCPEIDF.png"
 }

--- a/scripts/generate-aides-collectivities.js
+++ b/scripts/generate-aides-collectivities.js
@@ -14,10 +14,20 @@ import rules from "../publicodes-build/index.js";
 const engine = new Publicodes(rules);
 const ruleNames = Object.keys(rules);
 
+const rules_to_skip = [
+  "aides . commune",
+  "aides . intercommunalité",
+  "aides . département",
+  "aides . région",
+  "aides . état",
+  "aides . montant",
+  "aides . forfait mobilités durables",
+];
+
 const aidesRuleNames = ruleNames.filter((ruleName) => {
   if (ruleName.startsWith("aides .")) {
     if (!engine.getRule(ruleName).rawNode.titre) {
-      if (ruleName.split(" . ").length === 2) {
+      if (ruleName.split(" . ").length === 2 && !rules_to_skip.includes(ruleName)) {
         console.warn(`No title for ${ruleName}`);
       }
       return false;
@@ -41,6 +51,7 @@ const res = Object.fromEntries(
 );
 
 fs.writeFileSync(getDataPath("aides-collectivities.json"), JSON.stringify(res));
+console.log(`${aidesRuleNames.length} aides écrites.`);
 
 /// Utils
 

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3611,6 +3611,34 @@ aides . cc nievre et somme:
   dernière mise à jour: 13/08/2025
   date de fin: 30/06/2026
 
+aides . cc val-de-saone-centre:
+  remplace: intercommunalité
+  titre: Communauté de communes Val-de-Saône-Centre
+  description: >
+    Subvention pour l’achat de votre vélo à assistance électrique (neuf ou
+    d’occasion) ou de votre kit d’électrification.
+
+    
+    La demande de subvention doit être faite dans les 6 mois suivant l'achat du
+    vélo ou du kit d'électrification.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Val de Saône Centre'
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . adapté
+          - vélo . motorisation
+  valeur:
+    variations:
+      - si: vélo . motorisation
+        alors: 50 €
+      - si: vélo . état . neuf
+        alors: 200 €
+      - sinon: 100 €
+  lien: https://www.ccvsc01.org/primevelo
+  dernière mise à jour: 13/08/2025
+  date de fin: 30/06/2026
+
 aides . aurillac:
   remplace: intercommunalité
   titre: Communauté d'agglomération du Bassin d'Aurillac

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -655,13 +655,17 @@ aides . blacé:
   dernière mise à jour: 14/08/2025
   date de fin: 31/12/2025
 
+# TODO: à relire en 2026
 aides . charlieu-belmont:
   remplace: commune
   titre: Charlieu-Belmont Communauté
   description: >
-    Aide à l'achat OU aide à la réparation de VAE et de vélos musculaires à
-    usage personnel, neufs ou occasions chez les réparateurs / garages
-    spécialisés au titre de l'exercice 2024.
+    Aide pour l'achat de VAE ou vélos musculaires, neufs ou d'occasion, achetés
+    auprès d'un vendeur de cycle ou un magasin spécialisé dans le sport.
+
+
+    La demande dispose de 60 jours pour transmettre son dossier complet après
+    facturation.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Charlieu-Belmont'
@@ -669,6 +673,7 @@ aides . charlieu-belmont:
   valeur: 20% * vélo . prix
   plafond: 100€
   lien: https://www.charlieubelmont.com/environnement/plan-climat-air-energie-territorial/mobilite/
+  dernière mise à jour: 22/08/2025
 
 aides . unieux:
   remplace: commune
@@ -7307,6 +7312,38 @@ aides . ceyrat:
         alors: 150€
       - sinon: 0€
   lien: https://www.ceyrat.fr/votre-commune/services-municipaux/aides-communales/
+  dernière mise à jour: 22/08/2025
+
+# NOTE: dépôt des demandes jusqu'au 31 octobre 2025, à vérifier en 2026
+aides . cébazat:
+  remplace: commune
+  titre: Ville de Cébazat
+  description: >
+    Afin de développer la pratique du vélo en ville et ainsi favoriser les
+    modes de déplacement doux, la Ville propose 4 aides à l'achat d'un vélo à
+    assistance électrique et le prêt de vélos à assistance électrique. Clôture
+    des demandes le 31 octobre 2025.
+  applicable si: 
+    toutes ces conditions:
+      - localisation . code insee = '63063'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . motorisation
+          - vélo . pliant
+  valeur:
+    variations:
+      - si: vélo . pliant
+        alors: 50€
+      - si: vélo . cargo
+        alors: 200€
+      - si: vélo . électrique
+        alors: 150€
+      - si: vélo . motorisation
+        alors: 100€
+  lien: https://www.cebazat.fr/actualites/plan-velo-communal-pret-aides-financieres-2/
+  dernière mise à jour: 22/08/2025
+  date de fin: 31/10/2025
 
 aides . baud:
   remplace: commune

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7719,6 +7719,7 @@ aides . cacl:
         alors: 300€
   plafond: 50% * vélo . prix
   lien: https://www.cacl-guyane.fr/achetez-un-velo-avec-la-cacl/
+  dernière mise à jour: 12/08/2025
 
 aides . crestois et pays de saillans:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7707,12 +7707,14 @@ aides . grand besançon:
   titre: Grand Besançon Métropole
   description: >
     Grand Besançon Métropole propose une aide à l'achat d'un vélo à assistance
-    électrique neuf.
+    électrique neuf. Le prix d'achat du vélo doit être inférieur ou égal à
+    3000 €.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CU Grand Besançon Métropole'
       - demandeur . âge . majeur
       - revenu fiscal de référence par part <= 20781€/an
+      - vélo . prix <= 3000€
       - vélo . état . neuf
       - vélo . électrique
   valeur: 25% * vélo . prix
@@ -7722,6 +7724,7 @@ aides . grand besançon:
         alors: 400€
       - sinon: 200€
   lien: https://www.grandbesancon.fr/demarche-administrative/subvention-pour-lachat-dun-velo-electrique/
+  dernière mise à jour: 13/08/2025
 
 aides . haut vallespir:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -1668,7 +1668,7 @@ aides . carpiquet:
   valeur: 150€
   lien: https://www.carpiquet.fr/wp-content/uploads/2024/01/CONVENTION-AIDE-FINANCIERE-VAE-ET-TROTTINETTE-ELECTRIQUE-ANNEE-2024.pdf
 
-# NOTE: vérification faite le 10/04/2025. Aide reconduite en 2025. Lien corrigé.
+# TODO: à vérifier en 2026
 aides . ifs:
   remplace: commune
   titre: Ville d'Ifs
@@ -1897,6 +1897,7 @@ aides . saint-germain la blanche herbe:
       - vélo . électrique
   valeur: 100€
   lien: https://www.mairie-stgermainblancheherbe.fr/29-actualites/658-aide-pour-l-achat-d-un-velo-electrique
+
 # NOTE: informations pour 2023, à vérifier en 2025
 aides . trouville sur mer:
   remplace: commune

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -79,6 +79,7 @@ aides . ile de france:
         alors: 100 €
       - sinon: 0 €
   lien: "https://www.iledefrance-mobilites.fr/le-reseau/services-de-mobilite/velo/prime-achat-velo"
+  dernière mise à jour: 12/08/2025
 
 aides . occitanie:
   remplace: région

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -1410,12 +1410,11 @@ aides . toulon:
   lien: https://metropoletpm.fr/demarches/aide-lachat-dun-velo-assistance-electrique-vae
   dernière mise à jour: 29/07/2025
 
-# TODO: à vérifier en 2025
 aides . provence verte:
   remplace: intercommunalité
   titre: Agglomération Provence Verte
   description: >
-    Aide intercommunale est prévue pour l'année 2024 pour tout achat de vélo
+    Aide intercommunale est prévue pour l'année 2025 pour tout achat de vélo
     neuf (type VTC) à assistance électrique ou non.
   applicable si: 
     toutes ces conditions:
@@ -1435,6 +1434,8 @@ aides . provence verte:
         plafond: 100€
     - sinon: 0€
   lien: https://www.caprovenceverte.fr/vie-pratique/transport-mobilite/aide-a-lacquisition-dun-velo-en-provence-verte/
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
 aides . bretagne romantique:
   remplace: intercommunalité
@@ -2765,44 +2766,6 @@ aides . grand avignon:
   lien: https://www.grandavignon.fr/fr/actualites/aide-lachat-de-velo-assistance-electrique
   dernière mise à jour: 29/07/2025
 
-aides . luberon:
-  remplace: intercommunalité
-  titre: Luberon Monts de Vaucluse
-  description: >
-     Lancée le 16 septembre 2020 par LMV Agglomération, l'opération "LMV vous
-     met en selle" vous aide à acheter un vélo, neuf ou d'occasion, avec ou
-     sans assistance électrique. 
-  applicable si: 
-    toutes ces conditions:
-      - localisation . epci = 'CA Luberon Monts de Vaucluse'
-      - demandeur . âge >= 16 an
-      - une de ces conditions:
-          - vélo . électrique
-          - toutes ces conditions:
-              - vélo . mécanique
-              - vélo . état . neuf
-  valeur: 30% * vélo . prix
-  plafond:
-    variations:
-      - si:
-          toutes ces conditions:
-            - vélo . électrique
-            - une de ces conditions:
-                - toutes ces conditions:
-                    - vélo . état . neuf
-                    - vélo . prix <= 2500€
-                - toutes ces conditions:
-                    - vélo . état . occasion
-                    - vélo . prix <= 1500€
-        alors: 300€
-      - si:
-          toutes ces conditions:
-            - vélo . mécanique
-            - vélo . prix <= 1000€
-        alors: 200€
-      - sinon: 0€
-  lien: https://www.luberonmontsdevaucluse.fr/acces/mes-demarches/mobilite/une-subvention-pour-lachat-dun-velo/
-
 # NOTE: plus de page sur le site, seulement un formulaire de demande est disponible. A vérifier en 2025
 aides . kremlin-bicetre:
   remplace: commune
@@ -3346,6 +3309,7 @@ aides . sophia antipolis:
                 plafond: 500€
             - sinon: 0€
   lien: https://www.agglo-sophiaantipolis.fr/vivre-et-habiter/se-deplacer/le-velo/demande-subvention-aide-a-lacquisition/demande-aide-achat-a-partir-du-1er-septembre-2023-inclus
+  dernière mise à jour: 14/08/2025
 
 aides . mougins:
   remplace: commune
@@ -6853,7 +6817,9 @@ aides . witry-lès-reims:
 aides . golf de saint-tropez:
   remplace: intercommunalité
   titre: Golf de Saint-Tropez
-  description: Prime a l'acquisition d'un vélo à assistance électrique (VAE).
+  description: >
+    Prime a l'acquisition d'un vélo à assistance électrique (VAE) neuf. La
+    demande doit être formulée dans les 2 mois suivant l'achat du vélo.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Golfe de Saint-Tropez'
@@ -6862,6 +6828,7 @@ aides . golf de saint-tropez:
       - vélo . état . neuf
   valeur: 200€
   lien: https://www.golfe-sainttropez.fr/actualite/prime-exceptionnelle-de-200e-pour-lachat-dun-velo-a-assistance-electrique/
+  dernière mise à jour: 14/08/2025
 
 aides . labège:
   remplace: commune

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -198,6 +198,7 @@ aides . ardèche:
   valeur: 10% * vélo . prix
   plafond: 200€
   lien: https://www.ardeche.fr/2084-vae.htm
+  dernière mise à jour: 14/08/2025
 
 aides . paris:
   remplace: commune
@@ -3622,6 +3623,7 @@ aides . aurillac:
   valeur: 25% * vélo . prix
   plafond: 300€
   lien: https://www.stabus.fr/fr/velocab/
+  dernière mise à jour: 14/08/2025
 
 # NOTE: fixée jusqu'à 2026, à vérifier en 2027 (dans la limite des crédits)
 aides . terre des 2 caps:
@@ -4840,6 +4842,7 @@ aides . arche agglo:
         alors: 300€
       - sinon: 150€
   lien: https://www.archeagglo.fr/vivre-ici/transport-mobilite/velos/
+  dernière mise à jour: 14/08/2025
 
 aides . annonay:
   remplace: intercommunalité
@@ -4869,6 +4872,7 @@ aides . annonay:
         alors: 300€
       - sinon: 150€
   lien: https://www.annonayrhoneagglo.fr/agir-pour-lenvironnement/mobilite
+  dernière mise à jour: 14/08/2025
 
 # TODO: à vérifier en 2026
 aides . lorient agglo:
@@ -7743,13 +7747,12 @@ aides . haut vallespir:
   valeur: 100 € 
   lien: https://www.haut-vallespir.fr/?page_id=5276
 
-# TODO: à mettre à jour en 2025
 aides . val de drôme:
   remplace: intercommunalité
   titre: Communauté de communes du Val de Drôme en Biovallée
   description: >
     Aide versée dans la limite de l'enveloppe budgétaire allouée (15 000€ pour
-    2024).
+    2025).
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Val de Drôme en Biovallée'
@@ -7760,7 +7763,7 @@ aides . val de drôme:
           - vélo . motorisation
   valeur:
     variations:
-      - si: revenu fiscal de référence par part <= 14089 €/an
+      - si: revenu fiscal de référence par part <= 15400 €/an
         alors: 
           variations:
             - si: vélo . électrique
@@ -7776,6 +7779,7 @@ aides . val de drôme:
       - si: vélo . électrique ou mécanique
         alors: 40% * vélo . prix
   lien: https://www.valdedrome.com/8257-bonus-velo.htm
+  dernière mise à jour: 13/08/2025
 
 aides . cacl:
   remplace: intercommunalité
@@ -7814,6 +7818,7 @@ aides . crestois et pays de saillans:
   valeur: 25% * vélo . prix
   plafond: 250€
   lien: https://www.cccps.fr/demarches/aide-pour-lelectrification-dun-velo-classique/
+  dernière mise à jour: 13/08/2025
 
 # TODO: à mettre à jour en 2026
 aides . binic etables sur mer:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5193,19 +5193,17 @@ aides . ca mauges communauté:
   lien: https://www.mooj.fr/mobilites-alternatives/modes-actifs/vae-aide-achat/
   dernière mise à jour: 22/08/2025
 
-
-
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 octobre 2025, à vérifier en 2026
 aides . cholet:
   remplace: intercommunalité
   titre: Cholet Agglomération
   description: >
     Subvention pour l'achat d'un vélo neuf à assistance électrique. Le vélo
     devra être acheté auprès d'un revendeur professionnel partenaire de cette
-    opération et ayant signé une charte d'engagement avec Cholet Agglomération
+    opération et ayant signé une charte d'engagement avec Cholet Agglomération.
 
 
-    Fin de l'opération le 31 décembre 2024.
+    Fin de l'opération le 31 octobre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA Cholet Agglomération'
@@ -5217,13 +5215,19 @@ aides . cholet:
   valeur: 25% * vélo . prix
   plafond: 250€
   lien: https://www.cholet.fr/dossiers/dossier_5364_aide+velo+assistance+electrique.html
+  dernière mise à jour: 22/08/2025
+  date de fin: 31/10/2025
 
 aides . saumur val de loire:
   remplace: intercommunalité
-  titre: Communauté d'Agglomération Saumur Val de Loire
+  titre: Saumur Val de Loire Agglomération
   description: >
     Aide à l'acquisition de vélo à assistance électrique neuf ou d'occasion à
     usage personnel.
+
+
+    La demande d'aide doit être effectuée dans les deux mois suivants
+    l'acquisition du vélo.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA Saumur Val de Loire'
@@ -5233,6 +5237,7 @@ aides . saumur val de loire:
   valeur: 10% * vélo . prix
   plafond: 100€
   lien: https://www.saumurvaldeloire.fr/se-deplacer-a-velo
+  dernière mise à jour: 22/08/2025
 
 # NOTE: à vérifier en 2026
 aides . loire layon aubance:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -599,13 +599,14 @@ aides . givors:
   plafond: 20% * vélo . prix
   lien: https://www.givors.fr/cadre-de-vie/environnement/aide-a-lacquisition-dun-velo/
 
+# TODO: à vérifier en 2026
 aides . blacé:
   remplace: commune
   titre: Ville de Blacé
   description: >
     La commune de Blacé a adopté́ un dispositif d'aides financières à
     l'acquisition de vélos à assistance électrique (VAE), neufs ou d'occasion
-    jusqu'au 31 décembre 2024.
+    jusqu'au 31 décembre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '69023'
@@ -613,6 +614,8 @@ aides . blacé:
   valeur: 25% * vélo . prix
   plafond: 200€
   lien: https://mairie-blace.fr/fr/rb/1541490/prime-velo
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
 aides . charlieu-belmont:
   remplace: commune
@@ -2634,16 +2637,33 @@ aides . montpellier:
   plafond: 200€
   lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
 
+# TODO: à vérifier en 2027
+aides . montpellier vélo cargo pro:
   remplace: intercommunalité
   titre: Montpellier Méditerranée Métropole
   description: >
+    Jusqu'à 1000€ d'aide pour l'achat d'un vélo cargo ou triporteur à
+    assistance électrique neuf pour les professionnel·les en activités sur le
+    territoire de Montpellier Méditerranée Métropole.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'Montpellier Méditerranée Métropole'
       - demandeur . âge . majeur
+      - vélo . cargo électrique
       - vélo . état . neuf
+      - est professionnel
   valeur: 50% * vélo . prix
+  plafond: 1000€
   lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
+  avec:
+    est professionnel:
+      question: >
+        Êtes-vous un professionnel exerçant une activité sur le territoire de
+        Montpellier Méditerranée Métropole ?
+      type: booléen
+      par défaut: oui
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2026
 
 aides . sète:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2601,7 +2601,7 @@ aides . les sables d'olonne:
   lien: https://www.lsoagglo.fr/vivreauxolonnes/vie-pratique/mobilites/subventions-velo/
   dernière mise à jour: 22/08/2025
 
-# NOTE: informations pour 2024, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . vallons du lyonnais:
   remplace: intercommunalité
   titre: Communauté de Communes des Vallons du Lyonnais
@@ -2614,7 +2614,8 @@ aides . vallons du lyonnais:
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC des Vallons du Lyonnais (CCVL)'
-      - vélo . prix <= 3000€
+      - vélo . prix <= 3000 €
+      - revenu fiscal de référence par part <= 20000 €/an
       - une de ces conditions:
           - vélo . électrique
           - vélo . adapté
@@ -2626,8 +2627,10 @@ aides . vallons du lyonnais:
         alors: 400€
       - sinon: 200€
   lien: https://www.ccvl.fr/vivre-au-quotidien/mobilites/vae-aides-a-lachat-et-location-longue-duree/
+  dernière mise à jour: 22/08/2025
+  date de fin: 31/12/2025
 
-# NOTE: limite au 6 décembre 2024, à vérifier en 2025
+# TODO: à relire en 2026
 aides . pays de l'ozon:
   remplace: intercommunalité
   titre: Pays de l'Ozon
@@ -2636,10 +2639,12 @@ aides . pays de l'ozon:
     vélo cargo, VAE pliant, vélo électrifié chez un professionnel ou adapté aux 
     personnes porteuses de handicaps.
     
-    Dossier à déposer avant le 6 décembre 2024.
+    Dossier à déposer avant le 5 décembre 2025 et maximum trois mois après
+    l'achat.
   applicable si:
     toutes ces conditions:
       - localisation . epci = "CC du Pays de l'Ozon"
+      - vélo . prix >= 200€
       - une de ces conditions:
           - vélo . électrique
           - vélo . motorisation
@@ -2648,6 +2653,8 @@ aides . pays de l'ozon:
   valeur: 200€
   plafond: vélo . prix
   lien: https://www.pays-ozon.com/vivre-dans-le-pays-de-lozon/les-transports/subvention-velo-electrique/
+  dernière mise à jour: 22/08/2025
+  date de fin: 05/12/2025
 
 # NOTE: le plan hérault-vélo 2025-2030 en cours de construction, à vérifier en 2025
 aides . département hérault:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -444,6 +444,7 @@ aides . villefranche beaujolais saône:
       valeur: vélo . prix - (aides . état + aides . département + aides . région + aides . commune)
       plancher: 0€
   dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
 aides . ville-sur-jarnioux:
   remplace: commune
@@ -2125,6 +2126,31 @@ aides . vienne condrieu:
       - vélo . état . neuf
   valeur: 150€
   lien: https://www.vienne-condrieu-agglomeration.fr/nos-services-au-quotidien/deplacements/faire-du-velo/aide-financiere-vae/
+  dernière mise à jour: 22/08/2025
+
+# NOTE: valable depuis 2023 jusqu'à abrogation, à vérifier en 2025
+# NOTE: plus référencée depuis le site en janvier 2025.
+aides . pays de l'arbresle:
+  remplace: intercommunalité
+  titre: Communauté de Communes du Pays de L'Arbresle
+  description: >
+    La Communauté de Communes du Pays de L'Arbresle subventionne jusqu'à par
+    foyer pour l'achat d'un Vélo à Assistance Electrique (VAE), un vélo spécial
+    (vélo cargo, vélo rallongé, vélo adapté à un handicap) ou un kit
+    d'électrification, qu'il soit neuf ou d'occasion.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CC du Pays de l'Arbresle (CCPA)"
+      - une de ces conditions:
+          - vélo . cargo
+          - vélo . adapté
+          - vélo . motorisation
+          - toutes ces conditions:
+              - vélo . électrique
+              - vélo . prix <= 3000€
+  valeur: 50% * vélo . prix
+  plafond: 250€
+  lien: https://www.paysdelarbresle.fr/aide-a-lachat-dun-velo-a-assistance-electrique/
   dernière mise à jour: 22/08/2025
 
 aides . pont-de-beauvoisin:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2741,7 +2741,7 @@ aides . romagnat:
   lien: https://www.ville-romagnat.fr/cadre-de-vie-urbanisme/developpement-durable/velo-electrique/
 
 # TODO: ont développé leur propre simulateur, leur partager le lien ?
-# NOTE: reconduite pour 2024, à vérifier en 2025
+# NOTE: reconduite pour 2025, à vérifier en 2026
 aides . cournon d'auvergne:
   remplace: commune
   titre: Ville de Cournon-d'Auvergne
@@ -2764,6 +2764,8 @@ aides . cournon d'auvergne:
       - sinon: 100€
   plafond: vélo . prix
   lien: https://www.cournon-auvergne.fr/actualites/aide-pour-lachat-dun-velo-a-assistance-electrique/
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
 aides . grand avignon:
   remplace: intercommunalité
@@ -3100,7 +3102,62 @@ aides . montagnole:
   valeur: 200€
   lien: https://www.mairie-montagnole.fr/vae/
 
-# TODO: grand chambéry, à vérifier en 2025 : https://www.grandchambery.fr/mes-demarches/aides-energies/cheque-velo-a-assistance-electrique
+# NOTE: possède un simulateur qui ne fonctionne pas, à contacter
+# TODO: grand chambéry, à vérifier en 2026 : https://www.grandchambery.fr/mes-demarches/aides-energies/cheque-velo-a-assistance-electrique
+aides . grand chambéry:
+  remplace: intercommunalité
+  titre: Grand Chambéry l'Agglomération
+  description: >
+    Chèque utilisable dans les deux mois à compter de son émission, pour
+    l'achat d'un vélo à assistance électrique (VAE) ou d'un vélo cargo
+    électrique neuf auprès d'un vélociste partenaire avec Grand Chambéry (liste
+    consultable sur grandchambery.fr).
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CA du Grand Chambéry'
+      - demandeur . âge . majeur
+      - revenu fiscal de référence par part <= 30800 €/an
+      - vélo . état . neuf
+      - une de ces conditions:
+          - toutes ces conditions:
+              - vélo . électrique simple
+              - vélo . prix >= 1400€
+              - vélo . prix <= 3500€
+          - toutes ces conditions:
+              - vélo . cargo électrique
+              - vélo . prix >= 3500€
+              - vélo . prix <= 6000€
+  valeur: 
+    somme:
+      - variations:
+          - si: salarié d'une entreprise partenaire
+            alors: 100€
+          - sinon: 0€
+      - variations:
+          - si: vélo . cargo électrique
+            alors:
+              variations:
+                - si: revenu fiscal de référence par part <= 15400 €/an
+                  alors: 1500€
+                - sinon: 800€
+          - sinon:
+              variations:
+                - si: revenu fiscal de référence par part <= 15400 €/an
+                  alors: 1000€
+                - sinon: 500€
+  lien: https://www.grandchambery.fr/mes-demarches/aides-ener
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
+  avec:
+    salarié d'une entreprise partenaire:
+      question: >
+        Êtes-vous salarié·e d'une entreprise ayant mis en place un Plan de Mobilité Employeurs avec Grand Chambéry ou le Forfait Mobilité Durable ?
+      description: >
+        Liste des entreprises partenaires consultable sur le site de Grand
+        Chambéry :
+        https://www.grandchambery.fr/mes-demarches/aides-energies/cheque-velo-a-assistance-electrique.
+      type: booléen
+      par défaut: oui
 
 # NOTE: valide pour 2024, à vérifier en 2025
 aides . saint alban leysse:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -4349,7 +4349,7 @@ aides . granville:
   abattement: aides . état
   lien: https://www.ville-granville.fr/vivre-au-quotidien-demarches-services/se-deplacer/aide-a-lachat-dun-velo/
 
-# NOTE: infos pour 2023, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . saint-louis:
   remplace: intercommunalité
   titre: Saint-Louis Agglomération
@@ -4375,6 +4375,7 @@ aides . saint-louis:
       - sinon: 100 €
   plafond: 50% * vélo . prix
   lien: https://www.agglo-saint-louis.fr/fr/au-quotidien/mobilite/prime-velo
+  dernière mise à jour: 14/08/2025
 
 aides . saint-pair-sur-mer:
   remplace: commune
@@ -4449,7 +4450,8 @@ aides . blois:
   lien: https://www.agglopolys.fr/1247-le-velo-a-assistance-electrique.htm
   dernière mise à jour: 13/08/2025
 
-# NOTE: fin de validité en 2024, à vérifier en 2025
+# NOTE: fin de validité pas claire
+# TODO: à vérifier en 2026
 aides . epinal:
   remplace: intercommunalité
   titre: Agglomération Épinal
@@ -4460,6 +4462,7 @@ aides . epinal:
   applicable si: 
     toutes ces conditions:
       - localisation . epci = "CA d'Epinal"
+      - demandeur . âge . majeur
       - une de ces conditions:
           - vélo . électrique ou mécanique
           - vélo . motorisation
@@ -4473,6 +4476,7 @@ aides . epinal:
       - si: vélo . mécanique
         alors: 100€
   lien: https://www.agglo-epinal.fr/se-deplacer/velo/subvention-a-lachat-dun-vae/
+  dernière mise à jour: 14/08/2025
 
 aides . rochefort:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7993,6 +7993,34 @@ aides . commune barcelonette:
   dernière mise à jour: 14/08/2025
   date de fin: 31/12/2025
 
+aides . commune gap:
+  remplace: commune
+  titre: Commune de Gap
+  description: >
+    Aide pour l'achat d'un vélo à assistance électrique neuf ou d'un kit
+    d'électrification au près d'un commerçant professionnel implanté dans la
+    commune.
+
+
+    Dispositif disponible jusqu'au 31 octobre 2025.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '05060'
+      - vélo . état . neuf
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . motorisation
+          - vélo . électrique
+  valeur: 25% * vélo . prix
+  plafond: 
+    variations:
+      - si: vélo . électrique
+        alors: 200 €
+      - sinon: 150 €
+  lien: https://www.ville-gap.fr/aides-financieres-ville/
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/10/2025
+
 aides . territoire de l'ouest:
   remplace: intercommunalité
   titre: Territoire de l'Ouest

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3593,6 +3593,24 @@ aides . puisaye forterre:
   dernière mise à jour: 13/08/2025
   date de fin: 31/12/2025
 
+aides . cc nievre et somme:
+  remplace: intercommunalité
+  titre: Communauté de communes Nièvre et Somme
+  description: >
+    Subvention pour l'achat d'un vélo à assistance électrique neuf de 25% du
+    prix d'achat TTC, dans la limite de 100 € par foyer.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Nièvre et Somme'
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . adapté
+  valeur: 25% * vélo . prix
+  plafond: 100€
+  lien: https://www.nievresomme.fr/medias/files/reglement-ccns-vae.pdf
+  dernière mise à jour: 13/08/2025
+  date de fin: 30/06/2026
+
 aides . aurillac:
   remplace: intercommunalité
   titre: Communauté d'agglomération du Bassin d'Aurillac

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -247,7 +247,7 @@ aides . paris:
 aides . saint-étienne:
   remplace: intercommunalité
   titre: Saint-Étienne Métropole
-  description: Aide à l'achat d'un vélo à assistance électrique neuf (2024).
+  description: Aide à l'achat d'un vélo à assistance électrique neuf (2025).
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'Saint-Étienne Métropole'
@@ -258,7 +258,33 @@ aides . saint-étienne:
       - si: foyer . imposable
         alors: 200€
       - sinon: 100€
-  lien: https://www.saint-etienne-metropole.fr/form/aide-VAE-2024
+  lien: https://www.saint-etienne-metropole.fr/form/aide-VAE-2025
+  dernière mise à jour: 22/08/2025
+
+# TODO: à relire en 2026
+aides . cc monts du pilat:
+  remplace: intercommunalité
+  titre: Communauté de communes des Monts du Pilat
+  description: >
+    Jusqu'à 200 euros d'aide pour l'achat de vélos musculaires urbain,
+    tout-terrain, à assistance électrique ou VTT à assistance électrique, «
+    speed bikes », utilitaire ou familial, musculaire ou à assistance
+    électrique ou la pose d'un kit d'électrification.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC des Monts du Pilat'
+  valeur: 20% * vélo . prix
+  plafond:
+    variations:
+      - si: 
+          une de ces conditions:
+            - vélo . électrique
+            - vélo . adapté
+        alors: 200€
+      - sinon: 100€
+  lien: https://www.cc-montsdupilat.fr/mise-place-dune-aide-a-lachat-dun-velo
+  dernière mise à jour: 22/08/2025
+  date de fin: 31/12/2025
 
 # NOTE: à verifier en 2026
 aides . lyon:
@@ -350,10 +376,13 @@ aides . cc lysed:
     toutes ces conditions:
       - localisation . epci = 'CC Lyon-Saint-Exupéry en Dauphiné'
       - vélo . état . neuf
-  valeur: vélo . prix * 25%
+      - une de ces conditions:
+          - vélo . électrique ou mécanique
+          - vélo . adapté
+  valeur: 25% * vélo . prix 
   plafond: 200€
   lien: https://www.lysed.fr/plan-climat-air-energie/mobilite
-  dernière mise à jour: 09/06/2025
+  dernière mise à jour: 22/08/2025
 
 # TODO: différencier vélo adapté mécanique/électrique
 # TODO: à vérifier en 2026
@@ -1070,6 +1099,10 @@ aides . grenoble:
   remplace: intercommunalité
   titre: Syndicat Mixte des Mobilités de l'Aire Grenobloise et Grenoble Alpes Métropole 
   description: >
+    L'aide à l'achat d'un vélo est **temporairement suspendue** depuis le 16
+    mai 2025.
+
+
     Afin d'encourager les déplacements à vélo et de vous aider dans
     l'acquisition d'un équipement, le Syndicat Mixte des Mobilités de l'Aire
     Grenobloise et Grenoble Alpes Métropole mettent en place une aide à l'achat
@@ -1164,6 +1197,7 @@ aides . grenoble:
             - sinon: 90€
       - sinon: 0€
   lien: https://aidevelo.mobilites-m.fr/
+  dernière mise à jour: 22/08/2025
 
 aides . strasbourg:
   remplace: intercommunalité
@@ -2086,6 +2120,7 @@ aides . vienne condrieu:
       - vélo . état . neuf
   valeur: 150€
   lien: https://www.vienne-condrieu-agglomeration.fr/nos-services-au-quotidien/deplacements/faire-du-velo/aide-financiere-vae/
+  dernière mise à jour: 22/08/2025
 
 aides . pont-de-beauvoisin:
   remplace: commune
@@ -2102,6 +2137,7 @@ aides . pont-de-beauvoisin:
       - vélo . état . neuf
   valeur: 100€
   lien: https://www.mairie-pontdebeauvoisin38.fr/aide-a-lachat-dun-velo-a-assistance-electrique/
+  dernière mise à jour: 22/08/2025
 
 aides . saint-marcellin vercors isère:
   remplace: intercommunalité
@@ -2125,7 +2161,7 @@ aides . saint-marcellin vercors isère:
       alors: 200 €
     - sinon: 100 €
   plafond: 50% * vélo . prix
-  lien: http://www.saintmarcellin-vercors-isere.fr/evenement/9916/4451-toute-l-actualite.htm
+  lien: http://www.saintmarcellin-vercors-isere.fr/evenement/9916/4451-toute-l-actualite.html
 
 aides . montval sur loir:
   remplace: commune
@@ -6822,16 +6858,18 @@ aides . grand angouleme:
           plafond: 150 €
   lien: https://www.grandangouleme.fr/tous-a-velo/
 
+# TODO: à relire en 2026
 aides . massif du vercors:
   remplace: intercommunalité
   titre: Communauté de communes du Massif du Vercors 
   description: >
-    Bonus VAE - Aide à l'achat de vélos à assistance électrique.
+    Bonus VAE - Aide à l'achat de vélos à assistance électrique chez un
+    vélociste du territoire de la CCMV.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Massif du Vercors'
       - demandeur . âge . majeur
-      - revenu fiscal de référence par part <= 21805 €/an
+      - revenu fiscal de référence par part . revenu de référence <= plafond de ressources
       - vélo . électrique
   valeur:
     variations:
@@ -6843,6 +6881,29 @@ aides . massif du vercors:
               alors: 200 €
             - sinon: 300 €
   lien: https://www.vercors.org/fr/vie-quotidienne/se-deplacer/a-velo/
+  dernière mise à jour: 22/08/2025
+  date de fin: 31/01/2026
+  avec:
+    plafond de ressources:
+      valeur:
+        variations:
+          - si: foyer . personnes = 1
+            alors: 22015 
+          - si: foyer . personnes = 2
+            alors: 32197 
+          - si: foyer . personnes = 3
+            alors: 38719 
+          - si: foyer . personnes = 4
+            alors: 45234 
+          - si: foyer . personnes = 5
+            alors: 51775 
+          - sinon:
+              valeur: 51775 + (6525 * personnes supplémentaires * 1 €/an/personne)
+      unité: €/an
+
+    personnes supplémentaires:
+      valeur: foyer . personnes - 5
+      plancher: 0
 
 aides . portes du luxembourg:
   remplace: intercommunalité
@@ -7917,6 +7978,23 @@ aides . crestois et pays de saillans:
   lien: https://www.cccps.fr/demarches/aide-pour-lelectrification-dun-velo-classique/
   dernière mise à jour: 13/08/2025
 
+# aides . cc baronnies en drome provençale:
+#   remplace: intercommunalité
+#   titre: Communauté de communes des Baronnies en Drôme Provençale
+#   description: >
+#     Aide à l'électrification de vélo classique. La demande de subvention doit
+#     être effectuée dans un délai de 3 mois après la date indiquée sur la
+#     facture de la pose.
+#   applicable si:
+#     toutes ces conditions:
+#       - localisation . epci = 'CC du Crestois et de Pays de Saillans Coeur de Drôme'
+#       - demandeur . âge . majeur
+#       - vélo . motorisation
+#   valeur: 25% * vélo . prix
+#   plafond: 250€
+#   lien: https://www.cccps.fr/demarches/aide-pour-lelectrification-dun-velo-classique/
+#   dernière mise à jour: 13/08/2025
+
 # TODO: à mettre à jour en 2026
 aides . binic etables sur mer:
   remplace: commune
@@ -8864,7 +8942,7 @@ aides . bassin-pompey:
       - demandeur . âge . majeur
   valeur:
     variations:
-      - si: revenu fiscal de référence par part <= plafond de ressources
+      - si: revenu fiscal de référence par part . revenu de référence <= plafond de ressources
         alors: 50% * vélo . prix
       - sinon: 20% * vélo . prix
   plafond:
@@ -8875,7 +8953,7 @@ aides . bassin-pompey:
             - vélo . adapté
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= plafond de ressources
+            - si: revenu fiscal de référence par part . revenu de référence <= plafond de ressources
               alors: 450 € 
             - sinon: 150 €
       - si:
@@ -8884,13 +8962,13 @@ aides . bassin-pompey:
             - vélo . motorisation
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= plafond de ressources
+            - si: revenu fiscal de référence par part . revenu de référence <= plafond de ressources
               alors: 300 €
             - sinon: 100 €
 
       - sinon:
           variations:
-            - si: revenu fiscal de référence par part <= plafond de ressources
+            - si: revenu fiscal de référence par part . revenu de référence <= plafond de ressources
               alors: 135 €
             - sinon: 45 €
   lien: https://planvelo.bassinpompey.fr/primevelo

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -352,6 +352,7 @@ aides . cc lysed:
   dernière mise à jour: 09/06/2025
 
 # TODO: différencier vélo adapté mécanique/électrique
+# TODO: à vérifier en 2026
 aides . saône-beaujolais:
   remplace: intercommunalité
   titre: Communauté de communes Saône Beaujolais
@@ -360,6 +361,9 @@ aides . saône-beaujolais:
     traditionnels, de vélos à assistance électrique ou de kit d'électrification
     à destination des habitant·es de la Communauté de Communes
     Saône-Beaujolais.
+
+
+    L'achat doit être effectué chez un professionnel du territoire de la CCSB.
   applicable si: localisation . epci = 'CC Saône-Beaujolais'
   valeur: 30% * vélo . prix
   plafond:
@@ -367,15 +371,16 @@ aides . saône-beaujolais:
       - si: 
           une de ces conditions:
             - vélo . mécanique 
-            - vélo . adapté
         alors: 200€
       - si: 
           une de ces conditions:
             - vélo . électrique
             - vélo . motorisation
-        alors: 600€
+            - vélo . adapté
+        alors: 400€
       - sinon: 0€
-  lien: http://www.ccsb-saonebeaujolais.fr/fr/information/10135/aide-achat-un-velo
+  lien: https://ccsb-saonebeaujolais.fr/au-quotidien/se-deplacer/aide-a-lachat-dun-velo/
+  dernière mise à jour: 14/08/2025
 
 # NOTE: jusqu'au 31 décembre 2026
 # TODO: test intégration sur le plafond

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -1291,16 +1291,21 @@ aides . pays de saverne:
     La prime de la collectivité locale est de 10% du prix d'achat du vélo
     plafonnée à 100€ pour les ménages dont le revenu fiscal est inférieur ou
     égal à 15 400 €.
+
+
+    Demande à effectuer dans les 6 mois suivant l'achat du vélo.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Pays de Saverne'
+      - demandeur . âge . majeur
       - vélo . électrique
       - revenu fiscal de référence par part <= 15400 €/an
   valeur: 100€
   plafond: 10% * vélo . prix
   lien: http://www.paysdesaverne.fr/Actions/VelosElec/2019-04-VAE-velo-saverne.htm
+  dernière mise à jour: 14/08/2025
 
-# NOTE: renouvelé jusqu'au 31 décembre 2024
+# TODO: à vérifier en 2026
 aides . illkirch:
   remplace: commune
   titre: Ville de Illkirch-Graffenstaden
@@ -1323,6 +1328,7 @@ aides . illkirch:
         alors: 100€
       - sinon: 200€
   lien: http://www.illkirch.eu/aide-a-lachat-dun-velo-a-assistance-electrique/
+  dernière mise à jour: 14/08/2025
 
 aides . vendenheim:
   remplace: commune
@@ -1628,6 +1634,7 @@ aides . thue et mue:
         alors: 150€
       - sinon: 100€
   lien: https://www.thueetmue.fr/aide-lachat-dun-velo-electrique
+  dernière mise à jour: 14/08/2025
 
 # NOTE: infos pour 2023, pas d'infos pour 2024, à vérifier en 2025
 aides . hermanville-sur-mer:
@@ -2879,7 +2886,9 @@ aides . pau:
             - vélo . motorisation
         alors: 200€
       - sinon: 0€
-  lien: https://www.pau.fr/article/aide-a-lachat-velo--profitez-dun-coup-de-pouce-pour-changer-de-braquet
+  lien: https://www.pau.fr/actualites/aide-a-lachat-velo--profitez-dun-coup-de-pouce-pour-changer-de-braquet
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/01/2025
 
 aides . lescar:
   remplace: commune
@@ -4528,6 +4537,9 @@ aides . saintes:
       un kit d'électrification ou 400 € pour un vélo cargo à assistance
       électrique neuf dans la limite de l'enveloppe budgétaire annuelle
       allouée.
+
+
+      La demande doit être effectuée au maximum 30 jours après l'achat.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA "Saintes - Grandes Rives - L'Agglo"'
@@ -4543,7 +4555,8 @@ aides . saintes:
             - vélo . état . neuf
         alors: 400€
       - sinon: 200€
-  lien: https://www.agglo-saintes.fr/l-agglo-au-quotidien/transports-et-mobilites/530-aide-a-l-achat-d-un-velo-a-assistance-electrique.html
+  lien: https://agglo-saintes.fr/au-quotidien/mobilite-et-transport/les-aides-financieres-mobilites/
+  dernière mise à jour: 14/08/2025
 
 # TODO: à vérifier en 2026
 aides . dieppe:
@@ -5187,7 +5200,8 @@ aides . laval:
       - vélo . état . neuf
       - vélo . cargo électrique
   valeur: 300€
-  lien: https://www.agglo-laval.fr/utile-au-quotidien/transports-et-mobilites/lagglo-a-velo/prime-a-lachat-dun-velo-cargo
+  lien: https://www.agglo-laval.fr/utile-au-quotidien/transports-et-mobilites/lagglo-a-velo/passez-au-velo-cargo
+  dernière mise à jour: 14/08/2025
 
 aides . ville de talant:
   remplace: commune
@@ -5868,28 +5882,39 @@ aides . rives de moselle:
       - sinon: 0€
   lien: https://www.rivesdemoselle.fr/mobilites/#tousavelo
 
-# NOTE: peu d'informations, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . saint-avold:
   remplace: intercommunalité
   titre: Communauté d'Agglomération Saint-Avold Synergie
   description: >
     Aide à l'achat d'un vélo à assistance électrique de 150€ si acheté dans un
-    magasin du territoire de la CASAS, 50€ sinon. 
+    magasin du territoire de la CASAS, 50€ sinon. Pour 2025, une aide
+    forfaitaire de 50€ est également disponible pour l'installation d'un kit
+    d'électrification. 
+
+
+    Fin des dépôt le 16 septembre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA Saint-Avold Synergie'
-      - vélo . électrique
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . motorisation
   valeur:
     variations:
+      - si: vélo . motorisation
+        alors: 50€
       - si: vélo acheté localement
         alors: 150€
       - sinon: 50€
   lien: https://casas57.fr/nos-competences/ma-mobilite/velo/aide-a-lachat-dun-velo/
+  dernière mise à jour: 14/08/2025
+  date de fin: 16/09/2025
   avec:
     vélo acheté localement:
       type: booléen
       question: Le vélo est-il acheté sur le territoire de la CASAS ?
-      par défaut: non
+      par défaut: oui
 
 aides . montigny les metz:
   remplace: commune
@@ -7184,12 +7209,14 @@ aides . baud:
   valeur: 50€
   lien: https://www.mairie-baud.fr/7252-2/
 
-# NOTE: vérification le 10/04/2025. l'aide est reconduite en 2025 (article de
-# la voix du Nord) mais il n'y a pas encore de page d'information
+# TODO: vérification en 2026
 aides . longuenesse:
   remplace: commune
   titre: Ville de Longuenesse
-  description: Prime vélo sous forme de chèque Happy Kdo pour l'année 2024.
+  description: >
+    Prime vélo sous forme de chèque Happy Kdo pour l'année 2025. L'achat doit
+    être effectué dans un commerce situé sur le territoire de la CAPSO, durant
+    l'année 2025 et la demande déposée avant le 16 janvier 2026.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '62525'
@@ -7199,22 +7226,8 @@ aides . longuenesse:
   valeur: 20% * vélo . prix
   plafond: 100€
   lien: https://www.ville-longuenesse.fr/mon-quotidien/cadre-de-vie/developpement-durable/mobilite-douce
-
-aides . castelnau de médoc:
-  remplace: commune
-  titre: Ville de Castelnau de Médoc
-  description: >
-    Aide à l'acquisition d'un vélo à assistance électrique neuf.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '33104'
-      - demandeur . âge . majeur
-      - revenu fiscal de référence par part <= plafond état
-      - vélo . état . neuf
-      - vélo . électrique
-  valeur: 100€
-  plafond: vélo . prix
-  lien: https://www.mairie-castelnau-medoc.fr/actus/1557-aide-a-l-acquisition-de-velos
+  dernière mise à jour: 14/08/2025
+  date de fin: 16/01/2026
 
 # NOTE: valide jusqu'au 1er octobre 2025 (dans la limite de l'enveloppe
 # budgétaire annuelle), à vérifier en 2025.
@@ -7235,6 +7248,7 @@ aides . saulieu:
   valeur: 100€
   lien: https://www.saulieu-morvan.fr/joomla/tourisme-loisirs
   dernière mise à jour: 13/08/2025
+  date de fin: 01/10/2025
 
 aides . la côtière à montluel:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -173,8 +173,11 @@ aides . grand est:
 
 aides . corse:
   remplace: région
-  titre: Région Corse
-  description: Aide à l'achat des Vélos à Assistance Electrique.
+  titre: Agence d’Aménagement durable, d’Urbanisme et d’Energie de la Corse
+  description: >
+    Aide pour l'achat d'un premier vélo à assistance électrique (neuf ou
+    reconditionné) au sein d'un des vélocistes du Réseau "Muvemucci Altrimenti"
+    agréés par l'AUE.
   applicable si:
     toutes ces conditions:
       - localisation . région = '94'
@@ -182,6 +185,7 @@ aides . corse:
   valeur: 25% * vélo . prix
   plafond: 500€
   lien: https://www.aue.corsica/Aide-a-l-achat-des-Velos-a-Assistance-Electrique_a856.html
+  dernière mise à jour: 22/08/2025
 
 aides . ardèche:
   remplace: département

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -4540,7 +4540,7 @@ aides . saintes:
       - sinon: 200€
   lien: https://www.agglo-saintes.fr/l-agglo-au-quotidien/transports-et-mobilites/530-aide-a-l-achat-d-un-velo-a-assistance-electrique.html
 
-# NOTE: fin de validité en 2024, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . dieppe:
   remplace: commune
   titre: Ville de Dieppe
@@ -4550,11 +4550,10 @@ aides . dieppe:
     accordée, sous condition de ressources.
 
 
-    Date limite de dépôt des dossiers : 31 décembre 2024.
+    Date limite de dépôt des dossiers : 31 octobre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '76217'
-      - vélo . électrique ou mécanique
       - demandeur . âge >= 16 an
       - vélo . électrique ou mécanique
   valeur:
@@ -4564,7 +4563,9 @@ aides . dieppe:
       - si: revenu fiscal de référence par part <= 13489 €/an
         alors: 100€
       - sinon: 50€
-  lien: https://www.dieppe.fr/menus/vie-quotidienne-3/developpement-durable-49/aide-municipale-pour-acquerir-un-velo
+  lien: https://www.dieppe.fr/annuaires/catalogue-des-demarches/detail/acheter-un-velo
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/10/2025
 
 aides . villes soeurs:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5149,6 +5149,7 @@ aides . la roche sur yon:
               alors: 100€
             - sinon: 50€
   lien: https://larochesuryon.fr/velo/
+  dernière mise à jour: 22/08/2025
   avec:
     salarié d'une structure membre du PDIE:
       type: booléen
@@ -5157,6 +5158,42 @@ aides . la roche sur yon:
         Êtes-vous salarié d'une structure membre du Plan de Déplacement
         inter-entreprises (PDIE) ?
       par défaut: non
+
+aides . ca mauges communauté:
+  remplace: intercommunalité
+  titre: Mauges Communauté
+  description: >
+    Aide pour l'achat d'un vélo à assistance électrique (neuf ou d'occasion)
+    depuis le 2 janvier 2020.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CA Mauges Communauté"
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . motorisation
+  valeur:
+    variations:
+      - si: vélo . cargo
+        alors:
+          variations: 
+            - si:
+                toutes ces conditions:
+                  - vélo . cargo
+                  - une de ces conditions:
+                      - vélo . état . neuf
+                      - vélo . prix >= 1000 €
+              alors: 350 €
+      - si:
+          une de ces conditions:
+            - vélo . motorisation
+            - vélo . état . neuf
+            - vélo . prix >= 300 €
+        alors: 100 €
+  lien: https://www.mooj.fr/mobilites-alternatives/modes-actifs/vae-aide-achat/
+  dernière mise à jour: 22/08/2025
+
+
 
 # NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
 aides . cholet:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -4592,13 +4592,18 @@ aides . grand cubzaguais:
 aides . bourges:
   remplace: intercommunalité
   titre: Bourges Plus
-  description: Aide à l'achat d'un vélo 2024
+  description: >
+    Aide à l'achat d'un vélo neuf ou d’occasion, auprès de vendeurs
+    professionnels ou associatifs basés sur le territoire de l’agglomération de
+    Bourges (l’achat auprès d’un particulier ne pourra donc pas faire l’objet
+    d’une aide). Les kits de transformation ne sont pas concernés par cette
+    obligation. 
   applicable si: 
     toutes ces conditions:
       - localisation . epci = 'CA Bourges Plus'
       - une de ces conditions:
           - demandeur . en situation de handicap
-          - revenu fiscal de référence par part <= 31593 €/an
+          - revenu fiscal de référence par part <= 32911 €/an
   valeur: 50% * vélo . prix
   plafond:
     variations:
@@ -4628,6 +4633,8 @@ aides . bourges:
         alors: 100€
       - sinon: 0€
   lien: https://www.agglo-bourgesplus.fr/site/aide-achat-velo
+  dernière mise à jour: 13/08/2025
+  date de fin: 31/12/2025
 
 aides . montauban:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3568,7 +3568,7 @@ aides . la madeleine:
         alors: 150€
   lien: https://www.ville-lamadeleine.fr/formulaires/transition-ecologique-aides-municipales
 
-# NOTE: info pour 2024, à vérifier en 2025
+# NOTE: info pour 2025, à vérifier en 2026
 aides . puisaye forterre:
   remplace: intercommunalité
   titre: Communauté de communes de Puisaye-Forterre
@@ -3579,7 +3579,7 @@ aides . puisaye forterre:
     vélo adapté aux personnes en situation de handicap.
 
 
-    Date limite de dépôt des dossiers : 31 décembre 2024.
+    Date limite de dépôt des dossiers : 31 décembre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC de Puisaye-Forterre'
@@ -3590,6 +3590,8 @@ aides . puisaye forterre:
           - vélo . adapté
   valeur: 100€
   lien: https://www.puisaye-forterre.com/vivre/aide-a-la-mobilite/
+  dernière mise à jour: 13/08/2025
+  date de fin: 31/12/2025
 
 aides . aurillac:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2132,16 +2132,12 @@ aides . montval sur loir:
     - sinon: 0€
   lien: https://www.montvalsurloir.fr/demarche-administrative/demande-de-subvention-velo-electrique/
 
-# NOTE: informations pour 2024, à vérifier en 2025
 aides . sorgues du comtat:
   remplace: intercommunalité
   titre: Communauté de communes des Sorgues du Comtat
   description: >
-    Cette subvention concerne l'achat d'un seul vélo à assistance électrique
-    neuf, deux ou trois roues, à usage personnel, acquis à partir du 1er
-    janvier 2024. Cette prime s'élève à 20 % du prix TTC du vélo sans pouvoir
-    dépasser un plafond de 120 euros et ne pourra être versée qu'une seule fois
-    par demandeur.
+    Cette subvention concerne l’achat d’un seul vélo à assistance électrique
+    neuf, deux ou trois roues, à usage personnel, acquis durant l’année.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA des Sorgues du Comtat'
@@ -2151,6 +2147,7 @@ aides . sorgues du comtat:
   valeur: 20% * vélo . prix
   plafond: 120€
   lien: https://www.sorgues.fr/vivre/demarches/prime-velo.htm
+  dernière mise à jour: 14/08/2025
 
 # NOTE: informations pour 2024, à vérifier en 2025
 aides . grand périgueux:
@@ -8142,6 +8139,7 @@ aides . cc pays des sorgues:
   valeur: 200€
   plafond: vélo . prix
   lien: https://www.paysdessorgues.fr/aide-velo
+  dernière mise à jour: 14/08/2025
 
 aides . cc val parisis:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7753,6 +7753,7 @@ aides . perpignan métropole:
       - sinon: 250€
   lien: https://aide-velo.perpignan-mediterranee.org/
 
+# TODO: à vérifier en 2026
 aides . fier et usses:
   remplace: intercommunalité
   titre: Communauté de communes Fier et Usses
@@ -7760,35 +7761,42 @@ aides . fier et usses:
   applicable si: 
     toutes ces conditions:
       - localisation . epci = 'CC Fier et Usses'
+      - demandeur . âge . majeur
       - revenu fiscal de référence par part <= 30000 €/an
   valeur:
     variations:
-      - si: revenu fiscal de référence par part <= 14089€/an
+      - si: revenu fiscal de référence par part <= 15400 €/an
         alors:
           variations:
+            - si: vélo . adapté
+              alors: 600 €
             - si: vélo . cargo électrique
-              alors: 600€
+              alors: 600 €
             - si: vélo . électrique
-              alors: 400€
+              alors: 400 €
             - si: vélo . mécanique
-              alors: 150€
+              alors: 150 €
             - si: vélo . motorisation
-              alors: 200€
-            - sinon: 0€
-      - si: revenu fiscal de référence par part <= 23000€/an
+              alors: 200 €
+            - sinon: 0 €
+      - si: revenu fiscal de référence par part <= 23000 €/an
         alors:
           variations:
+            - si: vélo . adapté
+              alors: 500 €
             - si: vélo . cargo électrique
-              alors: 500€
+              alors: 500 €
             - si: vélo . électrique
-              alors: 300€
+              alors: 300 €
             - si: vélo . mécanique
-              alors: 100€
+              alors: 100 €
             - si: vélo . motorisation
-              alors: 150€
-            - sinon: 0€
+              alors: 150 €
+            - sinon: 0 €
       - sinon:
           variations:
+            - si: vélo . adapté
+              alors: 400€
             - si: vélo . cargo électrique
               alors: 400€
             - si: vélo . électrique
@@ -7798,6 +7806,7 @@ aides . fier et usses:
             - sinon: 0€
   plafond: 50% * vélo . prix
   lien: https://www.fier-et-usses.com/actualite/18078/2048-aide-a-l-achat-velo.htm
+  dernière mise à jour: 22/08/2025
 
 aides . pays de cruseilles:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -1986,6 +1986,25 @@ aides . montbéliard agglo:
       - revenu fiscal de référence par part <= 1800 €/mois
   valeur: 100€
   lien: https://aidevelo.agglo-montbeliard.fr/
+  dernière mise à jour: 13/08/2025
+
+aides . cc loue-lison:
+  remplace: intercommunalité
+  titre: Communauté de communes Loue-Lison
+  description: >
+    Aide à l’acquisition de 20% du prix d’achat TTC limitée à 200€ maximum pour
+    l’achat d’un vélo à assistance électrique neuf, dans la limite de
+    l’enveloppe budgétaire annuelle allouée.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC Loue-Lison'
+      - vélo . électrique
+      - vélo . état . neuf
+      - vélo . prix <= 2500 €
+  valeur: 20% * vélo . prix
+  plafond: 200€
+  lien: https://cclouelison.fr/fr/rb/1729730/mobilite-21
+  dernière mise à jour: 13/08/2025
 
 # NOTE: convention jusqu'au 22 mars 2026
 aides . montbéliard:
@@ -7133,6 +7152,7 @@ aides . saulieu:
       - vélo . prix >= 650€
   valeur: 100€
   lien: https://www.saulieu-morvan.fr/joomla/tourisme-loisirs
+  dernière mise à jour: 13/08/2025
 
 aides . la côtière à montluel:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -6520,19 +6520,27 @@ aides . chateauroux:
   remplace: intercommunalité
   titre: Châteauroux Métropole
   description: >
-    Aide à l'achat d'un vélo neuf à assistance électrique et/ou un kit de conversion d'un vélo classique à un vélo à assistance électrique pour
-    les habitants de l'une des communes de l'Agglomération
+    Aide à l'achat d'un vélo neuf à assistance électrique et/ou un kit de
+    conversion d'un vélo classique à un vélo à assistance électrique pour les
+    habitants de l'une des communes de l'Agglomération.
+
+
+    Demande à effectuer pour tout achat dans un délai maximum de 6 mois à
+    partir de la date d’achat.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA Châteauroux Métropole'
       - demandeur . âge . majeur
-      - vélo . électrique ou mécanique
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . motorisation
   valeur: 
     variations:
       - si: vélo . électrique
-        alors: 200€
-      - sinon: 50€
+        alors: 200 €
+      - sinon: 100 €
   lien: https://www.chateauroux-metropole.fr/vie-pratique-les-services/mobilite-et-stationnements/velo
+  dernière mise à jour: 13/08/2025
 
 aides . auray quiberon:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2568,6 +2568,7 @@ aides . les sables d'olonne:
           plafond: 75€
       - sinon: 0€
   lien: https://www.lsoagglo.fr/vivreauxolonnes/vie-pratique/mobilites/subventions-velo/
+  dernière mise à jour: 22/08/2025
 
 # NOTE: informations pour 2024, à vérifier en 2025
 aides . vallons du lyonnais:
@@ -3825,6 +3826,7 @@ aides . les herbiers:
         alors: 300€
       - sinon: 200€
   lien: https://www.paysdesherbiers.fr/velo/
+  dernière mise à jour: 22/08/2025
 
 aides . frejus:
   remplace: commune
@@ -5195,13 +5197,13 @@ aides . saumur val de loire:
   plafond: 100€
   lien: https://www.saumurvaldeloire.fr/se-deplacer-a-velo
 
-# NOTE: à vérifier en 2025
+# NOTE: à vérifier en 2026
 aides . loire layon aubance:
   remplace: intercommunalité
   titre: Communauté de Communes Loire Layon Aubance
   description: >
-    Subvention pour l'achat d'un vélo à assistance électrique en 2024. L'achat
-    doit être effectué physiquement dans un magasin. 
+    Subvention pour l'achat d'un vélo à assistance électrique en 2025. L'achat
+    doit être effectué physiquement dans un magasin après le 1er avril 2024.
 
 
     A noter que le montant de la subvention est plafonnée à 80% du prix d'achat
@@ -5226,6 +5228,7 @@ aides . loire layon aubance:
         alors: 150€
       - sinon: 0€
   lien: https://www.loire-layon-aubance.fr/vivre-et-habiter/transports/velo-a-assistance-electrique/
+  dernière mise à jour: 22/08/2025
 
 aides . laval:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -599,7 +599,6 @@ aides . givors:
   plafond: 20% * vélo . prix
   lien: https://www.givors.fr/cadre-de-vie/environnement/aide-a-lacquisition-dun-velo/
 
-# TODO: à vérifier en 2025
 aides . blacé:
   remplace: commune
   titre: Ville de Blacé
@@ -2635,22 +2634,15 @@ aides . montpellier:
   plafond: 200€
   lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
 
-# TODO: distinguer vélo adapté et vélo électrique adapté
-# NOTE: valable jusqu'au 31 décembre 2024, à vérifier en 2025
-aides . montpellier vélo adapté:
   remplace: intercommunalité
   titre: Montpellier Méditerranée Métropole
   description: >
-    500€ d'aide à l'achat d'un vélo à assistance électrique adapté pour les
-    personnes en situation de handicap ayant bénéficié du "Chèque Hérault
-    Handi-Vélo".
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'Montpellier Méditerranée Métropole'
-      - aides . département hérault vélo adapté > 0€
+      - demandeur . âge . majeur
       - vélo . état . neuf
   valeur: 50% * vélo . prix
-  plafond: 500€
   lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
 
 aides . sète:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7220,17 +7220,20 @@ aides . region centre:
   remplace: région
   titre: Région Centre-Val de Loire
   description: >
-    Mobilité rurale - Vélo à assistance électrique ou adapté. L'aide régionale
-    est réservée aux habitant·es d'une commune sur laquelle la Région est
+    Mobilité rurale - Subvention pour l'achat d'un vélo à assistance électrique
+    ou adapté destiné à un usage utilitaire (aller au travail, faire ses
+    courses, transporter ses enfants à l’école, etc.). L'aide régionale est
+    réservée aux habitant·es d'une commune sur laquelle la Région est
     l'autorité organisatrice de la mobilité locale de substitution.
   applicable si:
     toutes ces conditions:
-      - localisation . région = '24'
       - vélo . prix >= 600€
+      - demandeur . âge >= 16 an
       - une de ces conditions:
           - vélo . électrique
           - vélo . adapté
       - une de ces conditions:
+          - localisation . région = '24'
           - localisation . epci = "CC du Perche"
           - localisation . epci = "CC du Bonnevalais"
           - localisation . epci = "CC Coeur de Beauce"
@@ -7242,6 +7245,7 @@ aides . region centre:
           - localisation . epci = "CC de la Sologne des Etangs"
           - localisation . epci = "CC Coeur de Sologne"
           - localisation . epci = "CC de la Sologne des Rivières"
+          - localisation . epci = "CC Val-de-Cher-Controis"
           - localisation . epci = "CC de la Forêt"
           - localisation . epci = "CC des Loges"
           - localisation . epci = "CC du Val de Sully"
@@ -7265,12 +7269,20 @@ aides . region centre:
           - localisation . epci = "CC Coeur de Berry"
           - localisation . epci = "CC FerCher"
           - localisation . epci = "CC Berry Grand Sud"
-          - localisation . epci = "CC Val-de-Cher-Controis"
+          - localisation . epci = "CC le Dunois"
           - localisation . epci = "CC Chabris - Pays de Bazelle"
           - localisation . epci = "CC du Pays d'Issoudun"
           - localisation . epci = "CC Champagne Boischauts"
           - localisation . epci = "CC Coeur de Brenne"
           - localisation . epci = "CC Brenne - Val de Creuse"
+          - localisation . epci = "CC Écueillé-Valençay"
+          - localisation . epci = "CC du Châtillonnais en Berry"
+          - localisation . epci = "CC Levroux Boischaut Champagne"
+          - localisation . epci = "CC Val de l'Indre - Brenne"
+          - localisation . epci = "CC de la Châtre et Sainte-Sévère"
+          - localisation . epci = "CC du Val de Bouzanne"
+          - localisation . epci = "CC de la Marche Berrichonne"
+          - localisation . epci = "CC Éguzon - Argenton - Vallée de la Creuse"
           - localisation . epci = "CC Loches Sud Touraine"
           - localisation . epci = "CC Touraine Val de Vienne"
           - localisation . epci = "CC Touraine Vallée de l'Indre"
@@ -7280,13 +7292,15 @@ aides . region centre:
           - localisation . epci = "CC Autour de Chenonceaux Bléré-Val de Cher"
           - localisation . epci = "CC Touraine-Est Vallées"
           - localisation . epci = "CC du Castelrenaudais"
-          - localisation . epci = "CC Val de l'Indre - Brenne"
-          - localisation . epci = "CC du Val de Bouzanne"
-          - localisation . epci = "CC de la Marche Berrichonne"
-          - localisation . epci = "CC Éguzon - Argenton - Vallée de la Creuse"
-          - localisation . epci = "CC de la Châtre et Sainte-Sévère"
-          - localisation . epci = "CC du Châtillonnais en Berry"
-          - localisation . epci = "CC Écueillé-Valençay"
+  non applicable si:
+    une de ces conditions:
+      - localisation . epci = "Tours Métropole Val de Loire"
+      - localisation . code insee = "37270"
+      - localisation . code insee = "37273"
+      - localisation . epci = "CA Bourges Plus"
+      - localisation . code insee = "18207"
+      - localisation . code insee = "18097"
+      - localisation . code insee = "18179"
   valeur: 25% * vélo . prix
   plafond: 
     variations:
@@ -7294,6 +7308,7 @@ aides . region centre:
         alors: 500€
       - sinon: 200€
   lien: https://www.centre-valdeloire.fr/le-guide-des-aides-de-la-region-centre-val-de-loire/mobilite-rurale-velo-assistance-electrique
+  dernière mise à jour: 13/08/2025
 
 aides . region centre rémi zen:
   remplace: région

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -404,6 +404,7 @@ aides . villefranche beaujolais saône:
     prix déduit des autres aides: 
       valeur: vélo . prix - (aides . état + aides . département + aides . région + aides . commune)
       plancher: 0€
+  dernière mise à jour: 14/08/2025
 
 aides . ville-sur-jarnioux:
   remplace: commune
@@ -4193,15 +4194,19 @@ aides . montlucon:
   remplace: intercommunalité
   titre: Montluçon Communauté
   description: >
-    Aide pour l'acquisition d'un vélo à assistance électrique neuf ou
-    d'occasion ou d'un vélo classique musculaire neuf ou d'occasion à usage
-    personnel.
+    Aide pour l'acquisition d'un vélo à assistance électrique ou musculaire,
+    neuf ou d'occasion à usage personnel. L'achat doit être effectué dans un
+    commerce de Montluçon Communauté.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CA Montluçon Communauté'
       - demandeur . âge . majeur
   valeur: 
     variations:
+      - si: vélo . adapté
+        alors: 400€
+      - si: vélo . motorisation
+        alors: 200€
       - si: vélo . électrique
         alors: 
           variations:
@@ -4216,6 +4221,7 @@ aides . montlucon:
             - si: vélo . état . occasion
               alors: 50€
   lien: https://www.montlucon-communaute.com/vivre-au-quotidien/la-mobilite-durable/a-velo-dans-lagglo/
+  dernière mise à jour: 14/08/2025
 
 aides . cotentin:
   remplace: intercommunalité
@@ -4663,7 +4669,6 @@ aides . montauban:
   plafond: 250€
   lien: https://www.montauban.com/au-quotidien/mobilite-et-stationnement/velos-et-pistes-cyclables
 
-# NOTE: valide pour 2024, à vérifier en 2025 
 aides . plaine de l'ain VAE:
   remplace: intercommunalité
   titre: Communauté de communes de la Plaine de l'Ain
@@ -4671,7 +4676,7 @@ aides . plaine de l'ain VAE:
      Aide à l'acquisition de vélos à assistance électrique et trottinette
      électrique. 
 
-     Dossier à envoyer avant le 1er décembre 2024.
+     Dossier à envoyer avant le 1er décembre 2025.
   applicable si: 
     toutes ces conditions:
       - localisation . epci = "CC de la Plaine de l'Ain"
@@ -4684,7 +4689,8 @@ aides . plaine de l'ain VAE:
           - demandeur . statut . retraité
   valeur: 200€
   plafond: vélo . prix
-  lien: https://www.cc-plainedelain.fr/fr/les-subventions.html
+  lien: https://cc-plainedelain.fr/les-services/se-deplacer/se-deplacer-a-velo/
+  dernière mise à jour: 14/08/2025
   avec:
     distance domicile-travail inférieur à 15 km:
       type: booléen
@@ -4702,7 +4708,6 @@ aides . plaine de l'ain VAE:
         votre nom.
       par défaut: non
 
-# NOTE: valide pour 2024, à vérifier en 2025 
 aides . plaine de l'ain vélos spécifiques:
   remplace: intercommunalité
   titre: Communauté de communes de la Plaine de l'Ain
@@ -4721,7 +4726,8 @@ aides . plaine de l'ain vélos spécifiques:
           - vélo . adapté
   valeur: 300€
   plafond: vélo . prix
-  lien: https://www.cc-plainedelain.fr/fr/les-subventions.html
+  lien: https://cc-plainedelain.fr/les-services/se-deplacer/se-deplacer-a-velo/
+  dernière mise à jour: 14/08/2025
 
 aides . divonne-les-bains:
   remplace: commune
@@ -7185,6 +7191,7 @@ aides . la côtière à montluel:
       type: booléen
       question: Êtes-vous abonné au TER ?
       par défaut: non
+  derière mise à jour: 14/08/2025
 
 aides . pays orne moselle:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -8998,3 +8998,21 @@ aides . cc coeur-de-savoie:
   lien: https://www.coeurdesavoie.fr/4051-se-deplacer-a-velo.htm
   dernière mise à jour: 28/07/2025
   date de fin: 31/03/2026
+
+aides . cc forcalquier lure:
+  remplace: intercommunalité
+  titre: Communauté de communes Pays de Forcalquier-Montagne de Lure
+  description: >
+    A compter du 1er juin 2024, la CCPFM propose un dispositif de
+    subventionnement intitulé « Ma prime vélo » destiné aux habitant·es du
+    territoire souhaitant acheter un vélo mécanique ou à assistance électrique
+    (neuf ou d’occasion) ou souhaitant faire installer un kit de conversion «
+    assistance électrique » pour vélo.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CC Pays Forcalquier et Montagne de Lure"
+      - demandeur . âge . majeur
+  valeur: 40% * vélo . prix
+  plafond: 500 €
+  lien: https://www.forcalquier-lure.com/actualites/ma-prime-velo
+  dernière mise à jour: 21/08/2025

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3744,6 +3744,7 @@ aides . portes de sologne:
           valeur: 50% * vélo . prix
           plafond: 100€
   lien: https://www.ccportesdesologne.fr/vivre-et-habiter/coups-de-pouce-pour-lenvironnement/
+  dernière mise à jour: 13/08/2025
 
 # NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
 # TODO: regarder toutes les communes de l'intercommunalité
@@ -4359,6 +4360,7 @@ aides . blois:
   valeur: 25% * vélo . prix
   plafond: 200€
   lien: https://www.agglopolys.fr/1247-le-velo-a-assistance-electrique.htm
+  dernière mise à jour: 13/08/2025
 
 # NOTE: fin de validité en 2024, à vérifier en 2025
 aides . epinal:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -377,7 +377,7 @@ aides . saône-beaujolais:
       - sinon: 0€
   lien: http://www.ccsb-saonebeaujolais.fr/fr/information/10135/aide-achat-un-velo
 
-# NOTE: jusqu'au 31 décembre 2025
+# NOTE: jusqu'au 31 décembre 2026
 # TODO: test intégration sur le plafond
 aides . villefranche beaujolais saône:
   remplace: intercommunalité
@@ -4058,7 +4058,7 @@ aides . châtel:
   lien: https://www.mairie-chatel.com/Aide-Acquisition
   dernière mise à jour: 01/07/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 décembre 2025, à vérifier en 2026
 aides . le vigan:
   remplace: commune
   titre: Ville du Vigan
@@ -4068,7 +4068,7 @@ aides . le vigan:
     d'accorder une aide sous forme de subvention aux habitants de la ville qui
     feront l'ac-quisition d'un vélo à assistance électrique (VAE). Cette
     subvention est fixée à 200 euros maximum, sans condition de ressources, à
-    partir du 1er janvier 2024 jusqu'au 31 décembre 2024.
+    partir du 1er janvier 2025 jusqu'au 31 décembre 2025.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '30350'
@@ -4077,8 +4077,10 @@ aides . le vigan:
   valeur: 50% * vélo . prix
   plafond: 200€
   lien: https://www.levigan.fr/mes-demarches-administratives/velo-finance/
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
-# NOTE: pas d'information sur la fin de validité, à vérifier en 2025
+# NOTE: pas d'information sur la fin de validité, à vérifier en 2026
 aides . angers:
   remplace: intercommunalité
   titre: Angers Loire Métropole
@@ -4106,8 +4108,9 @@ aides . angers:
         alors: 50€
       - sinon: 0€
   lien: https://www.angersloiremetropole.fr/mon-quotidien/mobilites/velo/aide-a-l-achat-d-un-velo-neuf/index.html
+  dernière mise à jour: 14/08/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 décembre 2025, à vérifier en 2026
 aides . haut val de sèvre:
   remplace: intercommunalité
   titre: Communauté de communes Haut Val de Sèvre
@@ -4115,7 +4118,8 @@ aides . haut val de sèvre:
     Depuis 2022, la collectivité propose aux habitants une aide de 150€ pour
     l'achat d'un Vélo à Assistance Electrique (VAE).
 
-    Fin de validité le 31 décembre 2024.
+    Aide réservée aux vélos achetés moins de 6 mois à la date du dépôt de
+    dossier.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Haut Val de Sèvre'
@@ -4132,17 +4136,15 @@ aides . haut val de sèvre:
               - vélo . prix <= 2000 €
   valeur: 150€
   lien: https://cc-hautvaldesevre.fr/competences/environnement/mobilite/1558-aide-a-l-achat-d-un-velo-a-assistance-electrique.html
+  dernière mise à jour: 14/08/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 décembre 2025, à vérifier en 2026
 aides . anjou bleu:
   remplace: intercommunalité
   titre: Anjou Bleu Communauté
   description: >
     Anjou Bleu Communauté propose une aide à l'achat d'un vélo à assistance
     électrique neuf pour les habitant·es s de son territoire.
-
-
-    Fin de validité le 31 décembre 2024.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Anjou Bleu Communauté'
@@ -4157,9 +4159,10 @@ aides . anjou bleu:
   plafond: 
     variations:
       - si: vélo . cargo
-        alors: 200 €
-      - sinon: 100 €
-  lien: https://www.anjoubleucommunaute.fr/aide-a-lachat-de-velo-a-assistance-electrique/
+        alors: 400 €
+      - sinon: 200 €
+  lien: https://www.anjoubleucommunaute.fr/medias/2025/04/ABC-Aide-a-l-acquisition-de-VAE-reglement.pdf
+  dernière mise à jour: 14/08/2025
 
 # NOTE: relancé en 2025 
 aides . limoges metropole:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3140,21 +3140,23 @@ aides . grand chambéry:
       type: booléen
       par défaut: oui
 
-# NOTE: valide pour 2024, à vérifier en 2025
+# NOTE: valide pour 2025, à vérifier en 2026
 aides . saint alban leysse:
   remplace: commune
   titre: Ville de Saint-Alban-Leysse
   description: >
     La commune de Saint-Alban-Leysse propose une aide de 200€ pour l'achat d'un
-    vélo à assistance électrique (VAE) neuf.
+    vélo à assistance électrique (VAE) dont le prix est compris entre 1200€ et
+    3400€.
   applicable si:
     toutes ces conditions:
       - localisation . code insee = '73222'
       - vélo . électrique
-      - vélo . prix >= 1500 €
-      - vélo . prix <= 3700 €
+      - vélo . prix >= 1200 €
+      - vélo . prix <= 3400 €
   valeur: 200€
   lien: https://www.saintalbanleysse.fr/toutes-les-actualites/200eur-daide-communale-pour-lachat-dun-velo-a-assistance-electrique-vae
+  dernière mise à jour: 14/08/2025
 
 # NOTE: info pour 2023, à vérifier en 2025
 aides . les crêtes préardennaises:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7971,10 +7971,27 @@ aides . sisteronais-buëch:
     toutes ces conditions:
       - localisation . epci = 'CC du Sisteronais-Buëch'
       - vélo . électrique
+      - vélo . état . neuf
       - demandeur . âge . majeur
   valeur: 200 €
   lien: https://www.sisteronais-buech.fr/vivre-en-sisteronais-buech/se-deplacer/aide-a-lachat-dun-velo-a-assistance-electrique/
   dernière mise à jour: 14/08/2025
+
+aides . commune barcelonette:
+  remplace: commune
+  titre: Commune de Barcelonnette
+  description: Aide à l'achat d'un vélo à assistance électrique neuf de 200€.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '04019'
+      - vélo . électrique
+      - vélo . état . neuf
+      - demandeur . âge . majeur
+  valeur: vélo . prix
+  plafond: 200€
+  lien: https://www.ville-barcelonnette.fr/l-achat-d-aide-aux-velos-electrique.html
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2025
 
 aides . territoire de l'ouest:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7953,6 +7953,7 @@ aides . creusot-montceau:
             - sinon: 0€
       - sinon: 0€
   lien: https://www.creusot-montceau.org/actualite/la-communaute-urbaine-vous-aide-financierement-pour-lacquisition-dun-velo
+  dernière mise à jour: 13/08/2025
 
 aides . territoire de l'ouest:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3747,24 +3747,6 @@ aides . les herbiers:
       - sinon: 200€
   lien: https://www.paysdesherbiers.fr/velo/
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
-aides . riviera francaise:
-  remplace: intercommunalité
-  titre: Riviera Française
-  description: >
-    La Communauté d'Agglomération de la Riviera Française propose une aide
-    financière pour l'achat d'un vélo à assistance électrique neuf jusqu'au 31
-    décembre 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . epci = 'CA de la Riviera Française'
-      - demandeur . âge . majeur
-      - vélo . électrique
-      - vélo . état . neuf
-  valeur: vélo . prix
-  plafond: 300€
-  lien: https://www.riviera-francaise.fr/media/attachments/2022/03/30/convention-2022-2024-cc01221.pdf
-
 aides . frejus:
   remplace: commune
   titre: Ville de Fréjus
@@ -8005,7 +7987,7 @@ aides . commune gap:
     Dispositif disponible jusqu'au 31 octobre 2025.
   applicable si:
     toutes ces conditions:
-      - localisation . code insee = '05060'
+      - localisation . code insee = '05061'
       - vélo . état . neuf
       - demandeur . âge . majeur
       - une de ces conditions:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3075,31 +3075,16 @@ aides . vallée d'ossau:
   plafond: 200€
   lien: https://cc-ossau.fr/aide-a-lachat-dun-vae/
 
-# NOTE: subvention pour 2024, à vérifier en 2025
-aides . aix les bains:
-  remplace: commune
-  titre: Ville d'Aix-les-Bains
-  description: >
-    La Ville d'Aix-les-Bains propose une aide financière à hauteur de 10 % du
-    montant TTC du vélo, dans la limite de 250 € et des crédits disponibles.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '73008'
-      - vélo . électrique
-      - vélo . état . neuf
-  valeur: 10% * vélo . prix
-  plafond: 250€
-  lien: https://www.aixlesbains.fr/Cadre-de-vie/Transports-et-deplacements/A-velo/Aides-financieres-pour-se-deplacer-a-velo
-
+# TODO: relire en 2026
 aides . coeur de maurienne arvan:
   remplace: intercommunalité
   titre: Cœur de Maurienne Arvan
   description: >
     La subvention peut atteindre 40 % du prix d'achat TTC du vélo électrique
-    neuf ou d'occasion, dans la limite de 400 € par matériel
-  
+    neuf ou d'occasion, dans la limite de 400 € par matériel.
 
-    Limite de dépôt des dossiers pour l'année 2024 : 15 novembre 2024.
+
+    Le vélo doit être acheté au cours de l'année 2025.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Coeur de Maurienne Arvan'
@@ -3108,6 +3093,7 @@ aides . coeur de maurienne arvan:
   valeur: 40% * vélo . prix
   plafond: 400€
   lien: https://www.coeurdemaurienne-arvan.com/actualite/velo-electrique/
+  dernière mise à jour: 22/08/2025
 
 # NOTE: période 2023-2025, à vérifier en 2026
 aides . morzine-avoriaz:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2783,8 +2783,9 @@ aides . aubiere:
   valeur: 150€
   plafond: vélo . prix
   lien: https://ville-aubiere.fr/2024/06/27/passez-au-velo-pedalez-branche/
+  dernière mise à jour: 22/08/2025
 
-# NOTE: info pour 2020, à vérifier en 2025
+# NOTE: info pour 2020, à vérifier en 2026
 aides . romagnat:
   remplace: commune
   titre: Ville de Romagnat
@@ -2798,6 +2799,38 @@ aides . romagnat:
       - vélo . électrique
   valeur: 100€
   lien: https://www.ville-romagnat.fr/cadre-de-vie-urbanisme/developpement-durable/velo-electrique/
+  dernière mise à jour: 22/08/2025
+
+aides . cc plaine limagne:
+  remplace: intercommunalité
+  titre: Communauté de communes Plaine Limagne
+  description: >
+    Aide pour l'achat d'un vélo à assitance électrique, d'un vélo cargo, d'un
+    vélo classique ou d'un kit d'électrification.
+
+
+    La demande doit être déposée dans un délais de 3 mois après l'achat du
+    vélo.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CC Plaine Limagne"
+      - demandeur . âge >= 14 an
+      - une de ces conditions:
+          - vélo . électrique
+          - vélo . motorisation
+          - vélo . cargo
+          - vélo . état . neuf
+  valeur: 
+    variations:
+      - si: vélo . motorisation
+        alors: 150 €
+      - si: vélo . mécanique
+        alors: 100 €
+      - si: vélo . état . neuf
+        alors: 200 €
+      - sinon: 150 €
+  lien: https://www.plainelimagne.com/mobilite/
+  dernière mise à jour: 22/08/2025
 
 # TODO: ont développé leur propre simulateur, leur partager le lien ?
 # NOTE: reconduite pour 2025, à vérifier en 2026

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7955,6 +7955,27 @@ aides . creusot-montceau:
   lien: https://www.creusot-montceau.org/actualite/la-communaute-urbaine-vous-aide-financierement-pour-lacquisition-dun-velo
   dernière mise à jour: 13/08/2025
 
+# NOTE: lien mort au 08/10/2024
+aides . sisteronais-buëch:
+  remplace: intercommunalité
+  titre: Communauté de Communes du Sisteronais-Buëch
+  description: >
+    Aide forfaitaire de 200€ pour l'achat d'un vélo à assistance électrique
+    neuf. Le vélo doit être acheté chez un revendeur implanté dans l’un des
+    départements suivants : Hautes-Alpes, Alpes de Haute-Provence ou Drôme.
+
+
+    La demande doit être effectuée au plus tard dans les 2 mois suivant la date
+    de facturation.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC du Sisteronais-Buëch'
+      - vélo . électrique
+      - demandeur . âge . majeur
+  valeur: 200 €
+  lien: https://www.sisteronais-buech.fr/vivre-en-sisteronais-buech/se-deplacer/aide-a-lachat-dun-velo-a-assistance-electrique/
+  dernière mise à jour: 14/08/2025
+
 aides . territoire de l'ouest:
   remplace: intercommunalité
   titre: Territoire de l'Ouest

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3836,19 +3836,19 @@ aides . portes de sologne:
   lien: https://www.ccportesdesologne.fr/vivre-et-habiter/coups-de-pouce-pour-lenvironnement/
   dernière mise à jour: 13/08/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 décembre 2025, à vérifier en 2026
 # TODO: regarder toutes les communes de l'intercommunalité
 # TODO: add unit test?
 aides . grand reims:
   remplace: intercommunalité
   titre: Grand Reims Communauté urbaine
   description: >
-    Subvention jusqu'à 500€ pour l'achat d'un vélo à assistance
-    électrique, sous réserve qu'il soit acheté auprès d'un commerçant ou d'une
-    association locale. Les achats en ligne sont exclus. 
+    Subvention jusqu'à 500€ pour l'achat d'un vélo à assistance électrique,
+    sous réserve qu'il soit acheté auprès d'un commerçant ou d'une association
+    locale. Les achats en ligne sont exclus. 
    
 
-    Dossiers à déposer entre le 1er avril et le 31 octobre 2024, dans la limite des 
+    Dossiers à déposer entre le 1er avril et le 31 octobre 2025, dans la limite des 
     budgets disponibles.
   applicable si: 
     toutes ces conditions:
@@ -3876,8 +3876,10 @@ aides . grand reims:
             alors: 50€
           - sinon: 0€
   lien: https://www.grandreims.fr/se-deplacer/operation-aide-a-lachat-dun-velo-a-assistance-electrique
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/10/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# NOTE: valide jusqu'au 31 décembre 2025, à vérifier en 2026
 aides . reims:
   remplace: commune
   titre: Ville de Reims
@@ -3887,8 +3889,8 @@ aides . reims:
     domicile ou en magasin sont exclus. 
    
 
-    Dossiers à déposer entre le 1er avril et le 31 octobre 2024, dans la limite des 
-    budgets disponibles.
+    Dossiers à déposer entre le 1er avril et le 31 octobre 2025, dans la limite
+    des budgets disponibles.
   applicable si: 
     toutes ces conditions:
       - localisation . code insee = '51454'
@@ -3926,6 +3928,8 @@ aides . reims:
                 - sinon: 10€
           - sinon: 0€
   lien: https://www.reims.fr/qualite-de-vie-environnement/stationnement-et-deplacements/operation-aide-a-lachat-dun-velo
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/10/2025
 
 # NOTE: valide pour 2024, à vérifier en 2025
 aides . genevois:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3080,27 +3080,8 @@ aides . la motte servolex:
       - si: vélo . cargo
         alors: 300€
       - sinon: 150€
-  lien: https://www.mairie-lamotteservolex.fr/vos-demarches/subventions-eco-citoyennes-la-motte-servolex/
-
-# NOTE: limite 31 décembre 2024, à vérifier en 2025
-aides . montagnole:
-  remplace: commune
-  titre: Ville de Montagnole
-  description: >
-    Aide financière de 200 € net par vélo, d'une valeur minimum  unitaire de 1
-    200 € TTC, et par famille, acheté chez un vélociste implanté dans une
-    commune du périmètre de l'agglomération de Grand Chambéry quel que soit le
-    type de vélo (route, VTT, VTC, Cargo…).
-
-
-    Limite de dépôt des dossiers pour l'année 2024 : 31 décembre 2024.
-  applicable si:
-    toutes ces conditions:
-      - localisation . code insee = '73160'
-      - vélo . électrique
-      - vélo . prix >= 1200 €
-  valeur: 200€
-  lien: https://www.mairie-montagnole.fr/vae/
+  lien: https://www.mairie-lamotteservolex.fr/vos-demarches/subventions-eco-citoyennes-la-motte-servolex/#deux-roues
+  dernière mise à jour: 14/08/2025
 
 # NOTE: possède un simulateur qui ne fonctionne pas, à contacter
 # TODO: grand chambéry, à vérifier en 2026 : https://www.grandchambery.fr/mes-demarches/aides-energies/cheque-velo-a-assistance-electrique
@@ -3145,7 +3126,7 @@ aides . grand chambéry:
                 - si: revenu fiscal de référence par part <= 15400 €/an
                   alors: 1000€
                 - sinon: 500€
-  lien: https://www.grandchambery.fr/mes-demarches/aides-ener
+  lien: https://www.grandchambery.fr/mes-demarches/aides-energies/cheque-velo-a-assistance-electrique
   dernière mise à jour: 14/08/2025
   date de fin: 31/12/2025
   avec:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -5204,14 +5204,12 @@ aides . pays des achards:
 
 
     Les vélos adaptés à un handicap pourront faire l'objet d'une étude
-    spécifique.
+    spécifique. La demande de subvention doit être effectuée dans les 3 mois
+    suivant l'achat.
   applicable si: 
     toutes ces conditions:
       - localisation . epci = 'CC du Pays des Achards'
       - demandeur . âge . majeur
-      - une de ces conditions:
-          - vélo . électrique ou mécanique
-          - vélo . adapté
   valeur: 25% * vélo . prix
   plafond:
     variations:
@@ -5222,6 +5220,7 @@ aides . pays des achards:
         alors: 300€
       - sinon: 200€
   lien: https://www.cc-paysdesachards.fr/amenagement/mobilites/351-bonus-velo.html
+  dernière mise à jour: 14/08/2025
 
 aides . hem:
   remplace: commune

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7236,11 +7236,11 @@ aides . region centre:
     toutes ces conditions:
       - vélo . prix >= 600€
       - demandeur . âge >= 16 an
+      - localisation . région = '24'
       - une de ces conditions:
           - vélo . électrique
           - vélo . adapté
       - une de ces conditions:
-          - localisation . région = '24'
           - localisation . epci = "CC du Perche"
           - localisation . epci = "CC du Bonnevalais"
           - localisation . epci = "CC Coeur de Beauce"

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -3056,7 +3056,7 @@ aides . lescar:
             alors: 100€
   lien: https://www.lescar.fr/information-transversale/fil-infos/mise-en-place-dune-aide-pour-lacquisition-dun-velo-pour-les-lescariens-1140
 
-# NOTE: pas d'information sur la durée de validité, à vérifier en 2025
+# TODO: pas d'information sur la durée de validité, à vérifier en 2026
 aides . vallée d'ossau:
   remplace: intercommunalité
   titre: Vallée d'Ossau communauté de communes
@@ -3074,6 +3074,7 @@ aides . vallée d'ossau:
   valeur: 20% * vélo . prix
   plafond: 200€
   lien: https://cc-ossau.fr/aide-a-lachat-dun-vae/
+  dernière mise à jour: 22/08/2025
 
 # TODO: relire en 2026
 aides . coeur de maurienne arvan:
@@ -4053,7 +4054,7 @@ aides . genevois:
   plafond: 200€
   lien: https://www.cc-genevois.fr/fr/vie-pratique-et-services/vous-deplacer/velo-ou-pied
 
-# NOTE: limite de budget, à vérifier en 2025
+# TODO:  à vérifier en 2026
 aides . cluses arve et montagnes:
   remplace: intercommunalité
   titre: Communauté de communes Cluses Arve & montagnes
@@ -4104,6 +4105,7 @@ aides . cluses arve et montagnes:
         plafond: 400€
   plafond: 80% * vélo . prix
   lien: https://www.2ccam.fr/2023/06/09/prime-velo/
+  dernière mise à jour: 22/08/2025
   avec:
     participation employeur:
       type: nombre
@@ -7801,69 +7803,76 @@ aides . pays de cruseilles:
   remplace: intercommunalité
   titre: Pays de Cruseilles
   description: >
-    Prime Achat Vélo. A noter qu'un bonus de 300€ est accordé pour l'adaptation
-    d'un vélo pour les personnes à mobilité réduite.
-  applicable si: localisation . epci = 'CC du Pays de Cruseilles'
+    Prime Achat Vélo. Aide éligible pour les vélos achetés à partir du 1er
+    janvier 2025.
+  applicable si: 
+    toutes ces conditions:
+      - localisation . epci = 'CC du Pays de Cruseilles'
+      - demandeur . âge . majeur
   valeur:
     variations:
-      - si:
-          toutes ces conditions:
-            - vélo . cargo électrique
-            - vélo . prix >= 1000€
-            - vélo . prix <= 4500€
+      - si: vélo . adapté
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= 7100€/an
-              alors: 700€
-            - si: revenu fiscal de référence par part <= 15400€/an
-              alors: 600€
-            - si: revenu fiscal de référence par part <= 20000€/an
-              alors: 400€
-            - sinon: 0€
-      - si:
-          toutes ces conditions:
-            - vélo . cargo
-            - vélo . prix >= 1000€
-            - vélo . prix <= 3000€
+            - si: revenu fiscal de référence par part <= 7100 €/an
+              alors: 1000 €
+            - si: revenu fiscal de référence par part <= 15400 €/an
+              alors: 900 €
+            - si: revenu fiscal de référence par part <= 30000 €/an
+              alors: 700 €
+            - si: revenu fiscal de référence par part <= 40000 €/an
+              alors: 500 €
+            - sinon: 0 €
+      - si: vélo . cargo électrique
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= 7100€/an
-              alors: 400€
-            - si: revenu fiscal de référence par part <= 15400€/an
-              alors: 300€
-            - si: revenu fiscal de référence par part <= 20000€/an
-              alors: 200€
-            - sinon: 0€
-      - si:
-          toutes ces conditions:
-            - vélo . électrique
-            - vélo . prix >= 600€
-            - vélo . prix <= 3000€
+            - si: revenu fiscal de référence par part <= 7100 €/an
+              alors: 700 €
+            - si: revenu fiscal de référence par part <= 15400 €/an
+              alors: 600 €
+            - si: revenu fiscal de référence par part <= 30000 €/an
+              alors: 400 €
+            - si: revenu fiscal de référence par part <= 40000 €/an
+              alors: 200 €
+            - sinon: 0 €
+      - si: vélo . cargo
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= 7100€/an
-              alors: 400€
-            - si: revenu fiscal de référence par part <= 15400€/an
-              alors: 300€
-            - si: revenu fiscal de référence par part <= 20000€/an
-              alors: 200€
-            - sinon: 0€
-      - si:
-          toutes ces conditions:
-            - vélo . mécanique
-            - vélo . prix >= 400€
-            - vélo . prix <= 1200€
+            - si: revenu fiscal de référence par part <= 7100 €/an
+              alors: 400 €
+            - si: revenu fiscal de référence par part <= 15400 €/an
+              alors: 300 €
+            - si: revenu fiscal de référence par part <= 30000 €/an
+              alors: 200 €
+            - si: revenu fiscal de référence par part <= 40000 €/an
+              alors: 100 €
+            - sinon: 0 €
+      - si: vélo . électrique
         alors:
           variations:
-            - si: revenu fiscal de référence par part <= 7100€/an
-              alors: 200€
-            - si: revenu fiscal de référence par part <= 15400€/an
-              alors: 150€
-            - si: revenu fiscal de référence par part <= 20000€/an
-              alors: 100€
-            - sinon: 0€
-      - sinon: 0€
+            - si: revenu fiscal de référence par part <= 7100 €/an
+              alors: 400 €
+            - si: revenu fiscal de référence par part <= 15400 €/an
+              alors: 300 €
+            - si: revenu fiscal de référence par part <= 30000 €/an
+              alors: 200 €
+            - si: revenu fiscal de référence par part <= 40000 €/an
+              alors: 100 €
+            - sinon: 0 €
+      - si: vélo . mécanique
+        alors:
+          variations:
+            - si: revenu fiscal de référence par part <= 7100 €/an
+              alors: 200 €
+            - si: revenu fiscal de référence par part <= 15400 €/an
+              alors: 150 €
+            - si: revenu fiscal de référence par part <= 30000 €/an
+              alors: 100 €
+            - sinon: 0 €
+      - sinon: 0 €
+  plancher: 50 €
   lien: https://ccpaysdecruseilles.org/vivre-ici/mobilite/prime-achat-velo/
+  dernière mise à jour: 22/08/2025
 
 aides . tulle:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -7333,6 +7333,7 @@ aides . region centre rémi zen:
   valeur: 40% * vélo . prix
   plafond: 500€
   lien: https://www.centre-valdeloire.fr/le-guide-des-aides-de-la-region-centre-val-de-loire/remi-zen-velos-pliants-et-trottinettes
+  dernière mise à jour: 13/08/2025
   avec:
     abonné Rémi:
       question: Disposez-vous d'un abonnement Rémi Zen ?
@@ -7358,6 +7359,27 @@ aides . region centre rémi zen:
          - Abonnement Car Rémi Zen jeune interdépartemental
 
         Les abonnements scolaires et les abonnements commerciaux aux abris-vélo Rémi sont exclus de ce dispositif. Les cartes de réduction (Rémi Liberté) ne constituent pas des abonnements et ne donnent donc pas accès à l'aide.
+
+aides . cc portes eureliennes idf:
+  remplace: intercommunalité
+  titre: CC des Portes Euréliennes d'Ile de France
+  description: >
+    Aide jusqu’à 250 € pour l’achat de votre vélo à assistance électrique, neuf
+    ou d'occasion.
+
+
+    La demande doit s’effectuer par mail :
+    transport-mobilite@porteseureliennesidf.fr ou par courrier, dans la limite
+    des 4 mois après l’achat du vélo (date du tampon de la poste ou de la
+    réception du mail faisant foi).
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = "CC des Portes Euréliennes d'Ile de France"
+      - vélo . électrique
+  valeur: 25% * vélo . prix
+  plafond: 250 €
+  lien: https://www.porteseureliennesidf.fr/pages/portes-eureliennes-mobilite-79.html
+  dernière mise à jour: 13/08/2025
 
 aides . perpignan métropole:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -4233,7 +4233,7 @@ aides . grand poitiers adapté:
   lien: https://www.grandpoitiers.fr/au-quotidien/deplacements/mobilite-inclusive-et-solidaire/savoir-prendre-le-bus-ou-faire-du-velo
   dernière mise à jour: 30/02/2025
 
-# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . grand orb:
   remplace: intercommunalité
   titre: Grand Orb Communauté de communes
@@ -4244,7 +4244,7 @@ aides . grand orb:
     d'électrification (aide forfaitaire de 80 €).
 
 
-    Date limite de dépôt des dossiers : 10 janvier 2025.
+    Date limite de dépôt des dossiers : 10 janvier 2026.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC Grand Orb Communauté de Communes en Languedoc'
@@ -4257,7 +4257,9 @@ aides . grand orb:
       - si: vélo . électrique
         alors: 100€
       - sinon: 80€
-  lien: https://www.grandorb.fr/phototheque_publique/PCAET/2024/02/convention-aide-achat-VAE-2024pdf.pdf
+  lien: https://www.grandorb.fr/Developpement-durable/Plan-Climat/Aide-a-l-achat-de-velos-electriques/5/7159.html
+  dernière mise à jour: 14/08/2025
+  date de fin: 10/01/2026
 
 aides . montlucon:
   remplace: intercommunalité

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -4029,30 +4029,37 @@ aides . reims:
   dernière mise à jour: 14/08/2025
   date de fin: 31/10/2025
 
-# NOTE: valide pour 2024, à vérifier en 2025
+# TODO: à vérifier en 2026
 aides . genevois:
   remplace: intercommunalité
   titre: Communauté de communes du Genevois
   description: >
-    La CCG plafonne ce dispositif d'aide à l'achat de VAE à 125 unités (soit
-    une enveloppe budgétaire de 25 000€ à charge de la collectivité). Elle
-    attribue une aide de 200€ maximum pour l'achat d'un VAE, vélo dit "cargo",
-    "rallongé" ou "pliable doté d'une batterie sans plomb.
+    Une enveloppe de 25 000 € est attribué chaque année. L’aide est de 25% du
+    prix d’achat, plafonnée en fonction du type de vélo.
   applicable si:
     toutes ces conditions:
       - localisation . epci = 'CC du Genevois'
       - demandeur . âge . majeur
-      - une de ces conditions:
-          - vélo . pliant électrique
-          - toutes ces conditions:
-              - vélo . cargo électrique
-              - vélo . prix <= 6000€
-          - toutes ces conditions:
-              - vélo . électrique
-              - vélo . prix <= 4000€
-  valeur: vélo . prix
-  plafond: 200€
+  valeur: 25% * vélo . prix
+  plafond: 
+    variations:
+      - si:
+          une de ces conditions:
+            - vélo . cargo
+            - vélo . adapté
+        alors: 500 €
+      - si: 
+          toutes ces conditions:
+            - vélo . mécanique
+            - vélo . prix <= 1500 €
+        alors: 100 €
+      - si: 
+          toutes ces conditions:
+            - vélo . électrique
+            - vélo . prix <= 4000 €
+        alors: 200 €
   lien: https://www.cc-genevois.fr/fr/vie-pratique-et-services/vous-deplacer/velo-ou-pied
+  dernière mise à jour: 22/08/2025
 
 # TODO:  à vérifier en 2026
 aides . cluses arve et montagnes:

--- a/src/rules/aides.publicodes
+++ b/src/rules/aides.publicodes
@@ -2619,24 +2619,6 @@ aides . département hérault vélo adapté:
   lien: https://herault.fr/actualite/127075/2-le-departement-lance-une-enquete-sur-la-construction-du-plan-herault-velo.htm
   # lien: https://herault.fr/aideProjet/3/321-aide-a-l-achat-d-un-velo-electrique-vae.htm
 
-aides . montpellier:
-  remplace: intercommunalité
-  titre: Montpellier Méditerranée Métropole
-  description: >
-    Pour un usage professionnel ou personnel, les habitants de la métropole ont accès à une subvention permettant l'achat d'un vélo électrique ou d'occasion.
-  applicable si: 
-    toutes ces conditions:
-      - localisation . epci = 'Montpellier Méditerranée Métropole'
-      - demandeur . âge . majeur
-      - une de ces conditions:
-        - vélo . motorisation
-        - toutes ces conditions:
-          - vélo . électrique
-          - vélo . état . occasion
-  valeur: 50% * vélo . prix
-  plafond: 200€
-  lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
-
 # TODO: à vérifier en 2027
 aides . montpellier vélo cargo pro:
   remplace: intercommunalité
@@ -2662,6 +2644,32 @@ aides . montpellier vélo cargo pro:
         Montpellier Méditerranée Métropole ?
       type: booléen
       par défaut: oui
+  dernière mise à jour: 14/08/2025
+  date de fin: 31/12/2026
+
+# TODO: à vérifier en 2027
+aides . montpellier vae occasion:
+  remplace: intercommunalité
+  titre: Montpellier Méditerranée Métropole
+  description: >
+    Une subvention d'un montant de 200 € maximum, sans condition de ressource,
+    sera versée à tous les habitants de la Métropole de plus de 18 ans qui
+    feront l'acquisition d'un vélo à assistance électrique d'occasion (VAE) à
+    partir du 1er février 2021 ou l'achat d'un kit d'électrification à partir
+    du 29 juillet 2021 dans un magasin de la métropole jusqu'au 31 décembre
+    2026.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'Montpellier Méditerranée Métropole'
+      - demandeur . âge . majeur
+      - une de ces conditions:
+          - vélo . motorisation
+          - toutes ces conditions:
+              - vélo . électrique
+              - vélo . état . occasion
+  valeur: 50% * vélo . prix
+  plafond: 200€
+  lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
   dernière mise à jour: 14/08/2025
   date de fin: 31/12/2026
 

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1547,3 +1547,20 @@ aides . luberon:
       - sinon: 0€
   lien: https://www.luberonmontsdevaucluse.fr/acces/mes-demarches/mobilite/une-subvention-pour-lachat-dun-velo/
 
+# TODO: distinguer vélo adapté et vélo électrique adapté
+# NOTE: valable jusqu'au 31 décembre 2024, à vérifier en 2025
+aides . montpellier vélo adapté:
+  remplace: intercommunalité
+  titre: Montpellier Méditerranée Métropole
+  description: >
+    500€ d'aide à l'achat d'un vélo à assistance électrique adapté pour les
+    personnes en situation de handicap ayant bénéficié du "Chèque Hérault
+    Handi-Vélo".
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'Montpellier Méditerranée Métropole'
+      - aides . département hérault vélo adapté > 0€
+      - vélo . état . neuf
+  valeur: 50% * vélo . prix
+  plafond: 500€
+  lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -849,34 +849,6 @@ aides . coeur de nacre:
   lien: https://www.courseulles-sur-mer.com/aide-a-lacquisition-dun-velo-a-assistance-electrique-vae/
   dernière mise à jour: 20/02/2025
 
-# NOTE: dépôt des demandes jusqu'au 31 octobre 2024, à vérifier en 2025
-aides . cébazat:
-  remplace: commune
-  titre: Ville de Cébazat
-  description: >
-    Afin de développer la pratique du vélo en ville et ainsi favoriser les
-    modes de déplacement doux, la Ville propose 3 aides à l'achat d'un vélo à
-    assistance électrique et le prêt de vélos à assistance électrique. Clôture
-    des demandes le 31 octobre 2024.
-  applicable si: 
-    toutes ces conditions:
-      - localisation . code insee = '63063'
-      - demandeur . âge . majeur
-      - une de ces conditions:
-          - vélo . électrique
-          - vélo . motorisation
-          - vélo . pliant
-  valeur:
-    variations:
-      - si: vélo . pliant
-        alors: 50€
-      - si: vélo . électrique
-        alors: 150€
-      - si: vélo . motorisation
-        alors: 100€
-  lien: https://www.cebazat.fr/actualites/plan-velo-communal-pret-aides-financieres-2/
-  dernière mise à jour: 20/02/2025
-
 # NOTE: valide jusqu'au 30 novembre 2024, à vérifier en 2025
 aides . arve salève:
   remplace: intercommunalité

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -20,22 +20,6 @@ aides . écully:
  valeur: 100€
  lien: https://www.ecully.fr/actualites-109/prime-pour-lachat-dun-velo-a-assistance-electrique-3708.html
 
-# NOTE: pas d'indice sur la continuité de l'aide après le 30 novembre 2024
-aides . monts du pilat:
-  remplace: intercommunalité
-  titre: Communauté de communes des Monts du Pilat
-  applicable si:
-    toutes ces conditions:
-      - localisation . epci = 'CC des Monts du Pilat'
-      - vélo . électrique ou mécanique
-  valeur: 20% * vélo . prix
-  plafond:
-    variations:
-      - si: vélo . électrique
-        alors: 200€
-      - sinon: 100€
-  lien: https://www.cc-montsdupilat.fr/mise-place-dune-aide-a-lachat-dun-velo
-
 # NOTE: pas d'indice sur la continuité de l'aide après le 31 décembre 2022
 aides . vesoul:
   remplace: intercommunalité

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -674,30 +674,6 @@ aides . ried de marckolsheim:
   plafond: vélo . prix
   lien: https://www.ried-marckolsheim.fr/actualites/nouveau-prime-velo?highlight=WyJhaWRlIl0=
 
-# NOTE: valable depuis 2023 jusqu'à abrogation, à vérifier en 2025
-# NOTE: plus référencée depuis le site en janvier 2025.
-aides . pays de l'arbresle:
-  remplace: intercommunalité
-  titre: Communauté de Communes du Pays de L'Arbresle
-  description: >
-    La Communauté de Communes du Pays de L'Arbresle subventionne jusqu'à par
-    foyer pour l'achat d'un Vélo à Assistance Electrique (VAE), un vélo spécial
-    (vélo cargo, vélo rallongé, vélo adapté à un handicap) ou un kit
-    d'électrification, qu'il soit neuf ou d'occasion.
-  applicable si:
-    toutes ces conditions:
-      - localisation . epci = "CC du Pays de l'Arbresle (CCPA)"
-      - une de ces conditions:
-          - vélo . cargo
-          - vélo . adapté
-          - vélo . motorisation
-          - toutes ces conditions:
-              - vélo . électrique
-              - vélo . prix <= 3000€
-  valeur: 50% * vélo . prix
-  plafond: 250€
-  lien: https://www.paysdelarbresle.fr/aide-a-lachat-dun-velo-a-assistance-electrique/
-
 # NOTE: aide pour 2024, à vérifier en 2025
 # NOTE: plus référencée depuis le site
 aides . mont de marsan:

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1534,3 +1534,20 @@ aides . castelnau de médoc:
   plafond: vélo . prix
   lien: https://www.mairie-castelnau-medoc.fr/actus/1557-aide-a-l-acquisition-de-velos
 
+
+# NOTE: plus référencée sur le site
+aides . aix les bains:
+  remplace: commune
+  titre: Ville d'Aix-les-Bains
+  description: >
+    La Ville d'Aix-les-Bains propose une aide financière à hauteur de 10 % du
+    montant TTC du vélo, dans la limite de 250 € et des crédits disponibles.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '73008'
+      - vélo . électrique
+      - vélo . état . neuf
+  valeur: 10% * vélo . prix
+  plafond: 250€
+  lien: https://www.aixlesbains.fr/Cadre-de-vie/Transports-et-deplacements/A-velo/Aides-financieres-pour-se-deplacer-a-velo
+  dernière mise à jour: 22/08/2025

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1584,3 +1584,21 @@ aides . montagnole:
       - vélo . prix >= 1200 €
   valeur: 200€
   lien: https://www.mairie-montagnole.fr/vae/
+
+# NOTE: plus référencé sur le site
+aides . castelnau de médoc:
+  remplace: commune
+  titre: Ville de Castelnau de Médoc
+  description: >
+    Aide à l'acquisition d'un vélo à assistance électrique neuf.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '33104'
+      - demandeur . âge . majeur
+      - revenu fiscal de référence par part <= plafond état
+      - vélo . état . neuf
+      - vélo . électrique
+  valeur: 100€
+  plafond: vélo . prix
+  lien: https://www.mairie-castelnau-medoc.fr/actus/1557-aide-a-l-acquisition-de-velos
+

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -178,17 +178,6 @@ aides . colmar:
     - sinon: 0€
   lien: https://www.colmar.fr/sites/colmar.fr/files/documents/35-fe-participation-achat-velo-neuf.pdf
 
-# NOTE: lien mort au 08/10/2024
-aides . sisteronais-buëch:
-  remplace: intercommunalité
-  titre: Communauté de Communes du Sisteronais-Buëch
-  applicable si:
-    toutes ces conditions:
-      - localisation . epci = 'CC du Sisteronais-Buëch'
-      - vélo . électrique
-  valeur: 200 €
-  lien: https://www.sisteronais-buech.fr/economie-et-tourisme/aide-a-lachat-dun-velo-a-assistance-electrique/
-
 
 # NOTE: fin de l'opération le 31 décembre 2023
 aides . ardenne:

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1534,7 +1534,6 @@ aides . castelnau de médoc:
   plafond: vélo . prix
   lien: https://www.mairie-castelnau-medoc.fr/actus/1557-aide-a-l-acquisition-de-velos
 
-
 # NOTE: plus référencée sur le site
 aides . aix les bains:
   remplace: commune

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1489,3 +1489,21 @@ aides . avignon:
       - sinon: 0€
   lien: https://www.avignon.fr/toutes-les-actualites/actualite/tous-a-velo
   dernière mise à jour: 29/07/2025
+
+# NOTE: valide jusqu'au 31 décembre 2024, à vérifier en 2025
+aides . riviera francaise:
+  remplace: intercommunalité
+  titre: Riviera Française
+  description: >
+    La Communauté d'Agglomération de la Riviera Française propose une aide
+    financière pour l'achat d'un vélo à assistance électrique neuf jusqu'au 31
+    décembre 2024.
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CA de la Riviera Française'
+      - demandeur . âge . majeur
+      - vélo . électrique
+      - vélo . état . neuf
+  valeur: vélo . prix
+  plafond: 300€
+  lien: https://www.riviera-francaise.fr/media/attachments/2022/03/30/convention-2022-2024-cc01221.pdf

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1564,3 +1564,23 @@ aides . montpellier vélo adapté:
   valeur: 50% * vélo . prix
   plafond: 500€
   lien: https://www.montpellier3m.fr/vivre-transport/toutes-les-aides-pour-lachat-ou-la-reparation-de-velos
+
+# NOTE: à vérifier en 2026
+aides . montagnole:
+  remplace: commune
+  titre: Ville de Montagnole
+  description: >
+    Aide financière de 200 € net par vélo, d'une valeur minimum  unitaire de 1
+    200 € TTC, et par famille, acheté chez un vélociste implanté dans une
+    commune du périmètre de l'agglomération de Grand Chambéry quel que soit le
+    type de vélo (route, VTT, VTC, Cargo…).
+
+
+    Limite de dépôt des dossiers pour l'année 2024 : 31 décembre 2024.
+  applicable si:
+    toutes ces conditions:
+      - localisation . code insee = '73160'
+      - vélo . électrique
+      - vélo . prix >= 1200 €
+  valeur: 200€
+  lien: https://www.mairie-montagnole.fr/vae/

--- a/src/rules/historique/aides-desactivees.publicodes
+++ b/src/rules/historique/aides-desactivees.publicodes
@@ -1507,3 +1507,43 @@ aides . riviera francaise:
   valeur: vélo . prix
   plafond: 300€
   lien: https://www.riviera-francaise.fr/media/attachments/2022/03/30/convention-2022-2024-cc01221.pdf
+
+# NOTE: terminée en juillet 2025 : https://www.luberonmontsdevaucluse.fr/acces/mes-demarches/mobilite/une-subvention-pour-lachat-dun-velo/
+aides . luberon:
+  remplace: intercommunalité
+  titre: Luberon Monts de Vaucluse
+  description: >
+     Lancée le 16 septembre 2020 par LMV Agglomération, l'opération "LMV vous
+     met en selle" vous aide à acheter un vélo, neuf ou d'occasion, avec ou
+     sans assistance électrique. 
+  applicable si: 
+    toutes ces conditions:
+      - localisation . epci = 'CA Luberon Monts de Vaucluse'
+      - demandeur . âge >= 16 an
+      - une de ces conditions:
+          - vélo . électrique
+          - toutes ces conditions:
+              - vélo . mécanique
+              - vélo . état . neuf
+  valeur: 30% * vélo . prix
+  plafond:
+    variations:
+      - si:
+          toutes ces conditions:
+            - vélo . électrique
+            - une de ces conditions:
+                - toutes ces conditions:
+                    - vélo . état . neuf
+                    - vélo . prix <= 2500€
+                - toutes ces conditions:
+                    - vélo . état . occasion
+                    - vélo . prix <= 1500€
+        alors: 300€
+      - si:
+          toutes ces conditions:
+            - vélo . mécanique
+            - vélo . prix <= 1000€
+        alors: 200€
+      - sinon: 0€
+  lien: https://www.luberonmontsdevaucluse.fr/acces/mes-demarches/mobilite/une-subvention-pour-lachat-dun-velo/
+

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -161,6 +161,12 @@ vélo . prix pour maximiser les aides:
       alors: 1500 €
     - si:
         une de ces conditions:
+          - toutes ces conditions:
+              - localisation . epci = "CC de la Plaine de l'Ain"
+              - vélo . électrique
+      alors: 2500 €
+    - si:
+        une de ces conditions:
           - localisation . epci = 'CA Montluçon Communauté'
           - localisation . epci = 'CC Loue-Lison'
           - localisation . code insee = '14327'

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -162,6 +162,7 @@ vélo . prix pour maximiser les aides:
     - si:
         une de ces conditions:
           - localisation . epci = 'CA Montluçon Communauté'
+          - localisation . epci = 'CC Loue-Lison'
           - localisation . code insee = '14327'
           - localisation . code insee = '14341'
       alors: 2400 €

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -126,6 +126,8 @@ vélo . prix . HT:
 
 vélo . prix pour maximiser les aides:
   variations:
+    - si: localisation . code insee = '67218'
+      alors: 800 €
     - si: localisation . epci = "CC Coeur de Savoie"
       alors: 3500 €
     - si: localisation . epci = "CA du Grand Chambéry"

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -128,6 +128,12 @@ vélo . prix pour maximiser les aides:
   variations:
     - si: localisation . epci = "CC Coeur de Savoie"
       alors: 3500 €
+    - si: localisation . epci = "CA du Grand Chambéry"
+      alors:
+        variations:
+          - si: vélo . cargo
+            alors: 6000 €
+          - sinon: 3500 €
     - si: localisation . epci = 'CA de Nevers'
       alors:
         variations:

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -174,13 +174,14 @@ vélo . prix pour maximiser les aides:
       alors: 100€
     - si:
         une de ces conditions:
-          - localisation . epci = 'Métropole de Lyon'
-          - localisation . epci = 'CC Les Balcons du Dauphiné'
-          - localisation . epci = 'CA Grand Lac'
-          - localisation . code insee = '38140'
           - localisation . département = '07'
+          - localisation . epci = 'CA Grand Lac'
           - localisation . epci = 'CA Saint-Lô Agglo'
           - localisation . epci = 'CA Saint-Louis Agglomération'
+          - localisation . epci = 'CC Les Balcons du Dauphiné'
+          - localisation . epci = 'CU Grand Besançon Métropole'
+          - localisation . epci = 'Métropole de Lyon'
+          - localisation . code insee = '38140'
           - localisation . code insee = '73222'
       alors: 3000 €
     - si: localisation . epci = 'CA Annemasse-Les Voirons-Agglomération'

--- a/src/rules/velo.publicodes
+++ b/src/rules/velo.publicodes
@@ -128,6 +128,12 @@ vélo . prix pour maximiser les aides:
   variations:
     - si: localisation . code insee = '67218'
       alors: 800 €
+    - si: localisation . epci = "CC du Genevois"
+      alors: 
+        variations:
+          - si: vélo . mécanique
+            alors: 1500 €
+          - sinon: 4000 €
     - si: localisation . epci = "CC Coeur de Savoie"
       alors: 3500 €
     - si: localisation . epci = "CA du Grand Chambéry"

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -367,6 +367,22 @@ describe("AidesVeloEngine", () => {
 
           expect(aides).toHaveLength(0);
         });
+
+        it("Commune d'Illiers-Combray ne devrait pas être élligible", () => {
+          const engine = globalTestEngine.shallowCopy();
+          const aides = engine
+            .setInputs({
+              "localisation . région": "24",
+              "localisation . epci": "CC Entre Beauce et Perche",
+              "localisation . code insee": "28196",
+              "demandeur . âge": 18,
+              "vélo . prix": 700,
+              "vélo . type": "électrique",
+            })
+            .computeAides();
+
+          expect(aides).toHaveLength(0);
+        });
       });
     });
   });

--- a/test/AidesVeloEngine.test.ts
+++ b/test/AidesVeloEngine.test.ts
@@ -307,7 +307,7 @@ describe("AidesVeloEngine", () => {
           })
           .computeAides();
 
-        expect(aides).toHaveLength(3);
+        expect(aides).toHaveLength(2);
         expect(contain(aides, "aides . occitanie vélo adapté")).toBeTruthy();
         expect(
           contain(
@@ -317,7 +317,6 @@ describe("AidesVeloEngine", () => {
               description?.includes("Chèque Hérault Handi-Vélo")
           )
         ).toBeTruthy();
-        expect(contain(aides, "aides . montpellier vélo adapté")).toBeTruthy();
       });
 
       it("CA du Centre Littoral - vélo électrique", async () => {

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1884,4 +1884,41 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . toulon").nodeValue).toEqual(1000);
     });
   });
+
+  describe("Région Centre-Val de Loire", () => {
+    test("Région Centre-Val de loire devrait être élligible", () => {
+      engine.setSituation({
+        "localisation . région": "'24'",
+        "demandeur . âge": 18,
+        "vélo . prix": 700,
+        "vélo . type": "'électrique'",
+      });
+
+      expect(engine.evaluate("aides . region centre").nodeValue).not.toBeNull();
+    });
+
+    test("CC du Perche devrait être élligible", () => {
+      engine.setSituation({
+        "localisation . epci": "'CC du Perche'",
+        "demandeur . âge": 18,
+        "vélo . prix": 700,
+        "vélo . type": "'électrique'",
+      });
+
+      expect(engine.evaluate("aides . region centre").nodeValue).not.toBeNull();
+    });
+
+    test("Commune de Pigny ne devrait pas être élligible", () => {
+      engine.setSituation({
+        "localisation . région": "'24'",
+        "localisation . epci": "'CC Terres du Haut Berry'",
+        "localisation . code insee": "'18179'",
+        "demandeur . âge": 18,
+        "vélo . prix": 700,
+        "vélo . type": "'électrique'",
+      });
+
+      expect(engine.evaluate("aides . region centre").nodeValue).toBeNull();
+    });
+  });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -310,7 +310,9 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
         "vélo . prix": "1000€",
       });
-      expect(engine.evaluate("aides . montpellier").nodeValue).toEqual(null);
+      expect(
+        engine.evaluate("aides . montpellier vae occasion").nodeValue
+      ).toEqual(null);
 
       engine.setSituation({
         "localisation . epci": "'Montpellier Méditerranée Métropole'",
@@ -319,7 +321,9 @@ describe("Aides Vélo", () => {
         "vélo . état": "'occasion'",
         "vélo . prix": "1000€",
       });
-      expect(engine.evaluate("aides . montpellier").nodeValue).toEqual(200);
+      expect(
+        engine.evaluate("aides . montpellier vae occasion").nodeValue
+      ).toEqual(200);
 
       engine.setSituation({
         "localisation . epci": "'Montpellier Méditerranée Métropole'",
@@ -327,7 +331,9 @@ describe("Aides Vélo", () => {
         "vélo . type": "'motorisation'",
         "vélo . prix": "1000€",
       });
-      expect(engine.evaluate("aides . montpellier").nodeValue).toEqual(200);
+      expect(
+        engine.evaluate("aides . montpellier vae occasion").nodeValue
+      ).toEqual(200);
     });
 
     it("ne devrait pas être cumulable avec l'aide vélo adapté", () => {
@@ -340,10 +346,9 @@ describe("Aides Vélo", () => {
         "vélo . prix": "2000€",
       });
 
-      expect(engine.evaluate("aides . montpellier").nodeValue).toEqual(null);
       expect(
-        engine.evaluate("aides . montpellier vélo adapté").nodeValue
-      ).toEqual(500);
+        engine.evaluate("aides . montpellier vae occasion").nodeValue
+      ).toEqual(null);
       expect(
         engine.evaluate("aides . département hérault vélo adapté").nodeValue
       ).toEqual(1000);

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -27,12 +27,12 @@ describe("Aides Vélo", () => {
 
       ruleNames.forEach((key: RuleName) => {
         if (
-          key.startsWith("aides .") &&
-          key.split(" . ").length === 2 &&
-          !noNeedToAssociatesLoc.includes(key)
+          key.startsWith("aides .")
+          && key.split(" . ").length === 2
+          && !noNeedToAssociatesLoc.includes(key)
         ) {
           expect(
-            aidesAvecLocalisation[key as AideRuleNames]
+            aidesAvecLocalisation[key as AideRuleNames],
           ).not.toBeUndefined();
         }
       });
@@ -43,9 +43,9 @@ describe("Aides Vélo", () => {
       // TODO: improve the generation script to manage missing cities
       ruleNames.forEach((key) => {
         if (
-          key.startsWith("aides .") &&
-          key.split(" . ").length === 2 &&
-          !rulesToIgnore.includes(key)
+          key.startsWith("aides .")
+          && key.split(" . ").length === 2
+          && !rulesToIgnore.includes(key)
         ) {
           if (!miniatures[key as AideRuleNames]) {
             console.log(key);
@@ -58,9 +58,9 @@ describe("Aides Vélo", () => {
     it("devrait y avoir un lien valide pour chaque aides", () => {
       ruleEntries.forEach(([key, rule]) => {
         if (
-          key.startsWith("aides .") &&
-          key.split(" . ").length === 2 &&
-          !rulesToIgnore.includes(key)
+          key.startsWith("aides .")
+          && key.split(" . ").length === 2
+          && !rulesToIgnore.includes(key)
         ) {
           if (!rule["lien"]) {
             console.log(key);
@@ -148,7 +148,7 @@ describe("Aides Vélo", () => {
 
       const expectedAmount = 0.5 * 1000;
       expect(
-        engine.evaluate("aides . occitanie vélo adapté").nodeValue
+        engine.evaluate("aides . occitanie vélo adapté").nodeValue,
       ).toEqual(expectedAmount);
 
       engine.setSituation({
@@ -159,7 +159,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "25000€",
       });
       expect(
-        engine.evaluate("aides . occitanie vélo adapté").nodeValue
+        engine.evaluate("aides . occitanie vélo adapté").nodeValue,
       ).toEqual(1000);
     });
 
@@ -175,7 +175,7 @@ describe("Aides Vélo", () => {
         "aides . département": "400€",
       });
       expect(
-        engine.evaluate("aides . occitanie vélo adapté").nodeValue
+        engine.evaluate("aides . occitanie vélo adapté").nodeValue,
       ).toBeGreaterThanOrEqual(0);
     });
   });
@@ -280,10 +280,10 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . département hérault").nodeValue).toEqual(
-        null
+        null,
       );
       expect(
-        engine.evaluate("aides . département hérault vélo adapté").nodeValue
+        engine.evaluate("aides . département hérault vélo adapté").nodeValue,
       ).toEqual(500);
 
       engine.setSituation({
@@ -294,10 +294,10 @@ describe("Aides Vélo", () => {
         "vélo . prix": "25000€",
       });
       expect(engine.evaluate("aides . département hérault").nodeValue).toEqual(
-        null
+        null,
       );
       expect(
-        engine.evaluate("aides . département hérault vélo adapté").nodeValue
+        engine.evaluate("aides . département hérault vélo adapté").nodeValue,
       ).toEqual(1000);
     });
   });
@@ -311,7 +311,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
       expect(
-        engine.evaluate("aides . montpellier vae occasion").nodeValue
+        engine.evaluate("aides . montpellier vae occasion").nodeValue,
       ).toEqual(null);
 
       engine.setSituation({
@@ -322,7 +322,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
       expect(
-        engine.evaluate("aides . montpellier vae occasion").nodeValue
+        engine.evaluate("aides . montpellier vae occasion").nodeValue,
       ).toEqual(200);
 
       engine.setSituation({
@@ -332,7 +332,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
       expect(
-        engine.evaluate("aides . montpellier vae occasion").nodeValue
+        engine.evaluate("aides . montpellier vae occasion").nodeValue,
       ).toEqual(200);
     });
 
@@ -347,15 +347,15 @@ describe("Aides Vélo", () => {
       });
 
       expect(
-        engine.evaluate("aides . montpellier vae occasion").nodeValue
+        engine.evaluate("aides . montpellier vae occasion").nodeValue,
       ).toEqual(null);
       expect(
-        engine.evaluate("aides . département hérault vélo adapté").nodeValue
+        engine.evaluate("aides . département hérault vélo adapté").nodeValue,
       ).toEqual(1000);
     });
   });
 
-  describe('Perpignan Méditerrannée Métropole" ', () => {
+  describe("Perpignan Méditerrannée Métropole\" ", () => {
     it("devrait être élligible pour les vélo d'occasion", () => {
       engine.setSituation({
         "localisation . epci": "'CU Perpignan Méditerranée Métropole'",
@@ -365,7 +365,7 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . perpignan métropole").nodeValue).toEqual(
-        250
+        250,
       );
     });
 
@@ -378,7 +378,7 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . perpignan métropole").nodeValue).toEqual(
-        350
+        350,
       );
     });
 
@@ -391,7 +391,7 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . perpignan métropole").nodeValue).toEqual(
-        1000
+        1000,
       );
     });
   });
@@ -405,7 +405,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "20000€/an",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        250
+        250,
       );
 
       engine.setSituation({
@@ -415,7 +415,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "20000€/an",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        250
+        250,
       );
     });
 
@@ -428,7 +428,7 @@ describe("Aides Vélo", () => {
         "demandeur . en situation de handicap": "oui",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        400
+        400,
       );
 
       engine.setSituation({
@@ -439,7 +439,7 @@ describe("Aides Vélo", () => {
         "demandeur . en situation de handicap": "oui",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        750
+        750,
       );
     });
 
@@ -451,7 +451,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "15000€/an",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        null
+        null,
       );
 
       engine.setSituation({
@@ -461,7 +461,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "15000€/an",
       });
       expect(engine.evaluate("aides . sophia antipolis").nodeValue).toEqual(
-        null
+        null,
       );
     });
   });
@@ -491,7 +491,7 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . pays de cruseilles").nodeValue).toEqual(
-        300
+        300,
       );
     });
   });
@@ -615,7 +615,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "10000€/an",
       });
       expect(engine.evaluate("aides . saône-beaujolais").nodeValue).toEqual(
-        300
+        300,
       );
 
       engine.setSituation({
@@ -626,7 +626,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "10000€/an",
       });
       expect(engine.evaluate("aides . saône-beaujolais").nodeValue).toEqual(
-        200
+        200,
       );
     });
   });
@@ -660,7 +660,7 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . pays mornantais").nodeValue).toEqual(
-        null
+        null,
       );
     });
   });
@@ -735,7 +735,7 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . caen jeune").nodeValue).toEqual(null);
       expect(engine.evaluate("aides . caen").nodeValue).toEqual(null);
       expect(engine.evaluate("aides . caen vélo adapté").nodeValue).toEqual(
-        300
+        300,
       );
 
       // Pas nécessairement adapté
@@ -749,7 +749,7 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . caen jeune").nodeValue).toEqual(null);
       expect(engine.evaluate("aides . caen").nodeValue).toEqual(null);
       expect(engine.evaluate("aides . caen vélo adapté").nodeValue).toEqual(
-        300
+        300,
       );
     });
 
@@ -780,8 +780,7 @@ describe("Aides Vélo", () => {
         "demandeur . âge": "16 an",
         // TODO: use generated types instead of the json
         // @ts-ignore
-        "aides . vienne gartempe . titulaire d'un contrat d'alternance ou de stage":
-          "oui",
+        "aides . vienne gartempe . titulaire d'un contrat d'alternance ou de stage": "oui",
         "vélo . prix": "1000€",
       });
       expect(engine.evaluate("aides . vienne gartempe").nodeValue).toEqual(400);
@@ -806,7 +805,7 @@ describe("Aides Vélo", () => {
         "demandeur . bénéficiaire du RSA": "oui",
       });
       expect(engine.evaluate("aides . montval sur loir").nodeValue).toEqual(
-        100
+        100,
       );
     });
   });
@@ -928,7 +927,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
       });
       expect(engine.evaluate("aides . la motte servolex").nodeValue).toEqual(
-        150
+        150,
       );
 
       engine.setSituation({
@@ -938,7 +937,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'cargo électrique'",
       });
       expect(engine.evaluate("aides . la motte servolex").nodeValue).toEqual(
-        null
+        null,
       );
 
       engine.setSituation({
@@ -948,7 +947,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'mécanique simple'",
       });
       expect(engine.evaluate("aides . la motte servolex").nodeValue).toEqual(
-        null
+        null,
       );
 
       engine.setSituation({
@@ -958,7 +957,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'pliant'",
       });
       expect(engine.evaluate("aides . la motte servolex").nodeValue).toEqual(
-        null
+        null,
       );
     });
   });
@@ -1022,7 +1021,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
       });
       expect(
-        engine.evaluate("aides . cluses arve et montagnes").nodeValue
+        engine.evaluate("aides . cluses arve et montagnes").nodeValue,
       ).toEqual(300);
 
       engine.setSituation({
@@ -1033,7 +1032,7 @@ describe("Aides Vélo", () => {
         "vélo . état": "'occasion'",
       });
       expect(
-        engine.evaluate("aides . cluses arve et montagnes").nodeValue
+        engine.evaluate("aides . cluses arve et montagnes").nodeValue,
       ).toEqual(400);
     });
 
@@ -1045,7 +1044,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
       });
       expect(
-        engine.evaluate("aides . cluses arve et montagnes").nodeValue
+        engine.evaluate("aides . cluses arve et montagnes").nodeValue,
       ).toEqual(300);
 
       engine.setSituation({
@@ -1056,7 +1055,7 @@ describe("Aides Vélo", () => {
         "aides . cluses arve et montagnes . participation employeur": 500,
       });
       expect(
-        engine.evaluate("aides . cluses arve et montagnes").nodeValue
+        engine.evaluate("aides . cluses arve et montagnes").nodeValue,
       ).toEqual(700);
     });
   });
@@ -1124,7 +1123,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1000€",
       });
       expect(engine.evaluate("aides . la roche sur yon").nodeValue).toEqual(
-        100
+        100,
       );
 
       engine.setSituation({
@@ -1133,7 +1132,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "2000€",
       });
       expect(engine.evaluate("aides . la roche sur yon").nodeValue).toEqual(
-        null
+        null,
       );
 
       engine.setSituation({
@@ -1151,7 +1150,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": "1500€",
       });
       expect(engine.evaluate("aides . la roche sur yon").nodeValue).toEqual(
-        null
+        null,
       );
     });
 
@@ -1161,11 +1160,10 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
         "vélo . prix": "1000€",
         "demandeur . statut": "'salarié'",
-        "aides . la roche sur yon . salarié d'une structure membre du PDIE":
-          "oui",
+        "aides . la roche sur yon . salarié d'une structure membre du PDIE": "oui",
       });
       expect(engine.evaluate("aides . la roche sur yon").nodeValue).toEqual(
-        200
+        200,
       );
     });
   });
@@ -1180,7 +1178,7 @@ describe("Aides Vélo", () => {
       });
       expect(engine.evaluate("aides . denain").nodeValue).toEqual(150);
       expect(engine.evaluate("aides . denain").nodeValue).toEqual(
-        (engine.evaluate("aides . porte du hainaut").nodeValue as number) / 2
+        (engine.evaluate("aides . porte du hainaut").nodeValue as number) / 2,
       );
 
       engine.setSituation({
@@ -1192,7 +1190,7 @@ describe("Aides Vélo", () => {
       });
       expect(engine.evaluate("aides . denain").nodeValue).toEqual(100);
       expect(engine.evaluate("aides . denain").nodeValue).toEqual(
-        (engine.evaluate("aides . porte du hainaut").nodeValue as number) / 2
+        (engine.evaluate("aides . porte du hainaut").nodeValue as number) / 2,
       );
     });
   });
@@ -1253,7 +1251,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 200,
       });
       expect(engine.evaluate("aides . amboise").nodeValue).not.toBeLessThan(
-        200
+        200,
       );
 
       engine.setSituation({
@@ -1263,7 +1261,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 200,
       });
       expect(engine.evaluate("aides . amboise").nodeValue).not.toBeLessThan(
-        200
+        200,
       );
     });
 
@@ -1380,7 +1378,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 1000,
       });
       expect(engine.evaluate("aides . portes du luxembourg").nodeValue).toEqual(
-        200
+        200,
       );
     });
 
@@ -1392,7 +1390,7 @@ describe("Aides Vélo", () => {
         "aides . portes du luxembourg . assemblé en France": "oui",
       });
       expect(engine.evaluate("aides . portes du luxembourg").nodeValue).toEqual(
-        300
+        300,
       );
     });
   });
@@ -1465,7 +1463,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "5000 €/mois",
       });
       expect(
-        engine.evaluate("aides . villefranche beaujolais saône").nodeValue
+        engine.evaluate("aides . villefranche beaujolais saône").nodeValue,
       ).toBeGreaterThanOrEqual(0);
 
       engine.setSituation({
@@ -1476,7 +1474,7 @@ describe("Aides Vélo", () => {
         "aides . département": 400,
       });
       expect(
-        engine.evaluate("aides . villefranche beaujolais saône").nodeValue
+        engine.evaluate("aides . villefranche beaujolais saône").nodeValue,
       ).toBeGreaterThanOrEqual(0);
     });
   });
@@ -1489,7 +1487,7 @@ describe("Aides Vélo", () => {
         "revenu fiscal de référence par part": "10000 €/an",
       });
       expect(engine.evaluate("aides . val de drôme").nodeValue).toEqual(
-        200 * 0.4
+        200 * 0.4,
       );
     });
 
@@ -1532,7 +1530,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'mécanique simple'",
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        100
+        100,
       );
     });
 
@@ -1549,7 +1547,7 @@ describe("Aides Vélo", () => {
         "demandeur . statut": "'étudiant'",
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        200
+        200,
       );
 
       engine.setSituation({
@@ -1559,7 +1557,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'mécanique simple'",
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        150
+        150,
       );
 
       engine.setSituation({
@@ -1582,7 +1580,7 @@ describe("Aides Vélo", () => {
         "demandeur . statut": "'salarié'",
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        200
+        200,
       );
 
       engine.setSituation({
@@ -1591,7 +1589,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'mécanique simple'",
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        150
+        150,
       );
 
       engine.setSituation({
@@ -1601,7 +1599,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 2500,
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        1000
+        1000,
       );
 
       engine.setSituation({
@@ -1611,7 +1609,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 2500,
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        1250
+        1250,
       );
 
       engine.setSituation({
@@ -1621,7 +1619,7 @@ describe("Aides Vélo", () => {
         "vélo . prix": 2500,
       });
       expect(engine.evaluate("aides . creusot-montceau").nodeValue).toEqual(
-        1250
+        1250,
       );
 
       engine.setSituation({
@@ -1715,7 +1713,7 @@ describe("Aides Vélo", () => {
     test("par défaut", () => {
       engine.setSituation(baseSituation);
       expect(engine.evaluate("aides . cc arc sud bretagne").nodeValue).toEqual(
-        100
+        100,
       );
     });
 
@@ -1725,7 +1723,7 @@ describe("Aides Vélo", () => {
         "vélo . type": "'cargo électrique'",
       });
       expect(engine.evaluate("aides . cc arc sud bretagne").nodeValue).toEqual(
-        200
+        200,
       );
     });
   });
@@ -1796,7 +1794,7 @@ describe("Aides Vélo", () => {
       });
       expect(engine.evaluate("aides . grand poitiers").nodeValue).toBeNull();
       expect(
-        engine.evaluate("aides . grand poitiers adapté").nodeValue
+        engine.evaluate("aides . grand poitiers adapté").nodeValue,
       ).toEqual(250);
 
       engine.setSituation({
@@ -1807,7 +1805,7 @@ describe("Aides Vélo", () => {
       });
       expect(engine.evaluate("aides . grand poitiers").nodeValue).toEqual(250);
       expect(
-        engine.evaluate("aides . grand poitiers adapté").nodeValue
+        engine.evaluate("aides . grand poitiers adapté").nodeValue,
       ).toBeNull();
     });
   });
@@ -1819,8 +1817,7 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part . revenu de référence":
-          "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence": "20000 €/an",
         "foyer . personnes": 2,
       });
       expect(engine.evaluate("aides . bassin-pompey").nodeValue).toEqual(300);
@@ -1832,13 +1829,12 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part . revenu de référence":
-          "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence": "20000 €/an",
         "foyer . personnes": 7,
       });
       expect(
         engine.evaluate("aides . bassin-pompey . plafond de ressources")
-          .nodeValue
+          .nodeValue,
       ).toEqual(44860 + 5668 * 2);
     });
 
@@ -1848,8 +1844,7 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part . revenu de référence":
-          "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence": "20000 €/an",
       });
       expect(engine.evaluate("aides . bassin-pompey").nodeValue).toEqual(100);
     });
@@ -1863,7 +1858,7 @@ describe("Aides Vélo", () => {
       });
       expect(
         engine.evaluate("aides . bassin-pompey . plafond de ressources")
-          .nodeValue
+          .nodeValue,
       ).toEqual(19074);
     });
   });
@@ -1947,11 +1942,11 @@ describe("Aides Vélo", () => {
         {
           "vélo . prix": 2000,
         },
-        { keepPreviousSituation: true }
+        { keepPreviousSituation: true },
       );
 
       expect(engine.evaluate("aides . grand chambéry").nodeValue).toEqual(
-        500 + 100
+        500 + 100,
       );
     });
 
@@ -1965,6 +1960,45 @@ describe("Aides Vélo", () => {
       });
 
       expect(engine.evaluate("aides . grand chambéry").nodeValue).toEqual(1500);
+    });
+  });
+
+  describe("Mauges Communauté", () => {
+    test("vélo cargo d'occasion de moins de 400 euros", () => {
+      engine.setSituation({
+        "localisation . epci": "'CA Mauges Communauté'",
+        "vélo . type": "'cargo électrique'",
+        "vélo . état": "'occasion'",
+        "vélo . prix": 300,
+      });
+
+      expect(
+        engine.evaluate("aides . ca mauges communauté").nodeValue,
+      ).toBeNull();
+    });
+
+    test("maximise le prix pour l'occasion", () => {
+      engine.setSituation({
+        "localisation . epci": "'CA Mauges Communauté'",
+        "vélo . type": "'cargo électrique'",
+        "vélo . état": "'occasion'",
+      });
+
+      expect(engine.evaluate("aides . ca mauges communauté").nodeValue).toEqual(
+        350,
+      );
+
+      engine.setSituation(
+        {
+          "vélo . type": "'électrique'",
+          "vélo . état": "'occasion'",
+        },
+        { keepPreviousSituation: true },
+      );
+
+      expect(engine.evaluate("aides . ca mauges communauté").nodeValue).toEqual(
+        100,
+      );
     });
   });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1,8 +1,8 @@
 import Engine, { Rule } from "publicodes";
 import { describe, expect, it, test } from "vitest";
 
-import { AideRuleNames, RuleName } from "../src";
 import rules from "../publicodes-build";
+import { AideRuleNames, RuleName } from "../src";
 import { aidesAvecLocalisation, miniatures } from "../src/data";
 
 describe("Aides Vélo", () => {
@@ -1886,7 +1886,8 @@ describe("Aides Vélo", () => {
   });
 
   describe("Région Centre-Val de Loire", () => {
-    test("Région Centre-Val de loire devrait être élligible", () => {
+    // NOTE: car tout le territoire de la région n'est pas couvert
+    test("Région Centre-Val de loire nde devrait pas être élligible seule", () => {
       engine.setSituation({
         "localisation . région": "'24'",
         "demandeur . âge": 18,
@@ -1894,11 +1895,12 @@ describe("Aides Vélo", () => {
         "vélo . type": "'électrique'",
       });
 
-      expect(engine.evaluate("aides . region centre").nodeValue).not.toBeNull();
+      expect(engine.evaluate("aides . region centre").nodeValue).toBeNull();
     });
 
     test("CC du Perche devrait être élligible", () => {
       engine.setSituation({
+        "localisation . région": "'24'",
         "localisation . epci": "'CC du Perche'",
         "demandeur . âge": 18,
         "vélo . prix": 700,

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1928,4 +1928,40 @@ describe("Aides Vélo", () => {
       expect(engine.evaluate("aides . region centre").nodeValue).toBeNull();
     });
   });
+
+  describe("CA Grand Chambery", () => {
+    test("électrique simple RFR > 15400 €/an", () => {
+      engine.setSituation({
+        "localisation . epci": "'CA du Grand Chambéry'",
+        "vélo . type": "'électrique'",
+        "vélo . prix": 1000,
+        "revenu fiscal de référence par part": "20000 €/an",
+      });
+
+      expect(engine.evaluate("aides . grand chambéry").nodeValue).toBeNull();
+
+      engine.setSituation(
+        {
+          "vélo . prix": 2000,
+        },
+        { keepPreviousSituation: true }
+      );
+
+      expect(engine.evaluate("aides . grand chambéry").nodeValue).toEqual(
+        500 + 100
+      );
+    });
+
+    test("non salarié entreprise partenaire", () => {
+      engine.setSituation({
+        "localisation . epci": "'CA du Grand Chambéry'",
+        "vélo . type": "'cargo électrique'",
+        "vélo . prix": 5000,
+        "revenu fiscal de référence par part": "10000 €/an",
+        "aides . grand chambéry . salarié d'une entreprise partenaire": "non",
+      });
+
+      expect(engine.evaluate("aides . grand chambéry").nodeValue).toEqual(1500);
+    });
+  });
 });

--- a/test/rules.test.ts
+++ b/test/rules.test.ts
@@ -1819,7 +1819,8 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part": "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence":
+          "20000 €/an",
         "foyer . personnes": 2,
       });
       expect(engine.evaluate("aides . bassin-pompey").nodeValue).toEqual(300);
@@ -1831,7 +1832,8 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part": "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence":
+          "20000 €/an",
         "foyer . personnes": 7,
       });
       expect(
@@ -1846,7 +1848,8 @@ describe("Aides Vélo", () => {
         "localisation . epci": "'CC du Bassin de Pompey'",
         "vélo . prix": 1000,
         "vélo . type": "'électrique'",
-        "revenu fiscal de référence par part": "20000 €/an",
+        "revenu fiscal de référence par part . revenu de référence":
+          "20000 €/an",
       });
       expect(engine.evaluate("aides . bassin-pompey").nodeValue).toEqual(100);
     });


### PR DESCRIPTION
Cette PR met en place un système de suivi de la couverture des aides grâce aux fichiers dans le dossier `couverture/`. Pour l'instant la couverture ne prend pas en compte l'échelle communale.

J'en ai profité pour relire de nombreuses aides et compléter les fichiers de couverture des régions suivantes :

- Guadeloupe (01)
- Guyane (03)
- Centre-Val de Loire (24)
- Bourgogne-Franche-Comté (27)
- Auvergne-Rhône-Alpes (84)
- Provence-Alpes-Côte d'Azur (93)
- Corse (94)
- Saint-Pierre-et-Miquelon (975)
- Polynésie française (987)

Malheureusement, je n'ai pas eu le temps de tout relire, une seconde session de relecture devrait être faite à la rentrée.

> Pour information, j'ai utilisé [perplexity](https://www.perplexity.ai) et [Le Chat Mistral](https://mistral.ai/fr) pour m'aider dans la relecture de certaines régions (signifiée par l'emoji 🤖).